### PR TITLE
Fix string comparison in SetCurrentDrive

### DIFF
--- a/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
@@ -263,7 +263,7 @@ namespace Pash.Implementation
             foreach (var drive in fileSystemProvider.Drives)
             {
                 Path currentDir = System.Environment.CurrentDirectory;
-                if (drive.Name == currentDir.GetDrive())
+                if (string.Equals(drive.Name, currentDir.GetDrive(), StringComparison.OrdinalIgnoreCase))
                 {
                     drive.CurrentLocation = currentDir;
                     _currentDrive = drive;


### PR DESCRIPTION
I've explored the case when current path is `d:\Something\Something` (well, I have this setup in my debug environment). In this case, drive letter returned from `System.Management.Path.GetPath` is lowercase (i.e. `"d"`). But letters returned from FileSystemProvider are all uppercase (i.e. `"D"`). Because of that, an exception `"why are we here?"` is thrown.

So I've decided to better fix `SessionStateGlobal.SetCurrentDrive` code, because I think that we should never do assumptions about drive letter casing.
