### PR TITLE
Disable warnings as errors

### DIFF
--- a/Source/ParserTests/ParserTests.csproj
+++ b/Source/ParserTests/ParserTests.csproj
@@ -20,6 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>

--- a/Source/Pash.Microsoft.PowerShell.Commands.Utility/Pash.Microsoft.PowerShell.Commands.Utility.csproj
+++ b/Source/Pash.Microsoft.PowerShell.Commands.Utility/Pash.Microsoft.PowerShell.Commands.Utility.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Source/Pash.System.Management/Pash.System.Management.csproj
+++ b/Source/Pash.System.Management/Pash.System.Management.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
The commit fixes issue JayBazuzi/Pash2/issues/23 by adding
an attribute to stop xbuild/mono treating warnings as errors.
