### PR TITLE
Update Url's to reflect project move.

### DIFF
--- a/Libraries/Irony/Irony/Parsing/Terminals/RegexBasedTerminal.cs
+++ b/Libraries/Irony/Irony/Parsing/Terminals/RegexBasedTerminal.cs
@@ -25,9 +25,9 @@ namespace Irony.Parsing {
     // Mono's C# compiler prefers this overload, which is incorrect. Marking it `private` to
     // to work around.
     //
-    // See https://github.com/JayBazuzi/Pash2/issues/24
+    // See https://github.com/Pash-Project/Pash/issues/24
     //
-    // See https://github.com/JayBazuzi/Pash2/issues/29
+    // See https://github.com/Pash-Project/Pash/issues/29
     //
     // See https://bugzilla.xamarin.com/show_bug.cgi?id=6541
     private RegexBasedTerminal(string pattern, params string[] prefixes)

--- a/Libraries/Libraries.Tests/MonoTests.cs
+++ b/Libraries/Libraries.Tests/MonoTests.cs
@@ -17,7 +17,7 @@ namespace Libraries.Tests
         // test to call it out.
         [Test]
         [Description("https://bugzilla.xamarin.com/show_bug.cgi?id=6541")]
-        [Explicit("reenable when https://github.com/JayBazuzi/Pash2/issues/29 is closed.")]
+        [Explicit("reenable when https://github.com/Pash-Project/Pash/issues/29 is closed.")]
         public void MonoOverloadBug6541Test()
         {
             F("x");

--- a/Pash.proj
+++ b/Pash.proj
@@ -11,7 +11,7 @@
           DependsOnTargets="Build"
           >
     <!--
-    When this issue is resolved: https://github.com/JayBazuzi/Pash2/issues/29
+    When this issue is resolved: https://github.com/Pash-Project/Pash/issues/29
 
     Uncomment the next command & reenable the `Libraries.Tests.MonoTests.MonoOverloadBug6541Test`.
 

--- a/Source/ParserTests/Ast/Ast.Tests.cs
+++ b/Source/ParserTests/Ast/Ast.Tests.cs
@@ -402,7 +402,7 @@ ls
             Assert.AreEqual(StringConstantType.BareWord, memberAst.StringConstantType);
         }
 
-        [Test, Explicit("Bug - https://github.com/JayBazuzi/Pash2/issues/9")]
+        [Test, Explicit("Bug - https://github.com/Pash-Project/Pash/issues/9")]
         public void BadMemberAccess()
         {
             Assert.Throws<PowerShellGrammar.ParseException>(() =>
@@ -506,7 +506,7 @@ ls
             Assert.AreEqual(2, statements.Count);
         }
 
-        [Test(Description = "Issue: https://github.com/JayBazuzi/Pash2/issues/7")]
+        [Test(Description = "Issue: https://github.com/Pash-Project/Pash/issues/7")]
         public void StatementSequenceWithoutSemicolonTest()
         {
             Assert.Throws<PowerShellGrammar.ParseException>(() =>

--- a/Source/Pash.System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/Pash.System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -1196,7 +1196,7 @@ namespace Pash.ParserIntrinsics
                         throw new InvalidOperationException(parseTreeNode.ChildNodes[0].ToString());
                 }
 
-                // Issue: https://github.com/JayBazuzi/Pash2/issues/8 - command_module_opt is not in the grammar right now.
+                // Issue: https://github.com/Pash-Project/Pash/issues/8 - command_module_opt is not in the grammar right now.
 
                 commandElements.Add(BuildCommandNameExprAst(parseTreeNode.ChildNodes[1]));
             }

--- a/Source/Pash.System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
+++ b/Source/Pash.System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
@@ -420,7 +420,7 @@ namespace Pash.ParserIntrinsics
             ////            new_lines_opt   attribute_list_opt   new_lines_opt   param   new_lines_opt
             ////                    (   parameter_list_opt   new_lines_opt   )
             param_block.Rule =
-                /* new_lines_opt + TODO: https://github.com/JayBazuzi/Pash2/issues/11 (attribute_list_opt) + new_lines_opt + */ "param" + new_lines_opt
+                /* new_lines_opt + TODO: https://github.com/Pash-Project/Pash/issues/11 (attribute_list_opt) + new_lines_opt + */ "param" + new_lines_opt
                         + "(" + (parameter_list_opt) + new_lines_opt + ")";
 
             ////        parameter_list:
@@ -432,7 +432,7 @@ namespace Pash.ParserIntrinsics
             ////        script_parameter:
             ////            new_lines_opt   attribute_list_opt   new_lines_opt   variable   script_parameter_default_opt
             script_parameter.Rule =
-                new_lines_opt + /* TODO: https://github.com/JayBazuzi/Pash2/issues/11 (attribute_list_opt) + new_lines_opt + */ variable + (script_parameter_default_opt);
+                new_lines_opt + /* TODO: https://github.com/Pash-Project/Pash/issues/11 (attribute_list_opt) + new_lines_opt + */ variable + (script_parameter_default_opt);
 
             ////        script_parameter_default:
             ////            new_lines_opt   =   new_lines_opt   expression
@@ -483,7 +483,7 @@ namespace Pash.ParserIntrinsics
             ////            statement_list   statement
             statement_list.Rule = MakePlusRule(statement_list, statement);
 #else
-            // There's a bug in the language spec here. See https://github.com/JayBazuzi/Pash2/issues/7
+            // There's a bug in the language spec here. See https://github.com/Pash-Project/Pash/issues/7
             statement_list.Rule =
                 MakeListRule(statement_list, statement_terminators, statement, TermListOptions.AllowTrailingDelimiter | TermListOptions.PlusList);
 #endif
@@ -519,11 +519,11 @@ namespace Pash.ParserIntrinsics
             _statement_labeled_statement.Rule =
                 (label | Empty) + labeled_statement;
 
-            // See https://github.com/JayBazuzi/Pash2/issues/7
+            // See https://github.com/Pash-Project/Pash/issues/7
             _statement_flow_control_statement.Rule =
                 flow_control_statement /*+ (statement_terminator_opt)*/;
 
-            // See https://github.com/JayBazuzi/Pash2/issues/7
+            // See https://github.com/Pash-Project/Pash/issues/7
             _statement_pipeline.Rule =
                 pipeline /*+ (statement_terminator_opt)*/;
 
@@ -856,7 +856,7 @@ namespace Pash.ParserIntrinsics
             _command_simple.Rule =
                 command_name + command_elements_opt;
 
-            // ISSUE: https://github.com/JayBazuzi/Pash2/issues/8
+            // ISSUE: https://github.com/Pash-Project/Pash/issues/8
             _command_invocation.Rule =
                 command_invocation_operator + /* (command_module_opt) + */ command_name_expr + command_elements_opt;
 
@@ -867,7 +867,7 @@ namespace Pash.ParserIntrinsics
 
             ////        command_module:
             ////            primary_expression
-            // ISSUE: https://github.com/JayBazuzi/Pash2/issues/8
+            // ISSUE: https://github.com/Pash-Project/Pash/issues/8
             command_module.Rule =
                 primary_expression;
 
@@ -876,7 +876,7 @@ namespace Pash.ParserIntrinsics
             ////            generic_token_with_subexpr
             command_name.Rule =
                 generic_token
-                // ISSUE: https://github.com/JayBazuzi/Pash2/issues/9 - need whitespace prohibition
+                // ISSUE: https://github.com/Pash-Project/Pash/issues/9 - need whitespace prohibition
                 // |
                 // generic_token_with_subexpr
                 ;
@@ -884,7 +884,7 @@ namespace Pash.ParserIntrinsics
             ////        generic_token_with_subexpr:
             ////            No whitespace is allowed between ) and command_name.
             ////            generic_token_with_subexpr_start   statement_list_opt   )   command_name
-            // ISSUE: https://github.com/JayBazuzi/Pash2/issues/9 - need whitespace prohibition
+            // ISSUE: https://github.com/Pash-Project/Pash/issues/9 - need whitespace prohibition
             generic_token_with_subexpr.Rule =
                 generic_token_with_subexpr_start + (statement_list_opt) + ")" + command_name;
 
@@ -1195,20 +1195,20 @@ namespace Pash.ParserIntrinsics
             ////        member_access: Note no whitespace is allowed between terms in these productions.
             ////            primary_expression   .   member_name
             ////            primary_expression   ::   member_name
-            // ISSUE: https://github.com/JayBazuzi/Pash2/issues/9 - need whitespace prohibition
+            // ISSUE: https://github.com/Pash-Project/Pash/issues/9 - need whitespace prohibition
             member_access.Rule =
                 primary_expression + (ToTerm(".") | "::") + member_name;
 
             ////        element_access: Note no whitespace is allowed between primary_expression and [.
             ////            primary_expression   [  new_lines_opt   expression   new_lines_opt   ]
-            // ISSUE: https://github.com/JayBazuzi/Pash2/issues/9 - need whitespace prohibition
+            // ISSUE: https://github.com/Pash-Project/Pash/issues/9 - need whitespace prohibition
             element_access.Rule =
                 primary_expression + PreferShiftHere() + "[" + new_lines_opt + expression + new_lines_opt + "]";
 
             ////        invocation_expression: Note no whitespace is allowed between terms in these productions.
             ////            primary_expression   .   member_name   argument_list
             ////            primary_expression   ::   member_name   argument_list
-            // ISSUE: https://github.com/JayBazuzi/Pash2/issues/9 - need whitespace prohibition
+            // ISSUE: https://github.com/Pash-Project/Pash/issues/9 - need whitespace prohibition
             invocation_expression.Rule =
                 primary_expression + (ToTerm(".") | "::") + member_name + argument_expression;
 
@@ -1461,7 +1461,7 @@ namespace Pash.ParserIntrinsics
             ////            Carriage return character (U+000D) followed by line feed character (U+000A)
             if (source.PreviewChar == '`')
             {
-                // https://github.com/JayBazuzi/Pash2/issues/12
+                // https://github.com/Pash-Project/Pash/issues/12
                 //if (source.NextPreviewChar == '\u000D' && source.NextNextPreviewChar == '\u000A') return 3;
 
                 if (source.NextPreviewChar == '\u000D') return 2;

--- a/Source/TestHost/Tests.cs
+++ b/Source/TestHost/Tests.cs
@@ -199,7 +199,7 @@ namespace TestHost
             Assert.AreEqual(2, result);
         }
 
-        [Test, Description("https://github.com/JayBazuzi/Pash2/issues/6")]
+        [Test, Description("https://github.com/Pash-Project/Pash/issues/6")]
         public void UnrecognizedCommandBug()
         {
             // notice typo


### PR DESCRIPTION
As project home has moved on github this commit updates any Url's from:

```
https://github.com/JayBazuzi/Pash2/*
```

To:

```
https://https://github.com/Pash-Project/Pash/*
```
