### PR TITLE
Introduction of scopes

### DIFF
--- a/Source/System.Management/Automation/DriveManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/DriveManagementIntrinsics.cs
@@ -2,65 +2,138 @@
 using System;
 using System.Collections.ObjectModel;
 using Pash.Implementation;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace System.Management.Automation
 {
     public sealed class DriveManagementIntrinsics
     {
-        private SessionStateGlobal _sessionState;
+        private const string driveDoesntExistFormat = @"No such drive. A drive with the name ""{0}"" doesn't exist.";
+        private const string driveAlreadyExistsFormat = @"A drive with the name ""{0}"" already exists.";
 
-        internal DriveManagementIntrinsics(SessionStateGlobal sessionState)
+        private SessionStateScope sessionScope;
+
+        internal DriveManagementIntrinsics(SessionStateScope scope)
         {
-            _sessionState = sessionState;
+            sessionScope = scope;
         }
 
         public PSDriveInfo Current
         {
             get
             {
-                return _sessionState.CurrentDrive;
+                return sessionScope.SessionStateGlobal.CurrentDrive;
             }
         }
 
         public PSDriveInfo Get(string driveName)
         {
-            return _sessionState.GetDrive(driveName);
+            //recursively look for the drive
+            for (var candidate = sessionScope; candidate != null; candidate = candidate.ParentScope)
+            {
+                var info = candidate.GetLocalDrive(driveName);
+                if (info != null)
+                {
+                    return info;
+                }
+            }
+            //no such drive found
+            throw new MethodInvocationException(String.Format(driveDoesntExistFormat, driveName));
         }
 
         public Collection<PSDriveInfo> GetAll()
         {
-            return _sessionState.GetDrives(null);
+            //first get a copy of the drives in the local scope. NOTE: it also copies the correct StringComparer
+            //dictionary first, so ContainsKey is faster than in a collection
+            var visibleDrives = new Dictionary<string, PSDriveInfo>(sessionScope.LocalDrives);
+            //recursively gather all drives from parent scopes
+            for (var cur = sessionScope.ParentScope; cur != null; cur = cur.ParentScope)
+            {
+                foreach (KeyValuePair<string, PSDriveInfo> pair in cur.LocalDrives)
+                {
+                    //as ascend the scope hierarchy, we must not overwrite values of child scopes
+                    if (!visibleDrives.ContainsKey(pair.Key))
+                    {
+                        visibleDrives.Add(pair.Key, pair.Value);
+                    }
+                }
+            }
+            return new Collection<PSDriveInfo>(visibleDrives.Values.ToList());
         }
 
         public Collection<PSDriveInfo> GetAllAtScope(string scope)
         {
-            return _sessionState.GetDrives(scope);
+            if (String.IsNullOrEmpty(scope))
+            {
+                 //this behavior corresponds to PS 2.0
+                return GetAll();
+            }
+            SessionStateScope affectedScope = sessionScope.GetScope(scope);
+            return new Collection<PSDriveInfo>(affectedScope.LocalDrives.Values.ToList());
         }
 
         public Collection<PSDriveInfo> GetAllForProvider(string providerName)
         {
-            return _sessionState.GetDrivesForProvider(providerName);
+            if (String.IsNullOrEmpty(providerName))
+            {
+                //this behavior corresponds to PS 2.0
+                return GetAll();
+            }
+            /* "fun" fact: this method is different from getting the provider and checking its DriveProperty!
+            * ProviderInfo.Drives seems to only provide drives that are available in the 0 scope
+            * However, this functions needs to provide also the drives of child scopes that are associated with a
+            * provider.
+            * That's why sessionScope.SessionStateGlobal.GetProviderByName(providerName).Drives doesn't work here
+            * At least that's the behavior of PS 2.0
+            */
+            var allDrives = GetAll();
+            Collection<PSDriveInfo> providerDrives = new Collection<PSDriveInfo>();
+            foreach (var drive in allDrives)
+            {
+                if (drive.Provider.IsNameMatch(providerName))
+                {
+                    providerDrives.Add(drive);
+                }
+            }
+            //no drives means we don't have a proper provider!
+            if (providerDrives.Count < 1)
+            {
+                throw new MethodInvocationException(
+                    String.Format(@"No such provider. A provider with the name ""{0}"" doesn't exist.", providerName)
+                );
+            }
+            return providerDrives;
         }
 
         public PSDriveInfo GetAtScope(string driveName, string scope)
         {
-            // Scope?
-            return _sessionState.GetDrive(driveName);
+            SessionStateScope affectedScope = sessionScope.GetScope(scope);
+            var info = affectedScope.GetLocalDrive(driveName);
+            if (info == null)
+            {
+                throw new MethodInvocationException(String.Format(driveDoesntExistFormat, driveName));
+            }
+            return info;
         }
 
         public PSDriveInfo New(PSDriveInfo drive, string scope)
         {
-            return _sessionState.AddNewDrive(drive, scope);
+            SessionStateScope affectedScope = sessionScope.GetScope(scope);
+            if (!affectedScope.AddLocalDrive(drive))
+            {
+                throw new MethodInvocationException(String.Format(driveAlreadyExistsFormat, drive.Name));
+            }
+            return drive;
         }
 
         public void Remove(string driveName, bool force, string scope)
         {
-            _sessionState.RemoveDrive(driveName, force, scope);
+            SessionStateScope affectedScope = sessionScope.GetScope(scope);
+            if (!affectedScope.RemoveLocalDrive(driveName, force))
+            {
+                throw new MethodInvocationException(String.Format(driveDoesntExistFormat, driveName));
+            }
         }
-
-        // internals
-        //internal void New(PSDriveInfo drive, string scope, CmdletProviderContext context);
-        //internal object NewDriveDynamicParameters(string providerId, CmdletProviderContext context);
-        //internal void Remove(string driveName, bool force, string scope, CmdletProviderContext context);
     }
 }

