### PR TITLE
Implemented integer literal type promotion.

### DIFF
--- a/Source/TestHost/2.3.5.1.1 Integer literals.cs
+++ b/Source/TestHost/2.3.5.1.1 Integer literals.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TestHost
+{
+    [TestFixture]
+    class IntegerLiterals
+    {
+        [Test]
+        [TestCase("0", "System.Int32")]
+        [TestCase("2147483647", "System.Int32")] // int.MaxValue
+        [TestCase("2147483648", "System.Int64")] // int.MaxValue + 1
+        [TestCase("9223372036854775807", "System.Int64")] // long.MaxValue
+        [TestCase("9223372036854775808", "System.Decimal")] // long.MaxValue + 1
+        [TestCase("79228162514264337593543950335", "System.Decimal")] // decimal.MaxValue
+        [TestCase("79228162514264337593543950336", "System.Double")] // decimal.MaxValue + 1
+        public void SimpleIntegerLiteralShouldBeOfType(string literal, string expectedType)
+        {
+            var result = TestHost.Execute(true, string.Format("({0}).GetType()", literal));
+            Assert.AreEqual(expectedType + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void SimpleIntegerLiteralVeryLargeNumberShouldBeDouble()
+        {
+            var result = TestHost.Execute(true, string.Format("({0}).GetType()", new string('9', 200)));
+            Assert.AreEqual("System.Double" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void SimpleIntegerLiteralVeryVeryVeryLargeNumberShouldThrow()
+        {
+            var result = TestHost.Execute(true, string.Format("({0}).GetType()", new string('9', 310)));
+            StringAssert.Contains("Exception", result);
+        }
+
+        [Test, Combinatorial]
+        public void LongIntegerLiteralShouldBeInt64(
+            [Values("0", "2147483647", "2147483648", "9223372036854775807")]
+            string literal,
+            [Values("l", "L")]
+            string typeSuffix)
+        {
+            var result = TestHost.Execute(true, string.Format("({0}{1}).GetType()", literal, typeSuffix));
+            Assert.AreEqual("System.Int64" + Environment.NewLine, result);
+        }
+
+        [Test]
+        [TestCase("l")]
+        [TestCase("L")]
+        public void LongIntegerLiteralLargeNumberShouldThrow(string typeSuffix)
+        {
+            var result = TestHost.Execute(true, string.Format("(9223372036854775808{0}).GetType()", typeSuffix));
+            StringAssert.Contains("Exception", result);
+        }
+    }
+}

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="2.3.5.1.1 Integer literals.cs" />
     <Compile Include="Cmdlets\JoinPathTests.cs" />
     <Compile Include="Cmdlets\SortObjectTests.cs" />
     <Compile Include="Cmdlets\GetCommandTests.cs" />


### PR DESCRIPTION
Integer literals now automatically get widened to a larger type if necessary, going from `int`, over `long` and `decimal` to `double` if necessary. Previously integer literals were only `int`.

Also implemented the long type suffix which forces the literal to be of type `long`.

This follows the wording of the spec very closely (also visible in the comments in the source code). Where the specification did not specify exact behavior (such as when an un-suffixed literal overflows `double`), PowerShell v4's behavior was adopted.
