### PR TITLE
Second step of scope integration: Functions, Aliases, Refacoring

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Utility/NewAliasCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/NewAliasCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.Commands
 
         // TODO:
         [Parameter]
-        public string Option { get; set; }
+        public ScopedItemOptions Option { get; set; }
 
         // TODO:
         [Parameter]
@@ -46,7 +46,8 @@ namespace Microsoft.PowerShell.Commands
 
         protected override void ProcessRecord()
         {
-            SessionState.SessionStateGlobal.NewAlias(this.Name, this.Value);
+            AliasInfo info = new AliasInfo(Name, Value, SessionState.SessionStateGlobal.CommandManager, Option);
+            SessionState.Alias.New(info, Scope);
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Utility/NewVariableCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/NewVariableCommand.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PowerShell.Commands
 
         protected override void ProcessRecord()
         {
-            // TODO: deal with scope
             // TODO: deal with Force
             // TODO: deal with ShouldProcess
 
@@ -40,9 +39,12 @@ namespace Microsoft.PowerShell.Commands
             {
                 variable.Description = Description;
             }
+            //TODO: check if variable already exists and check if force has influence on behavior
+            //implement also an overloaded Get method in PSVariableIntrniscs that allow to pass a scope
             try
             {
-                SessionState.SessionStateGlobal.NewVariable(variable, (bool)this.Force);
+                //TODO: create a new overloaded method in PSVariableIntrinsics that allows to pass (bool)this.Force
+                SessionState.PSVariable.Set(variable);
             }
             catch (Exception ex)
             {

--- a/Source/Microsoft.PowerShell.Commands.Utility/RemoveVariableCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/RemoveVariableCommand.cs
@@ -35,6 +35,8 @@ namespace Microsoft.PowerShell.Commands
 
                 try
                 {
+                    //TODO: implement a Remove method that takes force and scope!
+                    //standard is local scope, no search in the parent scopes!
                     SessionState.PSVariable.Remove(variable);
                 }
                 catch (Exception ex)

--- a/Source/Microsoft.PowerShell.Commands.Utility/SetAliasCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/SetAliasCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.Commands
 
         // TODO:
         [Parameter]
-        public string Option { get; set; }
+        public ScopedItemOptions Option { get; set; }
 
         // TODO:
         [Parameter]
@@ -46,16 +46,8 @@ namespace Microsoft.PowerShell.Commands
 
         protected override void ProcessRecord()
         {
-            try
-            {
-                SessionState.SessionStateGlobal.SetAlias(this.Name, this.Value);
-            }
-            catch// (Exception ex)
-            {
-                //TODO:
-                //WriteError(new ErrorRecord(ex, "", ErrorCategory.InvalidOperation, alias));
-                return;
-            }
+            AliasInfo info = new AliasInfo(Name, Value, SessionState.SessionStateGlobal.CommandManager, Option);
+            SessionState.Alias.Set(info, Scope);
         }
     }
 }

--- a/Source/System.Management/Automation/AliasInfo.cs
+++ b/Source/System.Management/Automation/AliasInfo.cs
@@ -9,7 +9,7 @@ namespace System.Management.Automation
     /// <summary>
     /// Contains information about a Pash Alias.
     /// </summary>
-    public class AliasInfo : CommandInfo
+    public class AliasInfo : CommandInfo, IScopedItem
     {
         private string _definition;
         public override string Definition { get { return _definition; } }
@@ -44,6 +44,22 @@ namespace System.Management.Automation
             ResolvedCommand = ReferencedCommand;
         }
         //internal void SetOptions(ScopedItemOptions newOptions, bool force);
+
+
+        #region IScopedItem Members
+
+        public string ItemName
+        {
+            get { return Name; }
+        }
+
+        public ScopedItemOptions ItemOptions
+        {
+            get { return Options; }
+            set { Options = value; }
+        }
+
+        #endregion
     }
 
 }

--- a/Source/System.Management/Automation/DriveNotFoundException.cs
+++ b/Source/System.Management/Automation/DriveNotFoundException.cs
@@ -28,6 +28,12 @@ namespace System.Management.Automation
             : base(info, context)
         {
         }
+
+        internal DriveNotFoundException(string itemName, string errorIdAndResourceId, params object[] messageArgs)
+            : base(itemName, SessionStateCategory.Drive, errorIdAndResourceId, ErrorCategory.ObjectNotFound, 
+                   messageArgs)
+        {
+        }
     }
 }
 

--- a/Source/System.Management/Automation/ErrorCategoryInfo.cs
+++ b/Source/System.Management/Automation/ErrorCategoryInfo.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Globalization;
 
 namespace System.Management.Automation
 {
@@ -21,10 +22,21 @@ namespace System.Management.Automation
         public string Reason { get; set; }
         public string TargetName { get; set; }
         public string TargetType { get; set; }
-        /*
-        public string GetMessage();
-        public string GetMessage(CultureInfo uiCultureInfo);
-        public override string ToString();
-        */
+
+        public string GetMessage()
+        {
+            //TODO: fix this
+            return ToString();
+        }
+
+        public string GetMessage(CultureInfo uiCultureInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0}, Reason: {1}", Category, Reason);
+        }
     }
 }

--- a/Source/System.Management/Automation/FunctionInfo.cs
+++ b/Source/System.Management/Automation/FunctionInfo.cs
@@ -2,17 +2,30 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Pash.Implementation;
 
 namespace System.Management.Automation
 {
-    public class FunctionInfo : CommandInfo
+    public class FunctionInfo : CommandInfo, IScopedItem
     {
         public override string Definition { get { return Name; } }
         public ScopedItemOptions Options { get; set; }
         public ScriptBlock ScriptBlock { get; private set; }
+        public string Noun { get; private set; }
+        public string Verb { get; private set; }
+        public string Description { get; set; }
 
         internal FunctionInfo(string name, ScriptBlock function)
             : this(name, function, ScopedItemOptions.None) { }
+
+        internal FunctionInfo(string verb, string noun, ScriptBlock function, ScopedItemOptions options)
+            : base(verb + "-" + noun, CommandTypes.Function)
+        {
+            ScriptBlock = function;
+            Options = options;
+            Verb = verb;
+            Noun = noun;
+        }
 
         internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options)
             : base(name, CommandTypes.Function)
@@ -21,6 +34,21 @@ namespace System.Management.Automation
             Options = options;
         }
 
+
+        #region IScopedItem Members
+
+        public string ItemName
+        {
+            get { return Name; }
+        }
+
+        public ScopedItemOptions ItemOptions
+        {
+            get { return Options; }
+            set { Options = value; }
+        }
+
+        #endregion
         // internals
         //internal void SetScriptBlock(ScriptBlock function, bool force);
     }

--- a/Source/System.Management/Automation/ItemNotFoundException.cs
+++ b/Source/System.Management/Automation/ItemNotFoundException.cs
@@ -25,5 +25,11 @@ namespace System.Management.Automation
             : base(message, innerException)
         {
         }
+
+        internal ItemNotFoundException(string itemName, SessionStateCategory sessionStateCategory, 
+                                       string errorIdAndResourceId, params object[] messageArgs)
+            : base(itemName, sessionStateCategory, errorIdAndResourceId, ErrorCategory.ObjectNotFound, messageArgs)
+        {
+        }
     }
 }