--- a/Source/System.Management/Automation/ExtendedTypeSystemException.cs
+++ b/Source/System.Management/Automation/ExtendedTypeSystemException.cs
@@ -43,12 +43,30 @@ namespace System.Management.Automation
         internal const string ToStringExceptionMsg = "ToStringException";
         internal const string TypesXmlErrorMsg = "TypesXmlError";
 
-        public ExtendedTypeSystemException() { throw new NotImplementedException(); }
-        public ExtendedTypeSystemException(string message) { throw new NotImplementedException(); }
-        protected ExtendedTypeSystemException(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
-        public ExtendedTypeSystemException(string message, Exception innerException) { throw new NotImplementedException(); }
-        internal ExtendedTypeSystemException(string errorId, Exception innerException, string baseName, string resourceId, params object[] arguments)
-        { throw new NotImplementedException(); }
+        public ExtendedTypeSystemException()
+            : base()
+        {
+        }
+
+        public ExtendedTypeSystemException(string message)
+            : base(message)
+        {
+        }
+
+        protected ExtendedTypeSystemException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+        public ExtendedTypeSystemException(string message, Exception innerException) 
+            : base(message, innerException)
+        {
+        }
+
+        internal ExtendedTypeSystemException(string errorId, Exception innerException,
+                                             string baseName, string resourceId, params object[] arguments)
+        {
+            throw new NotImplementedException(); 
+        }
     }
 
 }

--- a/Source/System.Management/Automation/Internal/InternalCommand.cs
+++ b/Source/System.Management/Automation/Internal/InternalCommand.cs
@@ -23,7 +23,7 @@ namespace System.Management.Automation.Internal
             set
             {
                 _executionContext = value;
-                State = new SessionState(_executionContext.SessionState.SessionStateGlobal);
+                State = _executionContext.SessionState;
                 PSHostInternal = _executionContext.LocalHost;
             }
         }

--- a/Source/System.Management/Automation/PSVariable.cs
+++ b/Source/System.Management/Automation/PSVariable.cs
@@ -65,7 +65,9 @@ namespace System.Management.Automation
         //internal object TransformValue(object value);
         //internal bool IsAllScope { get; }
         //internal bool IsConstant { get; }
-        internal bool IsPrivate { get; private set; }
+        internal bool IsPrivate { 
+            get { return Options.HasFlag(ScopedItemOptions.Private); } 
+        }
         //internal bool IsReadOnly { get; }
         //internal bool WasRemoved { set; get; }
 

--- a/Source/System.Management/Automation/PSVariableIntrinsics.cs
+++ b/Source/System.Management/Automation/PSVariableIntrinsics.cs
@@ -1,59 +1,207 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
 using Pash.Implementation;
