### PR TITLE
Fix newlines in `1..10` test

### DIFF
--- a/Source/TestHost/Tests.cs
+++ b/Source/TestHost/Tests.cs
@@ -188,7 +188,7 @@ namespace TestHost
 8
 9
 10
-".Replace("\n", System.Environment.NewLine);
+";
 
                 Assert.AreEqual(expected, result);
             }


### PR DESCRIPTION
I picked up the latest code, ran tests, and this failed. I can't explain
why.