--- a/Source/System.Management/Automation/PSDriveInfo.cs
+++ b/Source/System.Management/Automation/PSDriveInfo.cs
@@ -3,10 +3,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using Pash.Implementation;
 
 namespace System.Management.Automation
 {
-    public class PSDriveInfo : IComparable
+    public class PSDriveInfo : IComparable, IScopedItem
     {
         // TODO: drive can be hidden
         public string Name { get; private set; }
@@ -131,6 +132,21 @@ namespace System.Management.Automation
                 return CompareTo(obj as PSDriveInfo);
 
             throw new InvalidOperationException("Can compare only to PSDriveInfo");
+        }
+
+        #endregion
+
+        #region IScopedItem Members
+
+        public string ItemName
+        {
+            get { return Name; }
+        }
+
+        public ScopedItemOptions ItemOptions
+        {
+            get { return ScopedItemOptions.None; }
+            set { /* nothing happens */ }
         }
 
         #endregion

--- a/Source/System.Management/Automation/PSVariable.cs
+++ b/Source/System.Management/Automation/PSVariable.cs
@@ -2,10 +2,11 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Text;
+using Pash.Implementation;
 
 namespace System.Management.Automation
 {
-    public class PSVariable
+    public class PSVariable : IScopedItem
     {
         public string Name { get; private set; }
         public virtual string Description { get; set; }
@@ -56,21 +57,6 @@ namespace System.Management.Automation
             throw new NotImplementedException();
         }
 
-        // internals
-        //internal static bool IsValidValue(object value, System.Attribute attribute);
-        //internal PSVariable(string name, object value, System.Management.Automation.ScopedItemOptions options, System.Collections.ObjectModel.Collection<Attribute> attributes, string description);
-        //internal PSVariable(string name, object value, System.Management.Automation.ScopedItemOptions options, string description);
-        //internal void SetOptions(System.Management.Automation.ScopedItemOptions newOptions, bool force);
-        //internal void SetValueRaw(object newValue, bool preserveValueTypeSemantics);
-        //internal object TransformValue(object value);
-        //internal bool IsAllScope { get; }
-        //internal bool IsConstant { get; }
-        internal bool IsPrivate { 
-            get { return Options.HasFlag(ScopedItemOptions.Private); } 
-        }
-        //internal bool IsReadOnly { get; }
-        //internal bool WasRemoved { set; get; }
-
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
@@ -92,5 +78,22 @@ namespace System.Management.Automation
 
             return Value;
         }
+
+    
+        #region IScopedItem Members
+
+        public string ItemName
+        {
+            get { return Name; }
+        }
+
+        public ScopedItemOptions ItemOptions
+        {
+            get { return Options; }
+            set { Options = value; }
+        }
+
+        #endregion
+
     }
 }

--- a/Source/System.Management/Automation/PSVariableIntrinsics.cs
+++ b/Source/System.Management/Automation/PSVariableIntrinsics.cs
@@ -7,38 +7,18 @@ namespace System.Management.Automation
 {
     public sealed class PSVariableIntrinsics
     {
-        private SessionStateScope sessionScope;
+        private SessionState _sessionState;
+        private SessionStateScope<PSVariable> _scope;
 
-        internal PSVariableIntrinsics(SessionStateScope scope)
+        internal PSVariableIntrinsics(SessionState sessionState, SessionStateScope<PSVariable> variableScope)
         {
-            sessionScope = scope;
+            _sessionState = sessionState;
+            _scope = variableScope;
         }
 
         public PSVariable Get(string name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("The variable name is null.");
-            }
-            var path = new VariablePath(name);
-            var unqualifiedName = path.IsUnqualified ? name : UnqualifyVariableName(name);
-            var qualifiedScope = ResolveQualifiedScope(path);
-            if (qualifiedScope != null)
-            {
-                var variable = qualifiedScope.GetLocalVariable(unqualifiedName);
-                //return null if it's private
-                if (qualifiedScope != sessionScope && variable.IsPrivate)
-                {
-                    return null;
-                }
-                return variable;
-            }
-            var hostingScope = FindHostingScope(unqualifiedName);
-            if (hostingScope != null)
-            {
-                return hostingScope.GetLocalVariable(unqualifiedName);
-            }
-            return null;
+            return _scope.Get(name, true);
         }
 
         public object GetValue(string name)
@@ -63,30 +43,9 @@ namespace System.Management.Automation
             Remove("local:" + variable.Name);
         }
 
-        public void Remove (string name)
+        public void Remove(string name)
         {
-            if (name == null) {
-                throw new ArgumentNullException("The variable name is null.");
-            }
-            //difference to get: we don't lookup the variable in parent scopes to remove it.
-            var path = new VariablePath(name);
-            var unqualifiedName = path.IsUnqualified ? name : UnqualifyVariableName(name);
-            var affectedScope = ResolveQualifiedScope(path) ?? FindHostingScope(unqualifiedName);
-            if (affectedScope == null)
-            {
-                return; //not found
-            }
-            var variable = affectedScope.GetLocalVariable(unqualifiedName);
-    
-            if (variable == null) //not in the affected scope
-            {
-                return;
-            }
-            if (variable.Options.HasFlag(ScopedItemOptions.Constant))
-            {
-                throw new SessionStateUnauthorizedAccessException("The variable is a constant and cannot be removed.");
-            }
-            affectedScope.RemoveLocalVariable(unqualifiedName);
+            _scope.Remove(name, true);
         }
 
         public void Set(PSVariable variable)
@@ -95,113 +54,28 @@ namespace System.Management.Automation
             {
                 throw new ArgumentNullException("The variable is null.");
             }
-            var original = sessionScope.GetLocalVariable(variable.Name);
+            var original = _scope.GetLocal(variable.Name);
             if (original == null)
             {
-                sessionScope.SetLocalVariable(variable);
+                _scope.SetLocal(variable, true);
                 return;
-            }
-            if (original.Options.HasFlag(ScopedItemOptions.ReadOnly | ScopedItemOptions.Constant))
-            {
-                throw new SessionStateUnauthorizedAccessException("The variable is read-only or a constant.");
             }
             original.Value = variable.Value;
             original.Description = variable.Description;
             original.Options = variable.Options;
-            sessionScope.SetLocalVariable(original);
+            _scope.SetLocal(original, true);
         }
 
         public void Set(string name, object value)
         {
-            if (name == null) {
-                throw new ArgumentNullException("The variable name is null.");
-            }
-            var path = new VariablePath(name);
-            var unqualifiedName = path.IsUnqualified ? name : UnqualifyVariableName (name);
-            var affectedScope = ResolveQualifiedScope(path) ?? sessionScope;
-            var original = affectedScope.GetLocalVariable(unqualifiedName);
-            var variable = original ?? new PSVariable(unqualifiedName);
-            if (variable.Options.HasFlag(ScopedItemOptions.ReadOnly | ScopedItemOptions.Constant))
-            {
-                throw new SessionStateUnauthorizedAccessException("The variable is read-only or a constant.");
-            }
-            if (path.IsPrivate && original == null) //only set private flag if this variable is new
-            {
-                variable.Options |= ScopedItemOptions.Private;
-            }
-            variable.Value = value;
-            affectedScope.SetLocalVariable(variable);
+            var qualName = new SessionStateScope<PSVariable>.QualifiedName(name);
+            _scope.Set(name, new PSVariable(qualName.UnqualifiedName, value), true, true);
         }
 
         internal Dictionary<string, PSVariable> GetAll()
         {
-            //get a copy of the vars in the local scope first. Note: it also copies the correct comperator
-            var visibleVars = new Dictionary<string, PSVariable> (sessionScope.LocalVariables);
-            //now check recursively the parent scopes for non-private, not overriden variables
-            for (var scope = sessionScope.ParentScope; scope != null; scope = scope.ParentScope)
-            {
-                foreach (var pair in scope.LocalVariables)
-                {
-                    if (!visibleVars.ContainsKey(pair.Key) && !pair.Value.IsPrivate)
-                    {
-                        visibleVars.Add(pair.Key, pair.Value);
-                    }
-                }
-            }
-            return visibleVars;
+            return _scope.GetAll();
         }
 
