### PR TITLE
Static method lookup on types should be case-insensitive

### DIFF
--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -485,8 +485,9 @@ namespace System.Management.Pash.Implementation
 
             if (methodCallAst.Member is StringConstantExpressionAst)
             {
+                BindingFlags bindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
                 var name = (methodCallAst.Member as StringConstantExpressionAst).Value;
-                var method = type.GetMethod(name, arguments.Select(a => a.GetType()).ToArray());
+                var method = type.GetMethod(name, bindingFlags, null, arguments.Select(a => a.GetType()).ToArray(), null);
                 var result = method.Invoke(obj, arguments.ToArray());
 
                 _pipelineCommandRuntime.WriteObject(result);

--- a/Source/TestHost/7.1.2 - Member Access.cs
+++ b/Source/TestHost/7.1.2 - Member Access.cs
@@ -55,6 +55,14 @@ a.Length
         }
 
         [Test]
+        public void StaticMethodAccessIsCaseInsensitive()
+        {
+            var result = TestHost.Execute(true, @"[Math]::abs(-15)");
+
+            Assert.AreEqual("15" + Environment.NewLine, result);
+        }
+
+        [Test]
         public void TwoParameters()
         {
             var result = TestHost.Execute(@"[char]::IsUpper(""AbC"", 1)");


### PR DESCRIPTION
Fixes #111, I guess.

May be still problematic. I also added a test for that case, but I'm not quite sure whether it's in the right place.
