### PR TITLE
Implement += assignment.

### DIFF
--- a/Source/System.Management.Tests/Ast/Ast.Tests.cs
+++ b/Source/System.Management.Tests/Ast/Ast.Tests.cs
@@ -1326,5 +1326,18 @@ ls
                 Assert.AreEqual(1, tryStatementAst.CatchClauses.Single().Body.Statements.Count);
             }
         }
+
+        [Test]
+        public void AssignmentByAdditionOperator()
+        {
+            AssignmentStatementAst assignmentStatementAst = ParseStatement("$i += 10");
+
+            var variableAst = (VariableExpressionAst)assignmentStatementAst.Left;
+            var commandAst = (CommandExpressionAst)assignmentStatementAst.Right.Children.First();
+            var constantAst = (ConstantExpressionAst)commandAst.Expression;
+            Assert.AreEqual("i", variableAst.VariablePath.UserPath);
+            Assert.AreEqual(TokenKind.PlusEquals, assignmentStatementAst.Operator);
+            Assert.AreEqual(10, constantAst.Value);
+        }
     }
 }

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -443,7 +443,18 @@ namespace System.Management.Pash.Implementation
             var variableExpressionAst = expressionAst as VariableExpressionAst;
             if (variableExpressionAst == null) throw new NotImplementedException(expressionAst.ToString());
 
-            this._context.SessionState.SessionStateGlobal.SetVariable(variableExpressionAst.VariablePath.UserPath, rightValue);
+            if (assignmentStatementAst.Operator == TokenKind.Equals)
+            {
+                this._context.SessionState.SessionStateGlobal.SetVariable(variableExpressionAst.VariablePath.UserPath, rightValue);
+            }
+
+            else if (assignmentStatementAst.Operator == TokenKind.PlusEquals)
+            {
+                dynamic currentValue = this._context.SessionState.SessionStateGlobal.GetVariable(variableExpressionAst.VariablePath.UserPath).GetBaseObjectValue();
+                dynamic assignmentValue = ((PSObject)rightValue).BaseObject;
+                object newValue = currentValue + assignmentValue;
+                this._context.SessionState.SessionStateGlobal.SetVariable(variableExpressionAst.VariablePath.UserPath, newValue);
+            }
 
             if (this._writeSideEffectsToPipeline) this._pipelineCommandRuntime.WriteObject(rightValue);
 

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -509,6 +509,9 @@ namespace Pash.ParserIntrinsics
                 case "=":
                     return TokenKind.Equals;
 
+                case "+=":
+                    return TokenKind.PlusEquals;
+
                 default:
                     throw new NotImplementedException(parseTreeNode.ToString());
             }

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -58,6 +58,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/Source/TestHost/Tests.cs
+++ b/Source/TestHost/Tests.cs
@@ -568,5 +568,14 @@ namespace TestHost
                 StringAssert.AreEqualIgnoringCase("System.Management.Automation.ErrorRecord" + Environment.NewLine, result);
             }
         }
+
+        [TestCase(@"$i = 1; $i += 10; Write-Host $i", "11")]
+        [TestCase(@"$x = 'a'; $x += 'b'; Write-Host $x", "ab")]
+        public void AssignmentByAdditionOperator(string input, string expected)
+        {
+            string result = TestHost.Execute(input);
+
+            StringAssert.AreEqualIgnoringCase(expected + Environment.NewLine, result);
+        }
     }
 }


### PR DESCRIPTION
Supports the following:

$i = 0;
$i += 10;

$x = 'a';
$x += 'bcdef';

Implementation uses dynamic to add two objects together which seems simpler than using reflection or casting.

It looks like PowerShell is not using dynamic. Trying to add two System.Objects together from the PowerShell command line results in the error:

Method invocation failed because [System.Object] doesn't contain a method named 'op_Addition'.

So it looks like PowerShell is using reflection for some types and probably handles types such as integers, which have no op_Addition method, individually by casting them to the correct type.
