### PR TITLE
Work around Mono GetDrives() bug

### DIFF
--- a/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
@@ -159,6 +159,15 @@ namespace Microsoft.PowerShell.Commands
 
         protected override bool HasChildItems(Path path) { throw new NotImplementedException(); }
 
+        public static bool IsLinux
+        {
+            get
+            {
+            	int p = (int) Environment.OSVersion.Platform;
+            	return (p == 4) || (p == 6) || (p == 128);
+            }
+        }
+
         protected override Collection<PSDriveInfo> InitializeDefaultDrives()
         {
             Collection<PSDriveInfo> collection = new Collection<PSDriveInfo>();
@@ -168,6 +177,18 @@ namespace Microsoft.PowerShell.Commands
             // TODO: Console.WriteLine("Mono: After GetDrives");
 
             System.Diagnostics.Debug.WriteLine("Number of drives: " + ((drives == null) ? "Null drives" : drives.Length.ToString()));
+
+			int driveCount = 0;
+
+            // TODO: Resolve hack to get around Mono bug where System.IO.DriveInfo.GetDrives() returns a single blank drive.
+            if ( drives.Length == 1 && IsLinux && drives[0].Name.Length == 0)
+            {
+                PSDriveInfo info = new PSDriveInfo("/", base.ProviderInfo, "/", "Root", null);
+                info.RemovableDrive = false;
+
+                collection.Add(info);
+                return collection;
+            }
 
             if (drives != null)
             {
@@ -199,6 +220,7 @@ namespace Microsoft.PowerShell.Commands
                     collection.Add(info);
                 }
             }
+
             return collection;
         }
 


### PR DESCRIPTION
The results of System.IO.DriveInfo.GetDrives() is incorrect on my
system, returning a single entry with a blank name.

This commit works around the issue by catching this condition when
running on *nix platforms, and returning a single drive called root.

*nix like operating systems are less reliant on the concept of a drive
anyway, so this allows Pash to continue operation and still represent
the cwd.

I've been watching problem through the Mono versions but has remained, currently I'm on Mono 3.0.7.

Not sure what is different about my system that causes this issue, but my guess is  it has something to do with the number or type of the filesystem's (> 100 zfs filesystem's, 122 entries in all listed by mount command)

I will do some debugging on Mono and try to submit a bug/patch but in the meantime this seems like a good way to deal with the issue in case it also effects others.

I'm all good to rework this if anyone has any suggestions to make it cleaner or deal with in a different way.

Here is a test program that shows the bug:

```
$ cat DriveInfoTest.cs 
using System;
using System.IO;

class Test
{
    public static void Main()
    {
        DriveInfo[] allDrives = DriveInfo.GetDrives();

        foreach (DriveInfo d in allDrives)
        {
            Console.WriteLine("Drive: {0}", d.Name);
            Console.WriteLine("Drive.RootDirectory: {0}", d.RootDirectory);
            Console.WriteLine("  File type: {0}", d.DriveType);
            if (d.IsReady == true)
            {
                Console.WriteLine("  Volume label: {0}", d.VolumeLabel);
                Console.WriteLine("  File system: {0}", d.DriveFormat);
                Console.WriteLine(
                    "  Available space to current user:{0, 15} bytes", 
                    d.AvailableFreeSpace);

                Console.WriteLine(
                    "  Total available space:          {0, 15} bytes",
                    d.TotalFreeSpace);

                Console.WriteLine(
                    "  Total size of drive:            {0, 15} bytes ",
                    d.TotalSize);
            }
        }
    }
}
$ mono ./DriveInfoTest.exe
Drive: 

Unhandled Exception:
System.ArgumentException: An empty file name is not valid.
  at System.IO.FileSystemInfo.CheckPath (System.String path) [0x00000] in <filename unknown>:0 
  at System.IO.DirectoryInfo..ctor (System.String path, Boolean simpleOriginalPath) [0x00000] in <filename unknown>:0 
  at System.IO.DirectoryInfo..ctor (System.String path) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.IO.DirectoryInfo:.ctor (string)
  at System.IO.DriveInfo.get_RootDirectory () [0x00000] in <filename unknown>:0 
  at Test.Main () [0x00000] in <filename unknown>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: An empty file name is not valid.
  at System.IO.FileSystemInfo.CheckPath (System.String path) [0x00000] in <filename unknown>:0 
  at System.IO.DirectoryInfo..ctor (System.String path, Boolean simpleOriginalPath) [0x00000] in <filename unknown>:0 
  at System.IO.DirectoryInfo..ctor (System.String path) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.IO.DirectoryInfo:.ctor (string)
  at System.IO.DriveInfo.get_RootDirectory () [0x00000] in <filename unknown>:0 
  at Test.Main () [0x00000] in <filename unknown>:0 
```
