### PR TITLE
Fixed a missing $ in a test case.

### DIFF
--- a/Source/TestHost/7.1.2 - Member Access.cs
+++ b/Source/TestHost/7.1.2 - Member Access.cs
@@ -32,7 +32,7 @@ namespace TestHost
         {
             var result = TestHost.Execute(true, @"
 $a = 10,20,30
-a.Length
+$a.Length
 ");
 
             Assert.AreEqual("3" + Environment.NewLine, result);


### PR DESCRIPTION
Side note: That test case _would_ pass if it used `Count` instead of `Length`, but since it was taken verbatim from the spec I decided not to change it.