+using System.Collections.Generic;
 
 namespace System.Management.Automation
 {
     public sealed class PSVariableIntrinsics
     {
-        private SessionStateGlobal _sessionState;
+        private SessionStateScope sessionScope;
 
-        internal PSVariableIntrinsics(SessionStateGlobal sessionState)
+        internal PSVariableIntrinsics(SessionStateScope scope)
         {
-            _sessionState = sessionState;
+            sessionScope = scope;
         }
 
         public PSVariable Get(string name)
         {
-            return _sessionState.GetVariable(name);
+            if (name == null)
+            {
+                throw new ArgumentNullException("The variable name is null.");
+            }
+            var path = new VariablePath(name);
+            var unqualifiedName = path.IsUnqualified ? name : UnqualifyVariableName(name);
+            var qualifiedScope = ResolveQualifiedScope(path);
+            if (qualifiedScope != null)
+            {
+                var variable = qualifiedScope.GetLocalVariable(unqualifiedName);
+                //return null if it's private
+                if (qualifiedScope != sessionScope && variable.IsPrivate)
+                {
+                    return null;
+                }
+                return variable;
+            }
+            var hostingScope = FindHostingScope(unqualifiedName);
+            if (hostingScope != null)
+            {
+                return hostingScope.GetLocalVariable(unqualifiedName);
+            }
+            return null;
         }
 
         public object GetValue(string name)
         {
-            return _sessionState.GetVariableValue(name);
+            var variable = Get(name);
+            return (variable != null) ? variable.Value : null;
         }
 
         public object GetValue(string name, object defaultValue)
         {
-            return _sessionState.GetVariableValue(name, defaultValue);
+            return GetValue(name) ?? defaultValue;
         }
 
         public void Remove(PSVariable variable)
         {
-            _sessionState.RemoveVariable(variable);
+            //no scope specified when passing an object: we only care about the local scope
+            if (variable == null)
+            {
+                throw new ArgumentNullException("The variable is null.");
+            }
+            //add the local scope specifier to make sure we don't screw up with other variables
+            Remove("local:" + variable.Name);
         }
 
-        public void Remove(string name)
+        public void Remove (string name)
         {
-            _sessionState.RemoveVariable(name);
+            if (name == null) {
+                throw new ArgumentNullException("The variable name is null.");
+            }
+            //difference to get: we don't lookup the variable in parent scopes to remove it.
+            var path = new VariablePath(name);
+            var unqualifiedName = path.IsUnqualified ? name : UnqualifyVariableName(name);
+            var affectedScope = ResolveQualifiedScope(path) ?? FindHostingScope(unqualifiedName);
+            if (affectedScope == null)
+            {
+                return; //not found
+            }
+            var variable = affectedScope.GetLocalVariable(unqualifiedName);
+    
+            if (variable == null) //not in the affected scope
+            {
+                return;
+            }
+            if (variable.Options.HasFlag(ScopedItemOptions.Constant))
+            {
+                throw new SessionStateUnauthorizedAccessException("The variable is a constant and cannot be removed.");
+            }
+            affectedScope.RemoveLocalVariable(unqualifiedName);
         }
 
         public void Set(PSVariable variable)
         {
-            _sessionState.SetVariable(variable);
+            if (variable == null)
+            {
+                throw new ArgumentNullException("The variable is null.");
+            }
+            var original = sessionScope.GetLocalVariable(variable.Name);
+            if (original == null)
+            {
+                sessionScope.SetLocalVariable(variable);
+                return;
+            }
+            if (original.Options.HasFlag(ScopedItemOptions.ReadOnly | ScopedItemOptions.Constant))
+            {
+                throw new SessionStateUnauthorizedAccessException("The variable is read-only or a constant.");
+            }
+            original.Value = variable.Value;
+            original.Description = variable.Description;
+            original.Options = variable.Options;
+            sessionScope.SetLocalVariable(original);
         }
 
         public void Set(string name, object value)
         {
-            _sessionState.SetVariable(name, value);
+            if (name == null) {
+                throw new ArgumentNullException("The variable name is null.");
+            }
+            var path = new VariablePath(name);
+            var unqualifiedName = path.IsUnqualified ? name : UnqualifyVariableName (name);
+            var affectedScope = ResolveQualifiedScope(path) ?? sessionScope;
+            var original = affectedScope.GetLocalVariable(unqualifiedName);
+            var variable = original ?? new PSVariable(unqualifiedName);
+            if (variable.Options.HasFlag(ScopedItemOptions.ReadOnly | ScopedItemOptions.Constant))
+            {
+                throw new SessionStateUnauthorizedAccessException("The variable is read-only or a constant.");
+            }
+            if (path.IsPrivate && original == null) //only set private flag if this variable is new
+            {
+                variable.Options |= ScopedItemOptions.Private;
+            }
+            variable.Value = value;
+            affectedScope.SetLocalVariable(variable);
         }
 
-        // internals
-        //internal PSVariable GetAtScope(string name, string scope);
-        //internal object GetValueAtScope(string name, string scope);
-        //internal void RemoveAtScope(PSVariable variable, string scope);
-        //internal void RemoveAtScope(string name, string scope);
-        //internal void SetAtScope(PSVariable variable, string scope);
-        //internal void SetAtScope(string name, object value, string scope);
+        internal Dictionary<string, PSVariable> GetAll()
+        {
+            //get a copy of the vars in the local scope first. Note: it also copies the correct comperator
+            var visibleVars = new Dictionary<string, PSVariable> (sessionScope.LocalVariables);
+            //now check recursively the parent scopes for non-private, not overriden variables
+            for (var scope = sessionScope.ParentScope; scope != null; scope = scope.ParentScope)
+            {
+                foreach (var pair in scope.LocalVariables)
+                {
+                    if (!visibleVars.ContainsKey(pair.Key) && !pair.Value.IsPrivate)
+                    {
+                        visibleVars.Add(pair.Key, pair.Value);
+                    }
+                }
+            }
+            return visibleVars;
+        }
+
+        private SessionStateScope ResolveQualifiedScope(VariablePath path)
+        {
+            if (!path.IsVariable)
+            {
+                //TODO: what if this "variable" isn't actually a variable?
+                // -> then we have a drive set, instead of a scope. this means... what?
+                throw new NotImplementedException();
+            }
+            if (path.IsScript)
+            {
+                return sessionScope.GetScope(SessionStateScope.ScopeSpecifiers.Script);
+            }
+            else if (path.IsGlobal)
+            {
+                return sessionScope.GetScope(SessionStateScope.ScopeSpecifiers.Global);
+            }
+            else if (path.IsLocal)
+            {
+                return sessionScope;
+            }
+            return null; //no scope explicitly given!
+        }
+
+        private string UnqualifyVariableName(string name)
+        {
+            //return name after ":"
+            var parts = name.Split(':');
+            if (parts.Length < 2)
+            {
+                return name;
+            }
+            return parts[1];
+        }
+
+        private SessionStateScope FindHostingScope(string unqualifiedName)
+        {
+            //iterate through scopes and parents until we find the variable
+            for (var candidate = sessionScope; candidate != null; candidate = candidate.ParentScope)
+            {
+                var variable = candidate.GetLocalVariable(unqualifiedName);
+                if (variable == null)
+                {
+                    continue;
+                }
+                //make also sure the variable isn't private, if it's from a parent scope!
+                if((candidate == sessionScope) || !variable.IsPrivate)
+                {
+                    return candidate;
+                }
+            }
+            return null; //nothing found
+        }
     }
 }

--- a/Source/System.Management/Automation/Provider/CmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/CmdletProvider.cs
@@ -36,7 +36,7 @@ namespace System.Management.Automation.Provider
         {
             get
             {
-                return new SessionState(this.ProviderRuntime.ExecutionContext.SessionState);
+                return this.ProviderRuntime.ExecutionContext.SessionState;
             }
         }
 

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -19,6 +19,7 @@ namespace System.Management.Automation
         {
             get
             {
+                //TODO: only get the ones of the global scope to match PS 2.0 behavior
                 return _sessionState.Drive.GetAllForProvider(FullName);
             }
         }

--- a/Source/System.Management/Automation/Runspaces/SessionStateProxy.cs
+++ b/Source/System.Management/Automation/Runspaces/SessionStateProxy.cs
@@ -17,7 +17,7 @@ namespace System.Management.Automation.Runspaces
             if (string.IsNullOrEmpty(name))
                 throw new NullReferenceException("Variable name can't be empty.");
 
-            return _runspace.GetVariable(name);
+            return _runspace.ExecutionContext.SessionState.PSVariable.Get(name);
         }
 
         public void SetVariable(string name, object value)
@@ -25,7 +25,7 @@ namespace System.Management.Automation.Runspaces
             if (string.IsNullOrEmpty(name))
                 throw new NullReferenceException("Variable name can't be empty.");
 
-            _runspace.SetVariable(name, value);
+            _runspace.ExecutionContext.SessionState.PSVariable.Set(name, value);
         }
     }
 }

