### PR TITLE
Parameters with no set specified should belong to all sets

### DIFF
--- a/Source/System.Management/Automation/CmdletInfo.cs
+++ b/Source/System.Management/Automation/CmdletInfo.cs
@@ -137,6 +137,16 @@ namespace System.Management.Automation
                 bool bIsDefaultParamSet = paramSetName == strDefaultParameterSetName;
 
                 paramSetInfo.Add(new CommandParameterSetInfo(paramSetName, bIsDefaultParamSet, paramSets[paramSetName]));
+
+                // If a parameter set is not specified for a parmeter, then the parameter belongs to all the parameter sets,
+                // therefore if this is not the AllParameterSets Set then add all parameters from the AllParameterSets Set to it...
+                if ( string.Compare(paramSetName,ParameterAttribute.AllParameterSets) != 0 && paramSets.ContainsKey(ParameterAttribute.AllParameterSets) ) 
+                {
+                    foreach ( CommandParameterInfo cpi in paramSets[ParameterAttribute.AllParameterSets] )
+                    {
+                        paramSets[paramSetName].Add(cpi);
+                    }
+                }
             }
 
             return new ReadOnlyCollection<CommandParameterSetInfo>(paramSetInfo);


### PR DESCRIPTION
If a CmdLet has parameter sets, and a parameter has
no parameter set specified, then that parameter should
belong to all parameter sets.

This was stopping parameters from being passed correctly to a CmdLet
when it has multiple parameter sets, for parameters that had no set
specified.

More work needs to be done to the parameter logic but should
improve it slightly.

As a result the following should now work:

```
Get-ChildItem -Recurse
```
