### PR TITLE
Add Clean/Rebuild targets to the project file.

### DIFF
--- a/Pash.proj
+++ b/Pash.proj
@@ -6,6 +6,15 @@
     <MSBuild Projects="Source\Pash.sln" />
   </Target>
 
+  <Target Name="Clean">
+    <MSBuild Projects="Source\Pash.sln" Targets="Clean" />
+  </Target>
+
+  <Target Name="Rebuild">
+    <MSBuild Projects="Source\Pash.sln" Targets="Rebuild" />
+  </Target>
+
+
   <!--=====================================================================-->
   <Target Name="Test"
           DependsOnTargets="Build"


### PR DESCRIPTION
This makes it easier to rebuild the project when using xbuid/MSBuild.
