### PR TITLE
Fix output when iterating through a foreach or for loop

### DIFF
--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -864,7 +864,7 @@ namespace System.Management.Pash.Implementation
 
             while ((bool)((PSObject)EvaluateAst(forStatementAst.Condition)).BaseObject)
             {
-                this._pipelineCommandRuntime.WriteObject(EvaluateAst(forStatementAst.Body), true);
+                this._pipelineCommandRuntime.WriteObject(EvaluateAst(forStatementAst.Body, false), true);
                 EvaluateAst(forStatementAst.Iterator);
             }
 

--- a/Source/TestHost/Tests.cs
+++ b/Source/TestHost/Tests.cs
@@ -423,6 +423,14 @@ namespace TestHost
         }
 
         [Test]
+        public void ForLoopWithAssignmentStatementAsBodyShouldNotOutputAssignmentResultOnEachIteration()
+        {
+            string result = TestHost.Execute("$j = 0; for ($i = 0; $i -ile 10; $i++) { $j++ }; $j");
+
+            Assert.AreEqual("11" + Environment.NewLine, result);
+        }
+
+        [Test]
         public void ForEach()
         {
             string result = TestHost.Execute("foreach ($i in (0..10)) { $i }");


### PR DESCRIPTION
Both the following were previously outputting the $j variable on each iteration:

$j = 0
foreach ($i in 0..10) {
   $j++
}

for ($i = 0; $i -ile 10; $i++) {
   $j++
}