--- a/Source/System.Management/Automation/SessionState.cs
+++ b/Source/System.Management/Automation/SessionState.cs
@@ -7,31 +7,43 @@ namespace System.Management.Automation
     public sealed class SessionState
     {
         internal SessionStateGlobal SessionStateGlobal { get; private set; }
+        internal SessionStateScope SessionStateScope { get; private set; }
 
         public DriveManagementIntrinsics Drive { get; private set; }
         public PathIntrinsics Path { get; private set; }
         public CmdletProviderManagementIntrinsics Provider { get; private set; }
         public PSVariableIntrinsics PSVariable { get; private set; }
 
-        // internal
-        internal SessionState(SessionStateGlobal sessionState)
+        // creates a session state with a new (glovbal) scope
+        internal SessionState(SessionStateGlobal sessionStateGlobal)
+               : this(sessionStateGlobal, null)
         {
-            SessionStateGlobal = sessionState;
-            Drive = new DriveManagementIntrinsics(sessionState);
-            Path = new PathIntrinsics(sessionState);
-            Provider = new CmdletProviderManagementIntrinsics(sessionState);
-            PSVariable = new PSVariableIntrinsics(sessionState);
+            defaultInit();
         }
 
-        internal SessionState(SessionState sessionState)
+        // creates a new scope and sets the parent session state's scope as predecessor        
+        internal SessionState(SessionState parentSession)
+               : this(parentSession.SessionStateGlobal, parentSession.SessionStateScope)
         {
-            SessionStateGlobal = sessionState.SessionStateGlobal;
-            Drive = sessionState.Drive;
-            Path = sessionState.Path;
-            Provider = sessionState.Provider;
-            PSVariable = sessionState.PSVariable;
         }
 
-        //internal SessionStateInternal Internal { get; };
+        //actual constructor work, but hidden to not be used accidently in a stupid way
+        private SessionState(SessionStateGlobal sessionStateGlobal, SessionStateScope parent) {
+            SessionStateGlobal = sessionStateGlobal;
+            SessionStateScope = (parent == null) ? new SessionStateScope(sessionStateGlobal) :
+                                                   new SessionStateScope(parent);
+            Drive = new DriveManagementIntrinsics(SessionStateScope);
+            Path = new PathIntrinsics(SessionStateGlobal);
+            Provider = new CmdletProviderManagementIntrinsics(SessionStateGlobal);
+            PSVariable = new PSVariableIntrinsics(SessionStateScope);
+        }
+
+
+        private void defaultInit()
+        {
+            PSVariable.Set("true", true);
+            PSVariable.Set("false", false);
+            PSVariable.Set("null", null);
+        }
     }
 }

--- a/Source/System.Management/Automation/SessionStateUnauthorizedAccessException.cs
+++ b/Source/System.Management/Automation/SessionStateUnauthorizedAccessException.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace System.Management.Automation
+{
+    public class SessionStateUnauthorizedAccessException : SessionStateException
+    {
+        public SessionStateUnauthorizedAccessException()
+            : base() { }
+
+        public SessionStateUnauthorizedAccessException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        public SessionStateUnauthorizedAccessException(string message)
+            : base(message) { }
+
+        public SessionStateUnauthorizedAccessException(string message, Exception innerException)
+            : base() { }
+    }
+}
+

--- a/Source/System.Management/Microsoft.PowerShell/Commands/VariableProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/VariableProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.Commands
             if (string.Equals("variable:" + name.CorrectSlash, name, StringComparison.CurrentCultureIgnoreCase))
                 return true;
 
-            return SessionState.SessionStateGlobal.GetVariable(name);
+            return SessionState.PSVariable.Get(name);
         }
 
         internal override bool CanRenameItem(object item)
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal override IDictionary GetSessionStateTable()
         {
-            return (IDictionary)SessionState.SessionStateGlobal.GetVariables();
+            return (IDictionary)SessionState.PSVariable.GetAll();
         }
 
         internal override void SetSessionStateItem(Path name, object value, bool writeItem)
@@ -74,7 +74,8 @@ namespace Microsoft.PowerShell.Commands
                 variable = new PSVariable(name, null);
             }
             // TODO: can be Force'ed
