### PR TITLE
POSIX calls optimization

### DIFF
--- a/Source/System.Management/Pash/Implementation/CommandManager.cs
+++ b/Source/System.Management/Pash/Implementation/CommandManager.cs
@@ -10,6 +10,7 @@ using System.Management.Automation.Provider;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
 using Extensions.Enumerable;
+using Pash.Implementation.Native;
 using Pash.ParserIntrinsics;
 
 namespace Pash.Implementation
@@ -372,20 +373,8 @@ namespace Pash.Implementation
             {
                 return false;
             }
-            
-            // Here we use reflection for dynamic loading of Mono.Posix assembly and invocation of
-            // the native access call. Reflection is used for cross-platform compatibility of
-            // System.Management assembly. Once compiled, it'll use native API only when run on
-            // Unix platform.
-            var posix = Assembly.Load("Mono.Posix");
-            var syscall = posix.GetType("Mono.Unix.Native.Syscall");
-            var accessModes = posix.GetType("Mono.Unix.Native.AccessModes");
-            
-            var access = syscall.GetMethod("access");
-            var x_ok = accessModes.GetField("X_OK");
 
-            var result = access.Invoke(null, new[] { path, x_ok.GetRawConstantValue() });
-            return result.Equals(0);
+            return Posix.access(path, Posix.X_OK) == 0;
         }
     }
 }

--- a/Source/System.Management/Pash/Implementation/Native/Posix.cs
+++ b/Source/System.Management/Pash/Implementation/Native/Posix.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+
+namespace Pash.Implementation.Native
+{
+    /// <summary>
+    /// Uses reflection for dynamic loading of Mono.Posix assembly and invocation of native calls.
+    /// Reflection is used for cross-platform compatibility of current assembly. Methods of this
+    /// class should be called only if Mono runtime is currently used.
+    /// </summary>
+    internal static class Posix
+    {
+        public static readonly object X_OK;
+
+        private static readonly Delegate _access;
+        
+        static Posix()
+        {
+            var posix = Assembly.Load("Mono.Posix");
+            var syscall = posix.GetType("Mono.Unix.Native.Syscall");
+            var access = syscall.GetMethod("access");
+            _access = Delegate.CreateDelegate(syscall, access);
+
+            var accessModes = posix.GetType("Mono.Unix.Native.AccessModes");
+            X_OK = accessModes.GetField("X_OK").GetRawConstantValue();
+        }
+
+        public static int access(string path, object mode)
+        {
+            return (int) _access.DynamicInvoke(new[] { path, mode });
+        }
+    }
+}

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -433,6 +433,7 @@
     <Compile Include="Pash\Implementation\LocalPipeline.cs" />
     <Compile Include="Pash\Implementation\LocalRunspace.cs" />
     <Compile Include="Pash\Implementation\LocalRunspaceConfiguration.cs" />
+    <Compile Include="Pash\Implementation\Native\Posix.cs" />
     <Compile Include="Pash\Implementation\Native\Shell32.cs" />
     <Compile Include="Pash\Implementation\ObjectPipelineReader.cs" />
     <Compile Include="Pash\Implementation\ObjectStream.cs" />


### PR DESCRIPTION
This is the optimization I talked about earlier. Removed unnecessary reflection calls from `IsUnixExecutable` function, abstracted out all the reflection stuff. Pash behavior wasn't changed.