-        private SessionStateScope ResolveQualifiedScope(VariablePath path)
-        {
-            if (!path.IsVariable)
-            {
-                //TODO: what if this "variable" isn't actually a variable?
-                // -> then we have a drive set, instead of a scope. this means... what?
-                throw new NotImplementedException();
-            }
-            if (path.IsScript)
-            {
-                return sessionScope.GetScope(SessionStateScope.ScopeSpecifiers.Script);
-            }
-            else if (path.IsGlobal)
-            {
-                return sessionScope.GetScope(SessionStateScope.ScopeSpecifiers.Global);
-            }
-            else if (path.IsLocal)
-            {
-                return sessionScope;
-            }
-            return null; //no scope explicitly given!
-        }
-
-        private string UnqualifyVariableName(string name)
-        {
-            //return name after ":"
-            var parts = name.Split(':');
-            if (parts.Length < 2)
-            {
-                return name;
-            }
-            return parts[1];
-        }
-
-        private SessionStateScope FindHostingScope(string unqualifiedName)
-        {
-            //iterate through scopes and parents until we find the variable
-            for (var candidate = sessionScope; candidate != null; candidate = candidate.ParentScope)
-            {
-                var variable = candidate.GetLocalVariable(unqualifiedName);
-                if (variable == null)
-                {
-                    continue;
-                }
-                //make also sure the variable isn't private, if it's from a parent scope!
-                if((candidate == sessionScope) || !variable.IsPrivate)
-                {
-                    return candidate;
-                }
-            }
-            return null; //nothing found
-        }
     }
 }

--- a/Source/System.Management/Automation/SessionStateException.cs
+++ b/Source/System.Management/Automation/SessionStateException.cs
@@ -7,14 +7,37 @@ namespace System.Management.Automation
     [Serializable]
     public class SessionStateException : RuntimeException
     {
-        public SessionStateException() { throw new NotImplementedException(); }
-        public SessionStateException(string message) { throw new NotImplementedException(); }
-        protected SessionStateException(SerializationInfo info, StreamingContext context) { throw new NotImplementedException(); }
-        public SessionStateException(string message, Exception innerException) { throw new NotImplementedException(); }
-        internal SessionStateException(string itemName, SessionStateCategory sessionStateCategory, string errorIdAndResourceId, ErrorCategory errorCategory, params object[] messageArgs)
-        { throw new NotImplementedException(); }
-        private static string BuildMessage(string itemName, string resourceId, params object[] messageArgs)
-        { throw new NotImplementedException(); }
+        public string ItemName { get; private set; }
+        public SessionStateCategory SessionStateCategory { get; private set; }
+        public override ErrorRecord ErrorRecord { get; set; }
+
+        public SessionStateException() : base()
+        {
+        }
+
+        public SessionStateException(string message) : base(message)
+        {
+        }
+
+        protected SessionStateException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public SessionStateException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        internal SessionStateException(string itemName, SessionStateCategory sessionStateCategory, 
+                                       string errorIdAndResourceId, ErrorCategory errorCategory,
+                                       params object[] messageArgs)
+            : base(String.Format("The {0} \"{1}\" ({2}) caused the following error: {3}",
+                                 new object[] {sessionStateCategory.ToString(), itemName, errorIdAndResourceId, 
+                                               errorCategory.ToString()}))
+        {
+            //TODO: make this better
+            SessionStateCategory = sessionStateCategory;
+            ErrorRecord = new ErrorRecord(this, errorIdAndResourceId, errorCategory, null);
+        }
 
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -22,9 +45,6 @@ namespace System.Management.Automation
             throw new NotImplementedException();
         }
 
-        public override ErrorRecord ErrorRecord { get { throw new NotImplementedException(); } }
-        public string ItemName { get { throw new NotImplementedException(); } }
-        public SessionStateCategory SessionStateCategory { get { throw new NotImplementedException(); } }
     }
 
 }

--- a/Source/System.Management/Automation/SessionStateUnauthorizedAccessException.cs
+++ b/Source/System.Management/Automation/SessionStateUnauthorizedAccessException.cs
@@ -16,6 +16,12 @@ namespace System.Management.Automation
 
         public SessionStateUnauthorizedAccessException(string message, Exception innerException)
             : base() { }
+
+        internal SessionStateUnauthorizedAccessException(string itemName, SessionStateCategory sessionStateCategory, 
+                                                         string errorIdAndResourceId, params object[] messageArgs)
+            : base(itemName, sessionStateCategory, errorIdAndResourceId, ErrorCategory.WriteError, messageArgs)
+        {
+        }
     }
 }
 

--- a/Source/System.Management/Microsoft.PowerShell/Commands/AliasProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/AliasProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal override System.Collections.IDictionary GetSessionStateTable()
         {
-            throw new NotImplementedException();
+            return SessionState.Alias.GetAll();
         }
 
         internal override object GetValueOfItem(object item)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/FunctionProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FunctionProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal override IDictionary GetSessionStateTable()
         {
-            return SessionState.SessionStateGlobal.GetFunctions();
+            return SessionState.Function.GetAll();
         }
 
         internal override object GetValueOfItem(object item)
@@ -64,8 +64,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal override void RemoveSessionStateItem(Path name)
         {
-            // TODO: can be Force'ed
-            SessionState.SessionStateGlobal.RemoveFunction(name);
+            throw new NotImplementedException();
         }
 
         internal override void SetSessionStateItem(Path name, object value, bool writeItem)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/SessionStateProviderBase.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/SessionStateProviderBase.cs
@@ -79,6 +79,7 @@ namespace Microsoft.PowerShell.Commands
             }
             return item;
         }
+        //TODO: remove these functions from all subclasses - they are never in use!
         internal abstract void RemoveSessionStateItem(Path name);
         internal abstract void SetSessionStateItem(Path name, object value, bool writeItem);
 

--- a/Source/System.Management/Pash/Implementation/AliasIntrinsics.cs
+++ b/Source/System.Management/Pash/Implementation/AliasIntrinsics.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Management.Automation;
+using System.Collections.Generic;
+
+namespace Pash.Implementation
+{
+    internal sealed class AliasIntrinsics
+    {
+        private SessionStateScope<AliasInfo> _scope;
+        private SessionState _sessionState;
+
+        internal AliasIntrinsics(SessionState sessionState, SessionStateScope<AliasInfo> aliasScope)
+        {
+            _sessionState = sessionState;
+            _scope = aliasScope;
+        }
+
+        public bool Exists(string aliasName)
+        {
+            return (Get(aliasName) != null);
+        }
+
+        public AliasInfo Get(string aliasName)
+        {
+            //Alias names do *not* support scope prefixes
+            return _scope.Get(aliasName, false);
+        }
+           
+        public AliasInfo GetAtScope(string aliasName, string scope)
+        {
+            return _scope.GetAtScope(aliasName, scope);
+        }
+
+        public Dictionary<string, AliasInfo> GetAllAtScope(string scope)
+        {
+            return _scope.GetAllAtScope(scope);
+        }
+
+        public Dictionary<string, AliasInfo> GetAll()
+        {
+            return _scope.GetAll();
+        }
+
+        public void Set(AliasInfo info, string scope)
+        {
+            _scope.SetAtScope(info, scope, true);
+        }
+
+        public void New(AliasInfo info, string scope)
+        {
+            _scope.SetAtScope(info, scope, false);
+        }
+
+        public void Remove(string aliasName, string scope)
+        {
+            _scope.RemoveAtScope(aliasName, scope);
+        }
+    }
+}
+