-            PSVariable item = base.SessionState.SessionStateGlobal.SetVariable(variable) as PSVariable;
+            SessionState.PSVariable.Set(variable);
+            PSVariable item = SessionState.PSVariable.Get(variable.Name);
             if (writeItem && (item != null))
             {
                 WriteItemObject(item, item.Name, false);
@@ -84,7 +85,7 @@ namespace Microsoft.PowerShell.Commands
         internal override void RemoveSessionStateItem(Path name)
         {
             // TODO: can be Force'ed
-            SessionState.SessionStateGlobal.RemoveVariable(name);
+            SessionState.PSVariable.Remove(name);
         }
 
         protected override void GetItem(Path name)

--- a/Source/System.Management/Pash/Implementation/ExecutionContext.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionContext.cs
@@ -16,20 +16,13 @@ namespace Pash.Implementation
         internal Runspace CurrentRunspace { get; set; }
         internal Stack<Pipeline> _pipelineStack;
         internal PSHost LocalHost { get; set; }
-        internal Dictionary<string, PSVariable> _variables;
         internal SessionState SessionState { get; private set; }
-        internal static SessionStateGlobal _sessionStateGlobal;
+        internal SessionStateGlobal SessionStateGlobal { get; private set; }
 
         private ExecutionContext()
         {
-            // TODO: create a "Global Session state"
-            if (_sessionStateGlobal == null)
-                _sessionStateGlobal = new SessionStateGlobal(this);
-
             // TODO: initialize all the default settings
             _pipelineStack = new Stack<Pipeline>();
-            _variables = new Dictionary<string, PSVariable>(StringComparer.CurrentCultureIgnoreCase);
-            SessionState = new SessionState(_sessionStateGlobal);
         }
 
         public ExecutionContext(PSHost host, RunspaceConfiguration config)
@@ -37,10 +30,13 @@ namespace Pash.Implementation
         {
             RunspaceConfiguration = config;
             LocalHost = host;
+            SessionStateGlobal = new SessionStateGlobal(this);
+            SessionState = new SessionState(SessionStateGlobal);
         }
 
-        public ExecutionContext Clone()
+        public ExecutionContext Clone(bool newScope = false)
         {
+            var sstate = newScope ? new SessionState(SessionState) : SessionState;
             var context = new ExecutionContext
             {
                 inputStreamReader = inputStreamReader,
@@ -48,7 +44,9 @@ namespace Pash.Implementation
                 errorStreamWriter = errorStreamWriter,
                 CurrentRunspace = CurrentRunspace,
                 LocalHost = LocalHost,
-                WriteSideEffectsToPipeline = WriteSideEffectsToPipeline
+                WriteSideEffectsToPipeline = WriteSideEffectsToPipeline,
+                SessionStateGlobal = SessionStateGlobal,
+                SessionState = sstate
             };
 
             // TODO: copy (not reference) all the variables to allow nested context

--- a/Source/System.Management/Pash/Implementation/SessionStateScope.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateScope.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Management.Automation;
+using System.Linq;
+
+namespace Pash.Implementation
+{
+    internal class SessionStateScope
+    {
+        public enum ScopeSpecifiers {
+            Global,
+            Local,
+            Script,
+            Private
+        };
+
+        internal Dictionary<string, AliasInfo> LocalAliases { get; private set; }
+        internal Dictionary<string, CommandInfo> LocalFunctions { get; private set; }
+        internal Dictionary<string, PSVariable> LocalVariables { get; private set; }
+        internal Dictionary<string, PSDriveInfo> LocalDrives { get; private set; }
+
+        public SessionStateScope ParentScope { get; private set; }
+        public SessionStateGlobal SessionStateGlobal { get; private set; }
+        public bool IsScriptScope { get; set; }
+
+        public SessionStateScope(SessionStateGlobal sessionStateGlobal) : this(null, sessionStateGlobal) {}
+
+        public SessionStateScope(SessionStateScope parentScope) : this(parentScope, parentScope.SessionStateGlobal) {}
+
+
+        private SessionStateScope(SessionStateScope parentScope, SessionStateGlobal sessionStateGlobal)
+        {
+            LocalAliases = new Dictionary<string, AliasInfo>(StringComparer.CurrentCultureIgnoreCase);
+            LocalFunctions = new Dictionary<string, CommandInfo>(StringComparer.CurrentCultureIgnoreCase);
+            LocalVariables = new Dictionary<string, PSVariable>(StringComparer.CurrentCultureIgnoreCase);
+            LocalDrives = new Dictionary<string, PSDriveInfo>(StringComparer.CurrentCultureIgnoreCase);
+            SessionStateGlobal = sessionStateGlobal;
+            IsScriptScope = false;
+            ParentScope = parentScope;
+            //TODO: care about AllScope items!
+            //Just setting the parent scope is a little too easy. We have to copy all AllScope members to this scope!
+        }
+
+        internal SessionStateScope GetScope(string specifier, bool numberAllowed = true)
+        {
+            int scopeLevel = -1;
+            SessionStateScope candidate = this;
+            //check if the specifier is a number before trying to interprete it as enum
+            if (int.TryParse(specifier, out scopeLevel))
+            {
+                //sometimes a number specifies the relative scope location, but in some contexts this isn't allowed
+                //this has to happen *after* trying to parse them as e.g. "0" would be a parsable enum value!
+                if (!numberAllowed || scopeLevel < 0)
+                {
+                    throw new ArgumentException("Invalid scope specifier");
+                }
+                while (scopeLevel > 0)
+                {
+                    //make sure we can proceed looking for the next scope
+                    if (candidate.ParentScope == null)
+                    {
+                        throw new ArgumentOutOfRangeException("Exceeded the maximum number of available scopes");
+                    }
+                    candidate = candidate.ParentScope;
+                    scopeLevel--;
+                }
+                return candidate;
+            }
+            //it's not a (positive) number, let's check if it's a named scope
+            ScopeSpecifiers scopeSpecifier;
+            if (!ScopeSpecifiers.TryParse(specifier, true, out scopeSpecifier))
+            {
+                throw new ArgumentException("Invalid scope specifier");
+            }
+            return GetScope(scopeSpecifier);
+        }
+
+        internal SessionStateScope GetScope(ScopeSpecifiers specifier)
+        {
+            //if the local scope is meant, return this instance itself
+            if (specifier == ScopeSpecifiers.Local || specifier == ScopeSpecifiers.Private)
+            {
+                return this;
+            }
+            var candidate = this;
+            //otherwise it's a global or script scope specifier
+            if (specifier == ScopeSpecifiers.Global || specifier == ScopeSpecifiers.Script)
+            {
+                while (candidate.ParentScope != null)
+                {
+                    if (candidate.IsScriptScope && specifier == ScopeSpecifiers.Script)
+                    {
+                        return candidate;
+                    }
+                    candidate = candidate.ParentScope;
+                }
+                //found the scope without a parent: the global scope
+                return candidate;
+            }
+            throw new ArgumentException(String.Format("Invalid scope specifier \"{0}\"", specifier));
+        }
+
+        #region drive access
+        internal PSDriveInfo GetLocalDrive(string driveName)
+        {
+            if (LocalDrives.ContainsKey(driveName))
+            {
+                return LocalDrives[driveName];
+            }
+            return null;
+        }
+
+        internal bool AddLocalDrive(PSDriveInfo drive)
+        {
+            if (LocalDrives.ContainsKey(drive.Name))
+            {
+                return false;
+            }
+            LocalDrives.Add(drive.Name, drive);
+            return true;
+        }
+
+        internal bool RemoveLocalDrive(string driveName, bool force)
+        {
+            /* TODO: force is used to remove the drive "although it's in use by the provider"
+             * So, we need to find out when a drive is in use and should throw an exception on removal without
+             * the "force" parameter being true
+             */
+            return LocalDrives.Remove(driveName);
+        }
+        #endregion
+
+        #region variable access
+        internal PSVariable GetLocalVariable(string unqualifiedName)
+        {
+            if (LocalVariables.ContainsKey(unqualifiedName))
+            {
+                return (PSVariable) LocalVariables[unqualifiedName];
+            }
+            return null;
+        }
+
+        internal void RemoveLocalVariable(string name)
+        {
+            LocalVariables.Remove(name);
+        }
+
+        internal void SetLocalVariable(PSVariable variable)
+        {
+            RemoveLocalVariable(variable.Name);
+            LocalVariables.Add(variable.Name, variable);
+        }
+        #endregion
+    }
+}
+

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -17,9 +17,9 @@
     <UpgradeBackupLocation />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>True</Optimize>
+    <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -461,6 +461,8 @@
     <Compile Include="Pash\Path.cs" />
     <Compile Include="Pash\PathNavigation.cs" />
     <Compile Include="Pash\Implementation\ApplicationProcessor.cs" />
+    <Compile Include="Pash\Implementation\SessionStateScope.cs" />
+    <Compile Include="Automation\SessionStateUnauthorizedAccessException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/TestHost/LocalHostUserInterfaceTests.cs
+++ b/Source/TestHost/LocalHostUserInterfaceTests.cs
@@ -42,7 +42,7 @@ namespace TestHost
             Console.SetOut(originalOut);
         }
 
-        [Test]
+        [Test,Explicit("Currently Nunit ignores the redirection of stdin when running from commandline, so the testing doesn't work")]
         public void TestReadLine()
         {
             SetInput("foobar" + Environment.NewLine);

--- a/Source/TestHost/SessionStateScopeTests.cs
+++ b/Source/TestHost/SessionStateScopeTests.cs
@@ -1,0 +1,334 @@
+using System;
+using NUnit.Framework;
+using Pash.Implementation;
+using System.Management.Automation.Runspaces;
+using System.Management.Automation;
+using System.Collections.Generic;
+
+namespace TestHost
+{
+    [TestFixture]
+    public class SessionStateScopeTests
+    {
+        public enum AvailableStates
+        {
+            Global,
+            Script,
+            Function,
+            Local
+        };
+
+        private SessionState globalState;
+        private SessionState scriptState;
+        private SessionState functionState;
+        private SessionState localState;
+        private Dictionary<AvailableStates, SessionState> states;
+
+        [SetUp]
+        public void createScopes()
+        {
+            TestHost testHost = new TestHost(new TestHostUserInterface());
+            Runspace hostRunspace = TestHost.CreateRunspace(testHost);
+
+            globalState = hostRunspace.ExecutionContext.SessionState;
+            scriptState = new SessionState(globalState);
+            scriptState.SessionStateScope.IsScriptScope = true;
+            functionState = new SessionState(scriptState);
+            localState = new SessionState(functionState);
+            states = new Dictionary<AvailableStates, SessionState>();
+            states.Add(AvailableStates.Global, globalState);
+            states.Add(AvailableStates.Script, scriptState);
+            states.Add(AvailableStates.Function, functionState);
+            states.Add(AvailableStates.Local, localState);
+        }
+
+        [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
+        [TestCase("-1", null, ExpectedException=typeof(ArgumentException))]
+        [TestCase("foo", null, ExpectedException=typeof(ArgumentException))]
+        [TestCase("3", AvailableStates.Global)]
+        [TestCase("global", AvailableStates.Global)]
+        [TestCase("2", AvailableStates.Script)]
+        [TestCase("script", AvailableStates.Script)]
+        [TestCase("1", AvailableStates.Function)]
+        [TestCase("0", AvailableStates.Local)]
+        [TestCase("local", AvailableStates.Local)]
+        public void GetScopeTest(string specifier, AvailableStates sessionState)
+        {
+            Assert.AreEqual(localState.SessionStateScope.GetScope(specifier), states[sessionState].SessionStateScope);
+        }
+
+        [TestCase("x", "f")] //correct x is fetched in general (from function scope)
+        [TestCase("local:x", null)] //local scope has no variable x
+        [TestCase("script:x", null)] //sx is private in the script scope
+        [TestCase("global:x", "g")]
+        [TestCase("y", "l")] //the overridden y in the local scope
+        [TestCase("local:y", "l")] //also the local one, but explicitly
+        [TestCase("script:y", "s")]
+        [TestCase("global:y", "g")]
+        [TestCase("z", "s")] //ignores the private z in function scope
+        public void VariableAccessTest(string name, object expected)
+        {
+            globalState.PSVariable.Set(new PSVariable("x", "g"));
+            globalState.PSVariable.Set(new PSVariable("y", "g"));
+            scriptState.PSVariable.Set(new PSVariable("x", "s", ScopedItemOptions.Private));
+            scriptState.PSVariable.Set(new PSVariable("y", "s"));
+            scriptState.PSVariable.Set(new PSVariable("z", "s"));
+            functionState.PSVariable.Set(new PSVariable("x", "f"));
+            functionState.PSVariable.Set(new PSVariable("y", "f"));
+            functionState.PSVariable.Set(new PSVariable("z", "f", ScopedItemOptions.Private));
+            localState.PSVariable.Set(new PSVariable("y", "l"));
+            Assert.AreEqual(expected, localState.PSVariable.GetValue(name));
+        }
+
+        [TestCase(AvailableStates.Global, "g", true)]
+        [TestCase(AvailableStates.Script, "s", true)]
+        [TestCase(AvailableStates.Function, "f", true)]
+        [TestCase(AvailableStates.Local, "l", true)]
+        [TestCase(AvailableStates.Local, "s", false)] //makes sure private setting works
+        public void VariableSetTest(AvailableStates sessionState, object value, bool initLocal=true)
+        {
+            functionState.PSVariable.Set("private:x", "f");
+            localState.PSVariable.Set("global:x", "g");
+            localState.PSVariable.Set("script:x", "s");
+            if (initLocal)
+            {
+                localState.PSVariable.Set ("local:x", "l");
+            }
+            Assert.AreEqual(value, states[sessionState].PSVariable.GetValue("x"));
+        }
+
+        [Test]
+        public void VariableNoPrivacyChangeTest()
+        {
+            globalState.PSVariable.Set("private:y", "py0");
+            globalState.PSVariable.Set("y", "py1");
+            globalState.PSVariable.Set("x", "x0");
+            globalState.PSVariable.Set("private:x", "x1");
+            Assert.IsNull(scriptState.PSVariable.GetValue("y"));
+            Assert.AreEqual("x1", scriptState.PSVariable.GetValue("x"));
+        }
+
+        [TestCase("global:x", AvailableStates.Global, true)]
+        [TestCase("script:x", AvailableStates.Script, true)]
+        [TestCase("local:x", AvailableStates.Local, true)]
+        [TestCase("x", AvailableStates.Function, false)] //looks in parent scopes and removes the variable
+        public void VariableRemoveTest(string variable, AvailableStates affectedState, bool initLocal)
+        {
+            globalState.PSVariable.Set("x", "g");
+            scriptState.PSVariable.Set("x", "s");
+            functionState.PSVariable.Set("x", "f");
+            if (initLocal)
+            {
+                localState.PSVariable.Set("x", "l");
+            }
+
+            localState.PSVariable.Remove(variable);
+            foreach (KeyValuePair<AvailableStates, SessionState> curState in states)
+            {
+                if (curState.Key == affectedState || (curState.Key == AvailableStates.Local && !initLocal))
+                {
+                    Assert.IsNull(curState.Value.PSVariable.Get("local:x"));
+                }
+                else
+                {
+                    Assert.IsNotNull(curState.Value.PSVariable.Get("local:x"));
+                }
+            }
+        }
+
+        [Test]
+        public void VariableRemoveByObjectTest()
+        {
+            globalState.PSVariable.Set("x", "g");
+            scriptState.PSVariable.Set("x", "s");
+            var variable = new PSVariable("x");
+            scriptState.PSVariable.Remove(variable);
+            Assert.IsNull(scriptState.PSVariable.Get("local:x"));
+            Assert.IsNotNull(globalState.PSVariable.Get("local:x"));
+            scriptState.PSVariable.Remove(variable); //doesn't affect parent scopes (different to passing the name)
+            Assert.IsNotNull(globalState.PSVariable.Get("local:x"));
+        }
+
+        [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
+        [TestCase("foo", null, ExpectedException=typeof(ArgumentException))]
+        [TestCase("3", AvailableStates.Global)]
+        [TestCase("global", AvailableStates.Global)]
+        [TestCase("2", AvailableStates.Script)]
+        [TestCase("script", AvailableStates.Script)]
+        [TestCase("1", AvailableStates.Function)]
+        [TestCase("0", AvailableStates.Local)]
+        [TestCase("local", AvailableStates.Local)]
+        public void DriveNewTest(string scope, AvailableStates affectedState)
+        {
+            PSDriveInfo info = createDrive("test");
+            localState.Drive.New (info, scope);
+            Assert.AreEqual(info, states[affectedState].Drive.Get(info.Name));
+        }
+
+        [Test]
+        public void DriveNewExistingTest ()
+        {
+            PSDriveInfo info = createDrive ("test");
+            globalState.Drive.New (info, "local");
+            scriptState.Drive.New (info, "local"); //overriding should work of course
+            try {
+                scriptState.Drive.New (info, "global"); //this shouldn't work, as the global scope has that drive
+                Assert.True (false);
+            } catch (MethodInvocationException) { }
+        }
+
+        [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
+        [TestCase("foo", null, ExpectedException=typeof(ArgumentException))]
+        [TestCase("3", AvailableStates.Global)]
+        [TestCase("global", AvailableStates.Global)]
+        [TestCase("2", AvailableStates.Script)]
+        [TestCase("script", AvailableStates.Script)]
+        [TestCase("1", AvailableStates.Function)]
+        [TestCase("0", AvailableStates.Local)]
+        [TestCase("local", AvailableStates.Local)]
+        public void DriveRemoveTest(string scope, AvailableStates affectedState)
+        {
+            Dictionary<AvailableStates, PSDriveInfo> driveInfos = new Dictionary<AvailableStates, PSDriveInfo>();
+            foreach (var curState in states)
+            {
+                var info = createDrive(curState.Key.ToString());
+                curState.Value.Drive.New(info, "local");
+                driveInfos[curState.Key] = info;
+            }
+            localState.Drive.Remove(driveInfos[affectedState].Name, true, scope);
+            foreach (var curState in states)
+            {
+                if (curState.Key == affectedState)
+                {
+                    Assert.AreEqual(0, curState.Value.Drive.GetAllAtScope("local").Count);
+                }
+                else
+                {
+                    Assert.AreEqual(driveInfos[curState.Key], curState.Value.Drive.Get(driveInfos[curState.Key].Name));
+                }
+            }
+        }
+
+        [Test]
+        public void DriveRemoveNotExistingTest ()
+        {
+            PSDriveInfo info = createDrive ("test");
+            try {
+                globalState.Drive.Remove (info.Name, true, "local");
+                Assert.True (false);
+            } catch (MethodInvocationException) { }
+        }
+
+        [Test]
+        public void DriveGetAllTest()
+        {
+            globalState.Drive.New(createDrive("override", "first"), "local");
+            globalState.Drive.New(createDrive("global"), "local");
+            scriptState.Drive.New(createDrive("script"), "local");
+            functionState.Drive.New(createDrive("override", "second"), "local");
+            var drives = localState.Drive.GetAll();
+            Assert.AreEqual(3, drives.Count);
+            bool found = false;
+            foreach (var curDrive in drives)
+            {
+                if (curDrive.Name.Equals("override"))
+                {
+                    if (found) //make sure it's only one time in there
+                    {
+                        Assert.True(false);
+                    }
+                    Assert.AreEqual("second", curDrive.Description);
+                    found = true;
+                }
+            }
+            Assert.True (found);
+        }
+
+        [TestCase("local", new string [] {})]
+        [TestCase("0", new string [] {})]
+        [TestCase("1", new string [] {"function"})]
+        [TestCase("script", new string [] {"script1", "script2"})]
+        [TestCase("2", new string [] {"script1", "script2"})]
+        [TestCase("global", new string [] {"global1", "global2"})]
+        [TestCase("3", new string [] {"global1", "global2"})]
+        [TestCase("4", new string [] {}, ExpectedException=typeof(ArgumentOutOfRangeException))]
+        public void DriveGetAllAtScopeTest(string scope, string[] expectedDescriptions)
+        {
+            globalState.Drive.New(createDrive("x", "global1"), "local");
+            globalState.Drive.New(createDrive("y", "global2"), "local");
+            scriptState.Drive.New(createDrive("x", "script1"), "local");
+            scriptState.Drive.New(createDrive("y", "script2"), "local");
+            functionState.Drive.New(createDrive("x", "function"), "local");
+            var drives = localState.Drive.GetAllAtScope(scope);
+            Assert.AreEqual(expectedDescriptions.Length, drives.Count);
+            foreach (var curDrive in drives)
+            {
+                Assert.Contains(curDrive.Description, expectedDescriptions);
+            }
+        }
+
+        [Test]
+        public void DriveGetTest()
+        {
+            globalState.Drive.New(createDrive("override", "first"), "local");
+            globalState.Drive.New(createDrive("global"), "local");
+            functionState.Drive.New(createDrive("override", "second"), "local");
+            var drive = localState.Drive.Get ("override");
+            Assert.AreEqual("override", drive.Name);
+            Assert.AreEqual("second", drive.Description);
+            Assert.AreEqual("global", localState.Drive.Get("global").Name);
+            try 
+            {
+                localState.Drive.Get("doesnt_exist");
+                Assert.True(false);
+            }
+            catch (MethodInvocationException) { }
+        }
+
+        [TestCase("local", "local")]
+        [TestCase("0", "local")]
+        [TestCase("1", "function")]
+        [TestCase("script", "script")]
+        [TestCase("2",  "script")]
+        [TestCase("global", "global")]
+        [TestCase("3", "global")]
+        [TestCase("4", "", ExpectedException=typeof(ArgumentOutOfRangeException))]
+        public void DriveGetAtScopeTest(string scope, string expectedDescription)
+        {
+            globalState.Drive.New(createDrive("x", "global"), "local");
+            scriptState.Drive.New(createDrive("x", "script"), "local");
+            functionState.Drive.New(createDrive("x", "function"), "local");
+            localState.Drive.New(createDrive("x", "local"), "local");
+            Assert.AreEqual(expectedDescription, localState.Drive.GetAtScope("x", scope).Description);
+        }
+
+        public void DriveGetAllForProviderTest ()
+        {
+            var provider = new ProviderInfo (null, null, "testProvider", "", null);
+            globalState.Drive.New (createDrive ("global", "", provider), "local");
+            scriptState.Drive.New (createDrive ("script", "", provider), "local");
+            functionState.Drive.New (createDrive ("function", "", provider), "local");
+            localState.Drive.New (createDrive ("local", "", provider), "local");
+            var drives = localState.Drive.GetAllForProvider ("testProvider");
+            Assert.AreEqual (4, drives.Count);
+            foreach (var curDrive in drives) {
+                Assert.Contains (curDrive.Name, new string[] {"global", "script", "function", "local"});
+            }
+            drives = scriptState.Drive.GetAllForProvider ("testProvider");
+            Assert.AreEqual (2, drives.Count);
+            foreach (var curDrive in drives) {
+                Assert.Contains (curDrive.Name, new string[] {"global", "script"});
+            }
+            try {
+                globalState.Drive.GetAllForProvider ("doesnt_exist");
+                Assert.True (false);
+            } catch (MethodInvocationException) { }
+        }
+
+        private PSDriveInfo createDrive(string name, string descr="", ProviderInfo provider=null)
+        {
+            return new PSDriveInfo(name, provider, String.Empty, descr, null);
+        }
+    }
+}
+

--- a/Source/TestHost/TestHost.cs
+++ b/Source/TestHost/TestHost.cs
@@ -66,7 +66,7 @@ namespace TestHost
             return ui.Log.ToString();
         }
 
-        private static Runspace CreateRunspace(PSHost host)
+        public static Runspace CreateRunspace(PSHost host)
         {
             if (InitialSessionState != null)
             {

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -98,6 +98,7 @@
     <Compile Include="FileSystemTests\FileSystemTestBaseTests.cs" />
     <Compile Include="FileSystemTests\FileSystemNavigationTests.cs" />
     <Compile Include="System.Management\PathNavigationTests.cs" />
+    <Compile Include="SessionStateScopeTests.cs" />  
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Management\Microsoft.Commands.Management.csproj">


### PR DESCRIPTION
Pash's architecture had no support for scopes. Instead, there was just
one global scope. These changes are the start of scope implementation.

While the "global scope" bahvior isn't changed, yet, the architecture
is changed to support scopes in regard to variables and drives.
The new class, SessionStateScope, is the new heart of a SessionState
and is intended to support nested scopes. The SessionStateGlobal class
is intended to care about the not-scope related things as providers.
An important change is that SessionStates aren't simple copy-objects
that are created every now and then, but only if it's really necessary.

There are further steps that need to be done to fully support scopes:
- While VariableIntrinsics and DriveManagementIntrinsics already implement
  the new scope behavior, the alias and function scope support still has
  to be added.
- Once this is completed, the creation of SessionStates has to be adjusted even
  more in order to correctly create new scopes.
- The existing cmdlets (new-variable, etc) need to be re-written to better
  support scopes, read-only flags, etc.
- There should be some refactoring of existing code. SessionState should
  be used as a central object to modify the sessions data.

Important: You don't need to merge this now, if you don't want to. However, I created this request such that you can take a look at my plans and the code to provide comments. So if you spotted anything or have questions, please feel free to comment. I will go on with implementing scope support for aliases and functions. After each of the proposed steps, I will update this merge request or create a new one, if this one was already merged then.
