### PR TITLE
Support Enum arguments.

### DIFF
--- a/Source/System.Management/Pash/Implementation/CommandProcessor.cs
+++ b/Source/System.Management/Pash/Implementation/CommandProcessor.cs
@@ -145,6 +145,10 @@ namespace System.Management.Automation
             {
                 SetValue(memberInfo, Command, value.ToString());
             }
+            
+            else if (memberType.IsEnum) {
+                  SetValue (memberInfo, Command, Enum.Parse (type, value.ToString(), true));
+            }
 
             else if (memberType == typeof(PSObject))
             {


### PR DESCRIPTION
BEFORE

``` shell
$ mono Source/PashConsole/bin/Debug/Pash.exe
Pash - Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/

PASH Pash> write-host "Running psake build tests" -ForeGroundColor GREEN
ERROR: System.ArgumentException: Object type System.String cannot be converted to target type: System.ConsoleColor
  at System.Reflection.Binder.ConvertValue (System.Object value, System.Type type, System.Globalization.CultureInfo culture, Boolean exactMatch) [0x00000] in <filename unknown>:0 
  at System.Reflection.Binder.ConvertValues (System.Object[] args, System.Reflection.ParameterInfo[] pinfo, System.Globalization.CultureInfo culture, Boolean exactMatch) [0x00000] in <filename unknown>:0 
  at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0 
  at System.Reflection.MonoProperty.SetValue (System.Object obj, System.Object value, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] index, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0 
  at System.Reflection.PropertyInfo.SetValue (System.Object obj, System.Object value, System.Object[] index) [0x00000] in <filename unknown>:0 
  at System.Management.Automation.CommandProcessor.SetValue (System.Reflection.MemberInfo info, System.Object targetObject, System.Object value) [0x00000] in <filename unknown>:0 
  at System.Management.Automation.CommandProcessor.BindArgument (System.String name, System.Object value, System.Type type) [0x00000] in <filename unknown>:0 
  at System.Management.Automation.CommandProcessor.BindArguments (System.Management.Automation.PSObject obj) [0x00000] in <filename unknown>:0 
  at Pash.Implementation.PipelineProcessor.Execute (Pash.Implementation.ExecutionContext context) [0x00000] in <filename unknown>:0 
  at Pash.Implementation.LocalPipeline.Invoke (IEnumerable input) [0x00000] in <filename unknown>:0 
```

AFTER

``` shell
$ mono Source/PashConsole/bin/Debug/Pash.exe
Pash - Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/

PASH Pash> write-host "Running psake build tests" -ForeGroundColor GREEN
Running psake build tests
```

with Running psake build tests printed in green.