--- a/Source/System.Management/Pash/Implementation/FunctionIntrinsics.cs
+++ b/Source/System.Management/Pash/Implementation/FunctionIntrinsics.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Management.Automation;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+
+namespace Pash.Implementation
+{
+    internal sealed class FunctionIntrinsics
+    {
+        private SessionState _sessionState;
+        private SessionStateScope<FunctionInfo> _scope;
+
+        internal FunctionIntrinsics(SessionState sessionState, SessionStateScope<FunctionInfo> functionScope)
+        {
+            _sessionState = sessionState;
+            _scope = functionScope;
+        }
+
+        public FunctionInfo Get(string functionName)
+        {
+            return _scope.Get(functionName, true);
+        }
+
+        internal Dictionary<string, FunctionInfo> GetAll()
+        {
+            /*
+             * "Fun" fact: The GetAll() function of all *Intrinsics classes is perfect to be used
+             * by the provider when "Get-ChildItem" is called for example. With PS2.0, alias and variable
+             * providers return all elements that are useable and visible in the current scope.
+             * But not the FunctionProvider. It returns even inaccessible functions, e.g. those that are private
+             * in a parent scope. They cannot be called, but are returned. This behavior is just bad, therefore
+             * I won't implement it. I will implement this the same way as for aliases and variables.
+             */
+            return _scope.GetAll();
+        }
+
+        public void Set(string name, ScriptBlock function, string description = "")
+        {
+            var qualName = new SessionStateScope<FunctionInfo>.QualifiedName(name);
+            var info = new FunctionInfo(qualName.UnqualifiedName, function);
+            info.Description = description;
+            _scope.Set(name, info, true, true);
+        }
+
+        public void Set(FunctionInfo info)
+        {
+            _scope.SetAtScope(info, "local", true);
+        }
+
+        public void Remove(string name)
+        {
+            _scope.Remove(name, true);
+        }
+
+    }
+}
+

--- a/Source/System.Management/Pash/Implementation/IScopedItem.cs
+++ b/Source/System.Management/Pash/Implementation/IScopedItem.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Management.Automation;
+
+namespace Pash.Implementation
+{
+    internal interface IScopedItem
+    {
+        string ItemName { get; }
+        ScopedItemOptions ItemOptions { get; set; }
+    }
+}
+

--- a/Source/System.Management/Pash/Implementation/LocalRunspace.cs
+++ b/Source/System.Management/Pash/Implementation/LocalRunspace.cs
@@ -134,7 +134,7 @@ namespace Pash.Implementation
         #region OpenXXX Runspace
         public override void Open()
         {
-            CommandManager = new CommandManager();
+            CommandManager = new CommandManager(ExecutionContext);
             InitializeSession();
             InitializeProviders();
         }

