### PR TITLE
Make `Ranges` test work on all platforms.

### DIFF
--- a/Source/TestHost/Tests.cs
+++ b/Source/TestHost/Tests.cs
@@ -177,18 +177,7 @@ namespace TestHost
             {
                 var result = TestHost.Execute("1..10");
 
-                var expected =
-@"1
-2
-3
-4
-5
-6
-7
-8
-9
-10
-".Replace("\n", System.Environment.NewLine);
+                var expected = string.Join(Environment.NewLine, Enumerable.Range(1, 10)) + Environment.NewLine;
 
                 Assert.AreEqual(expected, result);
             }


### PR DESCRIPTION
I think the newlineness of the source file was changing and affecting the outcome of the test.
