### PR TITLE
Fixed numbered/named groups in $Matches

### DIFF
--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -174,19 +174,20 @@ namespace System.Management.Pash.Implementation
         {
             var matches = new Hashtable();
             var groupNames = from name in regex.GetGroupNames()
-                             where match.Groups[name].Success && name != "0"
+                             where match.Groups[name].Success
                              select name;
-            var groupNumbers = from num in regex.GetGroupNumbers()
-                               where match.Groups[num].Success
-                               select num;
 
             foreach (string name in groupNames)
             {
-                matches.Add(name, match.Groups[name].Value);
-            }
-            foreach (int num in groupNumbers)
-            {
-                matches.Add(num, match.Groups[num].Value);
+                int num;
+                if (int.TryParse(name, out num))
+                {
+                    matches.Add(num, match.Groups[num].Value);
+                }
+                else
+                {
+                    matches.Add(name, match.Groups[name].Value);
+                }
             }
 
             _context.SetVariable("Matches", PSObject.AsPSObject(matches));

--- a/Source/TestHost/7.8.4 - Pattern Matching.cs
+++ b/Source/TestHost/7.8.4 - Pattern Matching.cs
@@ -17,10 +17,22 @@ namespace TestHost
             Assert.AreEqual(expected + Environment.NewLine, result);
         }
 
+        // Capturing group
         [TestCase(@"'Monday' -match 'mon' | out-null; $matches[0]", "Mon")]
         [TestCase(@"'Tuesday' -match 'tue' | out-null; $matches[0]", "Tue")]
         [TestCase(@"'01/02/2000 Desc' -match '(.*) (.*)' | out-null; $matches[1]", "01/02/2000")]
+        // Named capturing group
         [TestCase(@"'Monday' -match '(?<word>[a-z]+)' | out-null; $matches['word']", "Monday")]
+        // Numbered groups not as string
+        [TestCase(@"'abc' -match '(a)(b)(c)' | out-null; $matches['0'] -eq $null", "True")]
+        [TestCase(@"'abc' -match '(a)(b)(c)' | out-null; $matches['1'] -eq $null", "True")]
+        [TestCase(@"'abc' -match '(a)(b)(c)' | out-null; $matches['2'] -eq $null", "True")]
+        [TestCase(@"'abc' -match '(a)(b)(c)' | out-null; $matches['3'] -eq $null", "True")]
+        // Mixed named and numbered groups
+        [TestCase(@"'abc' -match '(a)(b)(?<x>c)' | out-null; $matches[1]", "a")]
+        [TestCase(@"'abc' -match '(a)(b)(?<x>c)' | out-null; $matches[2]", "b")]
+        [TestCase(@"'abc' -match '(a)(b)(?<x>c)' | out-null; $matches[3] -eq $null", "True")]
+        [TestCase(@"'abc' -match '(a)(b)(?<x>c)' | out-null; $matches['x']", "c")]
         public void Matches(string input, string expected)
         {
             string result = TestHost.Execute(input);


### PR DESCRIPTION
The previous code would mistakenly include numbered groups with a string key in `$Matches` which PowerShell does not do. Furthermore, named groups may not start with a digit anyway. A combination of `GetGroupNames` and `GetGroupNumbers` seems impossible to get to work correctly, but `GetGroupNames` yields the keys for the hashtable that PowerShell also sets; we just need to massage the numbers a bit.