--- a/Source/System.Management/Pash/Implementation/SessionStateScope.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateScope.cs
@@ -6,46 +6,301 @@ using System.Linq;
 
 namespace Pash.Implementation
 {
-    internal class SessionStateScope
+    internal class SessionStateScope<T> where T : IScopedItem
     {
-        public enum ScopeSpecifiers {
+        public enum ScopeSpecifiers
+        {
             Global,
             Local,
             Script,
             Private
-        };
-
-        internal Dictionary<string, AliasInfo> LocalAliases { get; private set; }
-        internal Dictionary<string, CommandInfo> LocalFunctions { get; private set; }
-        internal Dictionary<string, PSVariable> LocalVariables { get; private set; }
-        internal Dictionary<string, PSDriveInfo> LocalDrives { get; private set; }
-
-        public SessionStateScope ParentScope { get; private set; }
-        public SessionStateGlobal SessionStateGlobal { get; private set; }
-        public bool IsScriptScope { get; set; }
-
-        public SessionStateScope(SessionStateGlobal sessionStateGlobal) : this(null, sessionStateGlobal) {}
-
-        public SessionStateScope(SessionStateScope parentScope) : this(parentScope, parentScope.SessionStateGlobal) {}
-
-
-        private SessionStateScope(SessionStateScope parentScope, SessionStateGlobal sessionStateGlobal)
-        {
-            LocalAliases = new Dictionary<string, AliasInfo>(StringComparer.CurrentCultureIgnoreCase);
-            LocalFunctions = new Dictionary<string, CommandInfo>(StringComparer.CurrentCultureIgnoreCase);
-            LocalVariables = new Dictionary<string, PSVariable>(StringComparer.CurrentCultureIgnoreCase);
-            LocalDrives = new Dictionary<string, PSDriveInfo>(StringComparer.CurrentCultureIgnoreCase);
-            SessionStateGlobal = sessionStateGlobal;
-            IsScriptScope = false;
-            ParentScope = parentScope;
-            //TODO: care about AllScope items!
-            //Just setting the parent scope is a little too easy. We have to copy all AllScope members to this scope!
         }
 
-        internal SessionStateScope GetScope(string specifier, bool numberAllowed = true)
+        //allows foreach statement with scope hierarchies
+        public class ScopeHierarchyIterator : IEnumerable<SessionStateScope<T>>
+        {
+            private SessionStateScope<T> _start;
+
+            public ScopeHierarchyIterator(SessionStateScope<T> start)
+            {
+                _start = start;
+            }
+
+            public IEnumerator<SessionStateScope<T>> GetEnumerator()
+            {
+                for (var itemSet = _start; itemSet != null; itemSet = itemSet.ParentScope)
+                {
+                    yield return itemSet;
+                }
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            {
+                for (var itemSet = _start; itemSet != null; itemSet = itemSet.ParentScope)
+                {
+                    yield return itemSet;
+                }
+            }
+        }
+
+        public class QualifiedName
+        {
+            public string ScopeSpecifier { get; private set; }
+            public string UnqualifiedName { get; private set; }
+
+            public QualifiedName(string name)
+            {
+                //default: the name has no specifier
+                ScopeSpecifier = String.Empty;
+                UnqualifiedName = name;
+                //specifier is usually before the colon
+                var parts = name.Split(new char[] {':'}, 2);
+                if (parts.Length > 1 && ValidateScopeSpecifier(parts[0], false))
+                {
+                    ScopeSpecifier = parts[0];
+                    UnqualifiedName = parts[1];
+                }
+            }
+        }
+
+        internal SessionStateCategory SessionStateCategory { get; private set; }
+
+        public SessionStateScope<T> ParentScope{ get; private set; }
+        public Dictionary<string, T> Items { get; private set; }
+        public bool IsScriptScope { get; set; }
+        public IEnumerable<SessionStateScope<T>> HierarchyIterator
+        {
+            get { return new ScopeHierarchyIterator(this); }
+        }
+
+
+        public SessionStateScope(SessionStateScope<T> parentItems, SessionStateCategory sessionStateCategory)
+        {
+            ParentScope = parentItems;
+            Items = new Dictionary<string, T>(StringComparer.CurrentCultureIgnoreCase);
+            //TODO: care about AllScope items!
+
+            SessionStateCategory = sessionStateCategory;
+        }
+
+        #region general functions that work with full hierarchy and qualified names
+        public T Get(string name, bool isQualified)
+        {
+            if (name == null)
+            {
+                throw new MethodInvocationException("The value of the argument \"name\" is null");
+            }
+            //if the name is qualified, look for the specified scope
+            if (isQualified)
+            {
+                var qualName = new QualifiedName(name);
+                if (!String.IsNullOrEmpty(qualName.ScopeSpecifier))
+                {
+                    SessionStateScope<T> affectedScope = GetScope(qualName.ScopeSpecifier, false);
+                    var item = affectedScope.GetLocal(qualName.UnqualifiedName);
+                    //return null if it's private
+                    if (affectedScope != this && item.ItemOptions.HasFlag(ScopedItemOptions.Private))
+                    {
+                        return default(T);
+                    }
+                    return item;
+                }
+            }
+            //no scope specifier in name, look in hierarchy
+            var hostingScope = this.FindHostingScope(name);
+            if (hostingScope != null)
+            {
+                return hostingScope.GetLocal(name);
+            }
+            return default(T);
+        }
+
+        public void Set(string name, T value, bool isQualified, bool overwrite)
+        {
+            if (name == null)
+            {
+                throw new MethodInvocationException("The value of the argument \"name\" is null");
+            }
+            var qualName = new QualifiedName(name);
+            var isPrivate = isQualified ? String.Equals(ScopeSpecifiers.Private.ToString(), qualName.ScopeSpecifier,
+                                                       StringComparison.CurrentCultureIgnoreCase)
+                                        : false;
+            var affectedScope = isQualified ? GetScope(qualName.ScopeSpecifier, false, this) : this;
+            if (isPrivate) //make sure to set the private flag correctly
+            {
+                value.ItemOptions |= ScopedItemOptions.Private;
+            }
+            affectedScope.SetLocal(value, overwrite);
+        }
+
+        public void Remove(string name, bool isQualified)
+        {
+            if (name == null)
+            {
+                throw new MethodInvocationException("The value of the argument \"name\" is null");
+            }
+            //if the scope isn't specified, we will look in the hierarchy for the variable
+            SessionStateScope<T> affectedScope = null;
+            if (isQualified)
+            {
+                var qualName = new QualifiedName(name);
+                affectedScope = GetScope(qualName.ScopeSpecifier, false);
+                name = qualName.UnqualifiedName; //use the unqualified name to set the item
+            }
+            if (affectedScope == null)
+            {
+                affectedScope = FindHostingScope(name) ?? this;
+            }
+            affectedScope.RemoveLocal(name);
+        }
+
+        public Dictionary<string, T> GetAll()
+        {
+            //get a copy of the vars in the local scope first. Note: it also copies the correct comperator
+            var visibleItems = new Dictionary<string, T>(Items);
+            //now check recursively the parent scopes for non-private, not overriden variables
+            //explicitly instantiate hierarchyiterator as ParentScope can be null
+            foreach (var curScope in new ScopeHierarchyIterator(ParentScope))
+            {
+                foreach (var pair in curScope.Items)
+                {
+                    if (!visibleItems.ContainsKey(pair.Key) && 
+                        !pair.Value.ItemOptions.HasFlag(ScopedItemOptions.Private))
+                    {
+                        visibleItems.Add(pair.Key, pair.Value);
+                    }
+                }
+            }
+            return visibleItems;
+        }
+
+        #endregion
+
+        #region specified scope related
+
+        public T GetAtScope(string name, string scope)
+        {
+            var affectedScope = GetScope(scope, true, this);
+            return affectedScope.GetLocal(name);
+        }
+
+        public void SetAtScope(T value, string scope, bool overwrite)
+        {
+            var affectedScope = GetScope(scope, true, this);
+            affectedScope.SetLocal(value, overwrite);
+        }
+
+        public void RemoveAtScope(string name, string scope)
+        {
+            var affectedScope = GetScope(scope, true, this);
+            affectedScope.RemoveLocal(name);
+        }
+
+        public Dictionary<string, T> GetAllAtScope(string scope)
+        {
+            var affectedScope = GetScope(scope, true, this);
+            return affectedScope.Items;
+        }
+
+        #endregion
+           
+        #region local scope only
+
+        public T GetLocal(string name)
+        {
+            if (name == null)
+            {
+                throw new MethodInvocationException("The value of the argument \"name\" is null");
+            }
+            if (Items.ContainsKey(name))
+            {
+                return Items[name];
+            }
+            return default(T);
+        }
+
+        public void SetLocal(T item, bool overwrite)
+        {
+            if (item == null)
+            {
+                throw new MethodInvocationException("The value of the argument \"item\" is null");
+            }
+            var original = GetLocal(item.ItemName);
+            if (original != null)
+            {
+                if (!overwrite)
+                {
+                    throw new SessionStateException(item.ItemName, SessionStateCategory, String.Empty,
+                                                    ErrorCategory.ResourceExists, null);
+                }
+                if (original.ItemOptions.HasFlag(ScopedItemOptions.ReadOnly))
+                {
+                    throw new SessionStateUnauthorizedAccessException(item.ItemName, SessionStateCategory,
+                                                                      String.Empty, null);
+                }
+                if (!original.ItemOptions.HasFlag(ScopedItemOptions.Private)) //privacy cannot be changed
+                {
+                    item.ItemOptions &= ~ScopedItemOptions.Private;
+                }
+                else //original was private
+                {
+                    item.ItemOptions |= ScopedItemOptions.Private;
+                }
+                RemoveLocal(item.ItemName); //checks also for constants
+            }
+            Items.Add(item.ItemName, item);
+        }
+
+        public void RemoveLocal(string name)
+        {
+            if (name == null)
+            {
+                throw new MethodInvocationException("The value of the argument \"name\" is null");
+            }
+            var item = GetLocal(name);
+            if (item == null) //doesn't exist
+            {
+                throw new ItemNotFoundException(name, SessionStateCategory, String.Empty, null);
+            }
+            if (item.ItemOptions.HasFlag(ScopedItemOptions.Constant))
+            {
+                throw new SessionStateUnauthorizedAccessException(name, SessionStateCategory, String.Empty, null);
+            }
+            Items.Remove(name);
+        }
+
+        #endregion
+
+        #region helper functions
+
+        private SessionStateScope<T> FindHostingScope(string unqualifiedName)
+        {
+            //iterate through scopes and parents until we find the variable
+            foreach (var candidate in HierarchyIterator)
+            {
+                var item = candidate.GetLocal(unqualifiedName);
+                if (item == null)
+                {
+                    continue;
+                }
+                //make also sure the variable isn't private, if it's from a parent scope!
+                if ((candidate == this) || !item.ItemOptions.HasFlag(ScopedItemOptions.Private))
+                {
+                    return candidate;
+                }
+            }
+            return null; //nothing found
+        }
+
+        private SessionStateScope<T> GetScope(string specifier, bool numberAllowed,
+                                               SessionStateScope<T> fallback = null)
         {
             int scopeLevel = -1;
-            SessionStateScope candidate = this;
+            if (String.IsNullOrEmpty(specifier))
+            {
+                return fallback;
+            }
+            SessionStateScope<T> candidate = this;
             //check if the specifier is a number before trying to interprete it as enum
             if (int.TryParse(specifier, out scopeLevel))
             {
@@ -55,15 +310,14 @@ namespace Pash.Implementation
                 {
                     throw new ArgumentException("Invalid scope specifier");
                 }
-                while (scopeLevel > 0)
+                for (var curLevel = scopeLevel; curLevel > 0; curLevel--)
                 {
                     //make sure we can proceed looking for the next scope
-                    if (candidate.ParentScope == null)
+                    candidate = candidate.ParentScope;
+                    if (candidate == null)
                     {
                         throw new ArgumentOutOfRangeException("Exceeded the maximum number of available scopes");
                     }
-                    candidate = candidate.ParentScope;
-                    scopeLevel--;
                 }
                 return candidate;
             }
@@ -71,12 +325,12 @@ namespace Pash.Implementation
             ScopeSpecifiers scopeSpecifier;
             if (!ScopeSpecifiers.TryParse(specifier, true, out scopeSpecifier))
             {
-                throw new ArgumentException("Invalid scope specifier");
+                throw new ArgumentException(String.Format("Invalid scope specifier \"{0}\".", specifier));
             }
             return GetScope(scopeSpecifier);
         }
 
-        internal SessionStateScope GetScope(ScopeSpecifiers specifier)
+        private SessionStateScope<T> GetScope(ScopeSpecifiers specifier)
         {
             //if the local scope is meant, return this instance itself
             if (specifier == ScopeSpecifiers.Local || specifier == ScopeSpecifiers.Private)
@@ -101,57 +355,23 @@ namespace Pash.Implementation
             throw new ArgumentException(String.Format("Invalid scope specifier \"{0}\"", specifier));
         }
 
-        #region drive access
-        internal PSDriveInfo GetLocalDrive(string driveName)
+        static private bool ValidateScopeSpecifier(string specifier, bool numberAllowed)
         {
-            if (LocalDrives.ContainsKey(driveName))
-            {
-                return LocalDrives[driveName];
-            }
-            return null;
-        }
-
-        internal bool AddLocalDrive(PSDriveInfo drive)
-        {
-            if (LocalDrives.ContainsKey(drive.Name))
+            int scopeLevel = -1;
+            //first try to interprete it as an int. if we don't do this, the enums TryParse method will misinterpret it
+            if (int.TryParse(specifier, out scopeLevel) && (scopeLevel < 0 || !numberAllowed))
             {
                 return false;
             }
-            LocalDrives.Add(drive.Name, drive);
+            ScopeSpecifiers scopeSpecifier;
+            if (!ScopeSpecifiers.TryParse(specifier, true, out scopeSpecifier))
+            {
+                return false;
+            }
             return true;
         }
 
-        internal bool RemoveLocalDrive(string driveName, bool force)
-        {
-            /* TODO: force is used to remove the drive "although it's in use by the provider"
-             * So, we need to find out when a drive is in use and should throw an exception on removal without
-             * the "force" parameter being true
-             */
-            return LocalDrives.Remove(driveName);
-        }
-        #endregion
-
-        #region variable access
-        internal PSVariable GetLocalVariable(string unqualifiedName)
-        {
-            if (LocalVariables.ContainsKey(unqualifiedName))
-            {
-                return (PSVariable) LocalVariables[unqualifiedName];
-            }
-            return null;
-        }
-
-        internal void RemoveLocalVariable(string name)
-        {
-            LocalVariables.Remove(name);
-        }
-
-        internal void SetLocalVariable(PSVariable variable)
-        {
-            RemoveLocalVariable(variable.Name);
-            LocalVariables.Add(variable.Name, variable);
-        }
-        #endregion
+        #endregion                    
     }
 }
 

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -463,6 +463,9 @@
     <Compile Include="Pash\Implementation\ApplicationProcessor.cs" />
     <Compile Include="Pash\Implementation\SessionStateScope.cs" />
     <Compile Include="Automation\SessionStateUnauthorizedAccessException.cs" />
+    <Compile Include="Pash\Implementation\AliasIntrinsics.cs" />
+    <Compile Include="Pash\Implementation\FunctionIntrinsics.cs" />
+    <Compile Include="Pash\Implementation\IScopedItem.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/TestHost/SessionStateScopeTests.cs
+++ b/Source/TestHost/SessionStateScopeTests.cs
@@ -4,6 +4,7 @@ using Pash.Implementation;
 using System.Management.Automation.Runspaces;
 using System.Management.Automation;
 using System.Collections.Generic;
+using System.Management.Automation.Language;
 
 namespace TestHost
 {
@@ -23,6 +24,7 @@ namespace TestHost
         private SessionState functionState;
         private SessionState localState;
         private Dictionary<AvailableStates, SessionState> states;
+        private CommandManager hostCommandManager;
 
         [SetUp]
         public void createScopes()
@@ -32,7 +34,7 @@ namespace TestHost
 
             globalState = hostRunspace.ExecutionContext.SessionState;
             scriptState = new SessionState(globalState);
-            scriptState.SessionStateScope.IsScriptScope = true;
+            scriptState.IsScriptScope = true;
             functionState = new SessionState(scriptState);
             localState = new SessionState(functionState);
             states = new Dictionary<AvailableStates, SessionState>();
@@ -40,22 +42,31 @@ namespace TestHost
             states.Add(AvailableStates.Script, scriptState);
             states.Add(AvailableStates.Function, functionState);
             states.Add(AvailableStates.Local, localState);
+
+            hostCommandManager = new CommandManager(hostRunspace.ExecutionContext);
         }
 
-        [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
-        [TestCase("-1", null, ExpectedException=typeof(ArgumentException))]
-        [TestCase("foo", null, ExpectedException=typeof(ArgumentException))]
-        [TestCase("3", AvailableStates.Global)]
-        [TestCase("global", AvailableStates.Global)]
-        [TestCase("2", AvailableStates.Script)]
-        [TestCase("script", AvailableStates.Script)]
-        [TestCase("1", AvailableStates.Function)]
-        [TestCase("0", AvailableStates.Local)]
-        [TestCase("local", AvailableStates.Local)]
-        public void GetScopeTest(string specifier, AvailableStates sessionState)
+        #region general scope related
+
+        [TestCase("private:foo", "private", "foo")]
+        [TestCase("local:foo", "local", "foo")]
+        [TestCase("script:foo", "script", "foo")]
+        [TestCase("global:foo", "global", "foo")]
+        [TestCase("global:private:foo", "global", "private:foo")]
+        [TestCase("0:foo", "", "0:foo")]
+        [TestCase("1:foo", "", "1:foo")]
+        [TestCase("-1:foo", "", "-1:foo")]
+        [TestCase("bar:foo", "", "bar:foo")]
+        public void QualifiedNameTest(string name, string specifier, string unqualifiedName)
         {
-            Assert.AreEqual(localState.SessionStateScope.GetScope(specifier), states[sessionState].SessionStateScope);
+            var qualName = new SessionStateScope<PSVariable>.QualifiedName(name);
+            Assert.AreEqual(specifier, qualName.ScopeSpecifier);
+            Assert.AreEqual(unqualifiedName, qualName.UnqualifiedName);
         }
+
+        #endregion
+
+        #region variable related
 
         [TestCase("x", "f")] //correct x is fetched in general (from function scope)
         [TestCase("local:x", null)] //local scope has no variable x
@@ -79,6 +90,7 @@ namespace TestHost
             localState.PSVariable.Set(new PSVariable("y", "l"));
             Assert.AreEqual(expected, localState.PSVariable.GetValue(name));
         }
+
 
         [TestCase(AvailableStates.Global, "g", true)]
         [TestCase(AvailableStates.Script, "s", true)]
@@ -145,9 +157,20 @@ namespace TestHost
             scriptState.PSVariable.Remove(variable);
             Assert.IsNull(scriptState.PSVariable.Get("local:x"));
             Assert.IsNotNull(globalState.PSVariable.Get("local:x"));
-            scriptState.PSVariable.Remove(variable); //doesn't affect parent scopes (different to passing the name)
+            try
+            {
+                scriptState.PSVariable.Remove(variable); //doesn't affect parent scopes (different to passing the name)
+                Assert.True(false);
+            }
+            catch (ItemNotFoundException)
+            {
+            }
             Assert.IsNotNull(globalState.PSVariable.Get("local:x"));
         }
+
+        #endregion
+
+        #region drive related
 
         [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
         [TestCase("foo", null, ExpectedException=typeof(ArgumentException))]
@@ -174,7 +197,7 @@ namespace TestHost
             try {
                 scriptState.Drive.New (info, "global"); //this shouldn't work, as the global scope has that drive
                 Assert.True (false);
-            } catch (MethodInvocationException) { }
+            } catch (SessionStateException) { }
         }
 
         [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
@@ -216,7 +239,7 @@ namespace TestHost
             try {
                 globalState.Drive.Remove (info.Name, true, "local");
                 Assert.True (false);
-            } catch (MethodInvocationException) { }
+            } catch (DriveNotFoundException) { }
         }
 
         [Test]
