### PR TITLE
Unit test stack traces missing file and line info

### DIFF
--- a/Pash.proj
+++ b/Pash.proj
@@ -17,8 +17,8 @@
 
     <Exec Command="Tools\NUnit-2.6.1\bin\nunit-console.exe -nologo Pash.nunit  -run=Libraries.Tests" />
     -->
-    <Exec Command="     $(NUnitCommandLine)" Condition=" '$(OS)' == 'Windows_NT' "/>
-    <Exec Command="mono $(NUnitCommandLine)" Condition=" '$(OS)' != 'Windows_NT' "/>
+    <Exec Command="                        $(NUnitCommandLine)" Condition=" '$(OS)' == 'Windows_NT' "/>
+    <Exec Command="mono $(MonoCommandArgs) $(NUnitCommandLine)" Condition=" '$(OS)' != 'Windows_NT' "/>
   </Target>
 
   <PropertyGroup>
@@ -27,6 +27,10 @@
 
   <PropertyGroup>
     <PashConsoleCommandLine>Source\PashConsole\bin\Debug\Pash.exe</PashConsoleCommandLine>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <MonoCommandArgs>--debug --runtime=v4.0</MonoCommandArgs>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
On some mono environments when unit tests fail we get a stack trace that
is missing the file and line details making debugging more difficult.

This is due to us running a pre-compiled NUnit assembly that references
version 2.0.0.0 of mscorlib which can be seen here:

```
$ monodis Tools/NUnit-2.6.1/bin/nunit-console.exe
.assembly extern mscorlib
{
  .ver 2:0:0:0
  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 ) // .z\V.4..
}

...
```

This commit adds command line options to mono when running the test target
to a) force debugging info and b) force the use of the v4.0 profile.
