### PR TITLE
Fix App.Config for pashconsole.

### DIFF
--- a/Source/PashGui/PashGui.csproj
+++ b/Source/PashGui/PashGui.csproj
@@ -88,4 +88,7 @@
       <Link>App.config</Link>
     </None>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>"$(ProgramFiles)\NUnit 2.6.1\bin\nunit-console.exe" $(TargetPath) /nologo</PostBuildEvent>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
We renamed ConfigurationSection -> Configuration, but with 2 .config files, we missed one spot.

Now we have only 1 config file, and it is shared bewteen the two hosts.