@@ -302,26 +325,26 @@ namespace TestHost
             Assert.AreEqual(expectedDescription, localState.Drive.GetAtScope("x", scope).Description);
         }
 
-        public void DriveGetAllForProviderTest ()
+        public void DriveGetAllForProviderTest()
         {
             var provider = new ProviderInfo (null, null, "testProvider", "", null);
-            globalState.Drive.New (createDrive ("global", "", provider), "local");
-            scriptState.Drive.New (createDrive ("script", "", provider), "local");
-            functionState.Drive.New (createDrive ("function", "", provider), "local");
-            localState.Drive.New (createDrive ("local", "", provider), "local");
-            var drives = localState.Drive.GetAllForProvider ("testProvider");
-            Assert.AreEqual (4, drives.Count);
+            globalState.Drive.New(createDrive ("global", "", provider), "local");
+            scriptState.Drive.New(createDrive ("script", "", provider), "local");
+            functionState.Drive.New(createDrive ("function", "", provider), "local");
+            localState.Drive.New (createDrive("local", "", provider), "local");
+            var drives = localState.Drive.GetAllForProvider("testProvider");
+            Assert.AreEqual(4, drives.Count);
             foreach (var curDrive in drives) {
-                Assert.Contains (curDrive.Name, new string[] {"global", "script", "function", "local"});
+                Assert.Contains(curDrive.Name, new string[] {"global", "script", "function", "local"});
             }
             drives = scriptState.Drive.GetAllForProvider ("testProvider");
-            Assert.AreEqual (2, drives.Count);
+            Assert.AreEqual(2, drives.Count);
             foreach (var curDrive in drives) {
-                Assert.Contains (curDrive.Name, new string[] {"global", "script"});
+                Assert.Contains(curDrive.Name, new string[] {"global", "script"});
             }
             try {
-                globalState.Drive.GetAllForProvider ("doesnt_exist");
-                Assert.True (false);
+                globalState.Drive.GetAllForProvider("doesnt_exist");
+                Assert.True(false);
             } catch (MethodInvocationException) { }
         }
 
@@ -329,6 +352,265 @@ namespace TestHost
         {
             return new PSDriveInfo(name, provider, String.Empty, descr, null);
         }
+
+        #endregion
+    
+        #region function related
+
+        [TestCase("x", "f")] //correct x is fetched in general (from function scope)
+        [TestCase("local:x", null)] //local scope has no function x
+        [TestCase("script:x", null)] //x is private in the script scope
+        [TestCase("global:x", "g")]
+        [TestCase("y", "l")] //the overridden y in the local scope
+        [TestCase("local:y", "l")] //also the local one, but explicitly
+        [TestCase("script:y", "s")]
+        [TestCase("global:y", "g")]
+        [TestCase("z", "s")] //ignores the private z in function scope
+        public void FunctionGetTest(string name, string expectedDescription)
+        {
+            globalState.Function.Set(createFunction("x", "g"));
+            globalState.Function.Set(createFunction("y", "g"));
+            scriptState.Function.Set(createFunction("x", "s", ScopedItemOptions.Private));
+            scriptState.Function.Set(createFunction("y", "s"));
+            scriptState.Function.Set(createFunction("z", "s"));
+            functionState.Function.Set(createFunction("x", "f"));
+            functionState.Function.Set(createFunction("y", "f"));
+            functionState.Function.Set(createFunction("z", "f", ScopedItemOptions.Private));
+            localState.Function.Set(createFunction("y", "l"));
+            var info = localState.Function.Get(name);
+            if (expectedDescription == null)
+            {
+                Assert.IsNull(info);
+            }
+            else
+            {
+                Assert.AreEqual(expectedDescription, info.Description);
+            }
+        }
+  
+        [Test]
+        public void FunctionGetAllTest()
+        {
+            globalState.Function.Set(createFunction("override", "first"));
+            globalState.Function.Set(createFunction("global"));
+            scriptState.Function.Set(createFunction("script"));
+            functionState.Function.Set(createFunction("override", "second"));
+            var funs = localState.Function.GetAll();
+            Assert.AreEqual(3, funs.Count);
+            bool found = false;
+            foreach (var curFun in funs)
+            {
+                if (curFun.Value.Name.Equals("override"))
+                {
+                    if (found) //make sure it's only one time in there
+                    {
+                        Assert.True(false);
+                    }
+                    Assert.AreEqual("second", curFun.Value.Description);
+                    found = true;
+                }
+            }
+            Assert.True(found);
+        }
+
+        [TestCase(AvailableStates.Global, "g", true)]
+        [TestCase(AvailableStates.Script, "s", true)]
+        [TestCase(AvailableStates.Function, "f", true)]
+        [TestCase(AvailableStates.Local, "l", true)]
+        [TestCase(AvailableStates.Local, "s", false)] //makes sure private setting works
+        public void FunctionSetObjectTest(AvailableStates sessionState, object value, bool initLocal=true)
+        {
+            functionState.Function.Set("private:x", null, "f");
+            localState.Function.Set("global:x", null, "g");
+            localState.Function.Set("script:x", null, "s");
+            if (initLocal)
+            {
+                localState.Function.Set ("local:x", null, "l");
+            }
+            Assert.AreEqual(value, states[sessionState].Function.Get("x").Description);
+        }
+
+        [TestCase("global:x", AvailableStates.Global, true)]
+        [TestCase("script:x", AvailableStates.Script, true)]
+        [TestCase("local:x", AvailableStates.Local, true)]
+        [TestCase("x", AvailableStates.Function, false)] //looks in parent scopes and removes the variable
+        public void FunctionRemoveTest(string variable, AvailableStates affectedState, bool initLocal)
+        {
+            globalState.Function.Set("x", null, "g");
+            scriptState.Function.Set("x", null, "s");
+            functionState.Function.Set("x", null, "f");
+            if (initLocal)
+            {
+                localState.Function.Set("x", null, "l");
+            }
+
+            localState.Function.Remove(variable);
+            foreach (KeyValuePair<AvailableStates, SessionState> curState in states)
+            {
+                if (curState.Key == affectedState || (curState.Key == AvailableStates.Local && !initLocal))
+                {
+                    Assert.IsNull(curState.Value.Function.Get("local:x"));
+                }
+                else
+                {
+                    Assert.IsNotNull(curState.Value.Function.Get("local:x"));
+                }
+            }
+        }
+
+        private FunctionInfo createFunction(string name, string description = "",
+                                            ScopedItemOptions options = ScopedItemOptions.None)
+        {
+            var info = new FunctionInfo(name, null, options);
+            info.Description = description;
+            return info;
+        }
+        #endregion
+
+        #region alias related
+
+        [TestCase(AvailableStates.Global, true)] //the private one
+        [TestCase(AvailableStates.Script, false)] //doesn't see the private one
+        [TestCase(AvailableStates.Function, true)] //the non-private
+        [TestCase(AvailableStates.Local, true)] //can see the non-private
+        public void AliasExistsTest(AvailableStates affectedState, bool exists)
+        {
+            globalState.Alias.New(createAlias("test", "", ScopedItemOptions.Private), "local");
+            functionState.Alias.New(createAlias("test", ""), "local");
+            Assert.AreEqual(exists, states[affectedState].Alias.Exists("test"));
+        }
+
+        [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
+        [TestCase("foo", null, ExpectedException=typeof(ArgumentException))]
+        [TestCase("3", AvailableStates.Global)]
+        [TestCase("global", AvailableStates.Global)]
+        [TestCase("2", AvailableStates.Script)]
+        [TestCase("script", AvailableStates.Script)]
+        [TestCase("1", AvailableStates.Function)]
+        [TestCase("0", AvailableStates.Local)]
+        [TestCase("local", AvailableStates.Local)]
+        public void AliasNewTest(string scope, AvailableStates affectedState)
+        {
+            AliasInfo info = createAlias("test");
+            localState.Alias.New(info, scope);
+            Assert.AreEqual(info, states[affectedState].Alias.Get(info.Name));
+        }
+
+        [TestCase("4", null, ExpectedException=typeof(ArgumentOutOfRangeException))]
+        [TestCase("foo", null, ExpectedException=typeof(ArgumentException))]
+        [TestCase("3", AvailableStates.Global)]
+        [TestCase("global", AvailableStates.Global)]
+        [TestCase("2", AvailableStates.Script)]
+        [TestCase("script", AvailableStates.Script)]
+        [TestCase("1", AvailableStates.Function)]
+        [TestCase("0", AvailableStates.Local)]
+        [TestCase("local", AvailableStates.Local)]
+        public void AliasRemoveTest(string scope, AvailableStates affectedState)
+        {
+            Dictionary<AvailableStates, AliasInfo> aliasInfos = new Dictionary<AvailableStates, AliasInfo>();
+            foreach (var curState in states)
+            {
+                var info = createAlias(curState.Key.ToString());
+                curState.Value.Alias.New(info, "local");
+                aliasInfos[curState.Key] = info;
+            }
+            localState.Alias.Remove(aliasInfos[affectedState].Name, scope);
+            foreach (var curState in states)
+            {
+                if (curState.Key == affectedState)
+                {
+                    Assert.AreEqual(0, curState.Value.Alias.GetAllAtScope("local").Count);
+                }
+                else
+                {
+                    Assert.AreEqual(aliasInfos[curState.Key], curState.Value.Alias.Get(aliasInfos[curState.Key].Name));
+                }
+            }
+        }
+        [Test]
+        public void AliasGetAllTest()
+        {
+            globalState.Alias.New(createAlias("override", "first"), "local");
+            globalState.Alias.New(createAlias("global"), "local");
+            scriptState.Alias.New(createAlias("script"), "local");
+            functionState.Alias.New(createAlias("override", "second"), "local");
+            var drives = localState.Alias.GetAll();
+            Assert.AreEqual(3, drives.Count);
+            bool found = false;
+            foreach (var curAlias in drives)
+            {
+                if (curAlias.Value.Name.Equals("override"))
+                {
+                    if (found) //make sure it's only one time in there
+                    {
+                        Assert.True(false);
+                    }
+                    Assert.AreEqual("second", curAlias.Value.Definition);
+                    found = true;
+                }
+            }
+            Assert.True (found);
+        }
+
+        [TestCase("local", new string [] {})]
+        [TestCase("0", new string [] {})]
+        [TestCase("1", new string [] {"function"})]
+        [TestCase("script", new string [] {"script1", "script2"})]
+        [TestCase("2", new string [] {"script1", "script2"})]
+        [TestCase("global", new string [] {"global1", "global2"})]
+        [TestCase("3", new string [] {"global1", "global2"})]
+        [TestCase("4", new string [] {}, ExpectedException=typeof(ArgumentOutOfRangeException))]
+        public void AliasGetAllAtScopeTest(string scope, string[] expectedDescriptions)
+        {
+            globalState.Alias.New(createAlias("x", "global1"), "local");
+            globalState.Alias.New(createAlias("y", "global2"), "local");
+            scriptState.Alias.New(createAlias("x", "script1"), "local");
+            scriptState.Alias.New(createAlias("y", "script2"), "local");
+            functionState.Alias.New(createAlias("x", "function"), "local");
+            var drives = localState.Alias.GetAllAtScope(scope);
+            Assert.AreEqual(expectedDescriptions.Length, drives.Count);
+            foreach (var curAlias in drives)
+            {
+                Assert.Contains(curAlias.Value.Definition, expectedDescriptions);
+            }
+        }
+
+        [Test]
+        public void AliasGetTest()
+        {
+            globalState.Alias.New(createAlias("override", "first"), "local");
+            globalState.Alias.New(createAlias("global"), "local");
+            functionState.Alias.New(createAlias("override", "second"), "local");
+            var alias = localState.Alias.Get ("override");
+            Assert.AreEqual("override", alias.Name);
+            Assert.AreEqual("second", alias.Definition);
+            Assert.AreEqual("global", localState.Alias.Get("global").Name);
+            Assert.IsNull(localState.Alias.Get("doesnt_exist"));
+        }
+
+        [TestCase("local", "local")]
+        [TestCase("0", "local")]
+        [TestCase("1", "function")]
+        [TestCase("script", "script")]
+        [TestCase("2",  "script")]
+        [TestCase("global", "global")]
+        [TestCase("3", "global")]
+        [TestCase("4", "", ExpectedException=typeof(ArgumentOutOfRangeException))]
+        public void AliasGetAtScopeTest(string scope, string expectedDefinition)
+        {
+            globalState.Alias.New(createAlias("x", "global"), "local");
+            scriptState.Alias.New(createAlias("x", "script"), "local");
+            functionState.Alias.New(createAlias("x", "function"), "local");
+            localState.Alias.New(createAlias("x", "local"), "local");
+            Assert.AreEqual(expectedDefinition, localState.Alias.GetAtScope("x", scope).Definition);
+        }
+
+        private AliasInfo createAlias(string name, string definition = "",
+                                      ScopedItemOptions options = ScopedItemOptions.None)
+        {
+            return new AliasInfo(name, definition, hostCommandManager, options);
+        }
+
+        #endregion
     }
 }
-


### PR DESCRIPTION
This is the second big step of implementing scopes in Pash.
The major changes are the following:
- FunctionIntrinsics and AliasIntrinsics were introduced, s.t. function and aliases
  are handled analogously to variables and drives.
  Note: All the *Intrinsics classes need to be a little extended if the Providers /
  cmdlets are updated to use them. But this shouldn't be hard any more, because
  of the next point.
- The class SessionStateScope, which was introduced in the last step, was changed to
  be generic and always refer to a specific type of items.
  This approach was chosen, because the *Intrinsics classes are all specified a little
  differently with different details. To avoid a lot of duplicate code, the core
  methods are now directly in SessionStateScope, only the details (or wrapper functions)
  are exposed in the *Intrinsic classes.
  To review that class it's probably easier to just look at the complete new class instead of
  checking the diff. It also includes an iterator to iterate through the scope hierarchy.
- The interface IScopedItem was introduced in oder to make AliasInfo, PSVariable, PSDriveInfo,
  and FunctionInfo all usable by the new SessionStateScope implementation.
- The tests however still refer to the *Intrinsics classes, though they share mostly common
  functionality. However, these classes count in the end and bring slightly differences,
  so this makes sense.
- Some Exception classes were implemented in order to be used.
- First necessary changes in the cmdlets were done, in order to be able to integrate the
  new architecture. However, they still need some refinement in order to support all features
- The CommandManager now always need an ExecutionContext in order to instantiate. This is
  necessary in the new architecture and does make sense, as the SessionState is part of
  the ExecutionContext and it provides information about available aliases and providers.
  Therfore the provider intialization was moved to SessionStateGlobal, for now.
  Later on, also the Providers should be handled by SessionState.Provider (ProviderIntrinsics,
  see specification),  but are no scoped items.

All tests run without errors, on both windows and linux. I also tested some basic work in Pash,
and didn't face any problems.

Upcoming steps:
- Make sure new scopes are created when scripts, functions or scriptblocks are executed
- Take another look at the existing cmdlets and refine some
- Make functions work with parameters

Sorry for the huge diff, but that's what it took to implement it properly ;-)
