### PR TITLE
Third step of scope integration: Use of scopes, general fixes/cleanup about commands

### DIFF
--- a/Source/PashConsole/FullHost.cs
+++ b/Source/PashConsole/FullHost.cs
@@ -24,8 +24,9 @@ namespace Pash
 
             string exePath = Assembly.GetCallingAssembly().Location;
             string configPath = Path.Combine(Path.GetDirectoryName(exePath), "config.ps1");
-
-            Execute(configPath);
+            //we need to dot-source the script to affect the global scope
+            //make sure that the pending pull request is updated and merged to implement this properly
+            Execute(". \"" + configPath + "\"");
         }
 
         void executeHelper(string cmd, object input)
@@ -43,7 +44,9 @@ namespace Pash
             // instance variable so that it is available to be stopped.
             try
             {
-                currentPipeline.Commands.Add(cmd);
+                // A command is not a simple word here, it's the whole user input and might contain
+                // multiple commands. Therefore we parse it first, but make sure it's not executed in a local scope
+                currentPipeline.Commands.AddScript(cmd, false);
 
                 // Now add the default outputter to the end of the pipe and indicate
                 // that it should handle both output and errors from the previous

--- a/Source/System.Management/Automation/AliasInfo.cs
+++ b/Source/System.Management/Automation/AliasInfo.cs
@@ -40,7 +40,18 @@ namespace System.Management.Automation
         {
             _definition = definition;
 
-            ReferencedCommand = cmdManager.FindCommand(definition);
+            //only set referenced command if found
+            //aliases only cause errors when they are used, not at instanciation
+            CommandInfo refInfo = null;
+            try
+            {
+                cmdManager.FindCommand(definition);
+            }
+            catch (CommandNotFoundException)
+            {
+            }
+
+            ReferencedCommand = refInfo;
             ResolvedCommand = ReferencedCommand;
         }
         //internal void SetOptions(ScopedItemOptions newOptions, bool force);

--- a/Source/System.Management/Automation/FunctionInfo.cs
+++ b/Source/System.Management/Automation/FunctionInfo.cs
@@ -3,14 +3,15 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Pash.Implementation;
+using System.Collections.ObjectModel;
+using System.Management.Automation.Language;
 
 namespace System.Management.Automation
 {
-    public class FunctionInfo : CommandInfo, IScopedItem
+    public class FunctionInfo : CommandInfo, IScopedItem, IScriptBlockInfo
     {
-        public override string Definition { get { return Name; } }
+        public override string Definition { get { return ScriptBlock.ToString(); } }
         public ScopedItemOptions Options { get; set; }
-        public ScriptBlock ScriptBlock { get; private set; }
         public string Noun { get; private set; }
         public string Verb { get; private set; }
         public string Description { get; set; }
@@ -25,6 +26,7 @@ namespace System.Management.Automation
             Options = options;
             Verb = verb;
             Noun = noun;
+            ScopeUsage = ScopeUsages.NewScope;
         }
 
         internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options)
@@ -32,8 +34,24 @@ namespace System.Management.Automation
         {
             ScriptBlock = function;
             Options = options;
+            ScopeUsage = ScopeUsages.NewScope;
         }
 
+        #region IScriptBlockInfo Members
+
+        public ScriptBlock ScriptBlock { get; private set; }
+        public ScopeUsages ScopeUsage { get; private set; }
+
+        public ReadOnlyCollection<ParameterAst> GetParameters()
+        {
+            var scriptBlockAst = (ScriptBlockAst)ScriptBlock.Ast;
+            if (scriptBlockAst.ParamBlock != null)
+                return scriptBlockAst.ParamBlock.Parameters;
+
+            return new ReadOnlyCollection<ParameterAst>(new List<ParameterAst>());
+        }
+
+        #endregion
 
         #region IScopedItem Members
 

--- a/Source/System.Management/Automation/Runspaces/Command.cs
+++ b/Source/System.Management/Automation/Runspaces/Command.cs
@@ -7,11 +7,10 @@ namespace System.Management.Automation.Runspaces
 {
     public sealed class Command
     {
-        internal readonly ScriptBlockAst ScriptBlockAst;
 
-        readonly string _commandText;
-        public string CommandText { get { return this._commandText; } }
+        internal ScriptBlockAst ScriptBlockAst { get; set; }
 
+        public string CommandText { get; private set; }
         public bool IsScript { get; private set; }
         public bool UseLocalScope { get; private set; }
 
@@ -31,9 +30,10 @@ namespace System.Management.Automation.Runspaces
         public Command(string command, bool isScript, bool useLocalScope)
             : this()
         {
-            _commandText = command;
+            CommandText = command;
             IsScript = isScript;
             UseLocalScope = useLocalScope;
+            ScriptBlockAst = null;
         }
 
         private Command()
@@ -43,10 +43,11 @@ namespace System.Management.Automation.Runspaces
             MergeToResult = PipelineResultTypes.None;
         }
 
-        internal Command(ScriptBlockAst scriptBlockAst)
+        internal Command(ScriptBlockAst scriptBlockAst, bool useLocalScope = false)
             : this()
         {
             this.ScriptBlockAst = scriptBlockAst;
+            this.UseLocalScope = useLocalScope;
             IsScript = false;
         }
 

--- a/Source/System.Management/Automation/Runspaces/CommandCollection.cs
+++ b/Source/System.Management/Automation/Runspaces/CommandCollection.cs
@@ -13,7 +13,7 @@ namespace System.Management.Automation.Runspaces
 
         public void AddScript(string scriptContents)
         {
-            Add(new Command(scriptContents, true));
+            AddScript(scriptContents, true); //per default a script runs in  its own scope
         }
 
         public void AddScript(string scriptContents, bool useLocalScope)

--- a/Source/System.Management/Automation/ScriptInfo.cs
+++ b/Source/System.Management/Automation/ScriptInfo.cs
@@ -1,27 +1,32 @@
-﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Management.Automation.Language;
+using Pash.Implementation;
+
 
 namespace System.Management.Automation
 {
-    public class ScriptInfo : CommandInfo
+
+    public class ScriptInfo : CommandInfo, IScriptBlockInfo
     {
         public override string Definition { get { return ScriptBlock.ToString(); } }
-        public ScriptBlock ScriptBlock { get; private set; }
 
-        public override string ToString() { return Definition; }
-
-        // internals
-        internal ScriptInfo(string name, ScriptBlock script)
+        internal ScriptInfo(string name, ScriptBlock script, ScopeUsages scopeUsage = ScopeUsages.NewScope)
             : base(name, CommandTypes.Script)
         {
             ScriptBlock = script;
+            ScopeUsage = scopeUsage;
         }
 
-        internal ReadOnlyCollection<ParameterAst> GetParameters()
+        #region IScriptBlockInfo Members
+
+        public ScriptBlock ScriptBlock { get; private set; }
+        public ScopeUsages ScopeUsage{ get; set; }
+
+        public ReadOnlyCollection<ParameterAst> GetParameters()
         {
             var scriptBlockAst = (ScriptBlockAst)ScriptBlock.Ast;
             if (scriptBlockAst.ParamBlock != null)
@@ -29,5 +34,9 @@ namespace System.Management.Automation
 
             return new ReadOnlyCollection<ParameterAst>(new List<ParameterAst>());
         }
+
+        #endregion
+
+        public override string ToString() { return Definition; }
     }
 }

--- a/Source/System.Management/Pash/Implementation/ExecutionContext.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionContext.cs
@@ -34,9 +34,13 @@ namespace Pash.Implementation
             SessionState = new SessionState(SessionStateGlobal);
         }
 
-        public ExecutionContext Clone(bool newScope = false)
+        public ExecutionContext Clone(ScopeUsages scopeUsage = ScopeUsages.CurrentScope)
         {
-            var sstate = newScope ? new SessionState(SessionState) : SessionState;
+            var sstate = (scopeUsage == ScopeUsages.CurrentScope) ? SessionState : new SessionState(SessionState);
+            if (scopeUsage == ScopeUsages.NewScriptScope)
+            {
+                sstate.IsScriptScope = true;
+            }
             var context = new ExecutionContext
             {
                 inputStreamReader = inputStreamReader,
@@ -49,13 +53,14 @@ namespace Pash.Implementation
                 SessionState = sstate
             };
 
-            // TODO: copy (not reference) all the variables to allow nested context
+            // TODO: copy (not reference) all the variables to allow nested context <- what does it mean?
 
             return context;
         }
 
         public ExecutionContext CreateNestedContext()
         {
+            //What's the purpose of this function?
             ExecutionContext nestedContext = Clone();
 
             //nestedContext.

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -33,7 +33,7 @@ namespace System.Management.Pash.Implementation
         ExecutionVisitor CloneSub(bool writeSideEffectsToPipeline)
         {
             return new ExecutionVisitor(
-                this._context.CreateNestedContext(),
+                this._context.CreateNestedContext(), //Why can't we just use the original context?
                 new PipelineCommandRuntime(this._pipelineCommandRuntime.pipelineProcessor),
                 writeSideEffectsToPipeline
                 );
@@ -233,10 +233,8 @@ namespace System.Management.Pash.Implementation
 
         public override AstVisitAction VisitCommand(CommandAst commandAst)
         {
-            if (commandAst.InvocationOperator == TokenKind.Dot)
-                return VisitDotSourceCommand(commandAst);
-
             // Pipeline uses global execution context, so we should set its WriteSideEffects flag, and restore it to previous value after.
+            //TODO: make sure this is still needed
             var pipeLineContext = _context.CurrentRunspace.ExecutionContext;
             bool writeSideEffects = pipeLineContext.WriteSideEffectsToPipeline;
             try
@@ -261,7 +259,7 @@ namespace System.Management.Pash.Implementation
                 {
                     // TODO: develop a rational model for null/singleton/collection
                     var result = pipeline.Invoke();
-                    if (result.Any())
+                    if (result != null && result.Any())
                     {
                         _pipelineCommandRuntime.WriteObject(result, true);
                     }
@@ -275,15 +273,6 @@ namespace System.Management.Pash.Implementation
             {
                 pipeLineContext.WriteSideEffectsToPipeline = writeSideEffects;
             }
-
-            return AstVisitAction.SkipChildren;
-        }
-
-        private AstVisitAction VisitDotSourceCommand(CommandAst commandAst)
-        {
-            object scriptFileName = EvaluateAst(commandAst.Children.First());
-            ScriptBlockAst ast = PowerShellGrammar.ParseInteractiveInput(File.ReadAllText(scriptFileName.ToString()));
-            ast.Visit(this);
 
             return AstVisitAction.SkipChildren;
         }
@@ -312,15 +301,34 @@ namespace System.Management.Pash.Implementation
 
         Command GetCommand(CommandAst commandAst)
         {
-            if (commandAst.CommandElements.First() is ScriptBlockExpressionAst)
+            var firstCommandElement = commandAst.CommandElements.First();
+            object command = null;
+            bool useLocalScope = commandAst.InvocationOperator != TokenKind.Dot;
+            if (firstCommandElement is ScriptBlockExpressionAst)
             {
-                var scriptBlockAst = (commandAst.CommandElements.First() as ScriptBlockExpressionAst).ScriptBlock;
-                return new Command(scriptBlockAst);
+                command = (firstCommandElement as ScriptBlockExpressionAst).ScriptBlock;
             }
-
-            else
+            else //otherwise we evaluate it and get the result
             {
-                return new Command(commandAst.GetCommandName());
+                command = EvaluateAst(firstCommandElement);
+                if (command is PSObject)
+                {
+                    command = (command as PSObject).BaseObject;
+                }
+            }
+            //if it's a script block, we are only interested in its Ast (which is indeed always a ScriptBlockAst)
+            if (command is ScriptBlock)
+            {
+                command = (command as ScriptBlock).Ast as ScriptBlockAst;
+            }
+            //let's check if we got something useful to execute
+            if (command is ScriptBlockAst)
+            {
+                return new Command(command as ScriptBlockAst, useLocalScope);
+            }
+            else //all other objects will converted as a string with ToString(). This is normal powershell behavior!
+            {
+                return new Command(command.ToString(), false, useLocalScope);
             }
         }
 
@@ -497,11 +505,7 @@ namespace System.Management.Pash.Implementation
 
         public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
         {
-            var functionInfo = new /*FunctionInfo*/ScriptInfo(functionDefinitionAst.Name, functionDefinitionAst.Body.GetScriptBlock());
-
-            // HACK: we shouldn't be casting this. But I'm too confused about runspace management in Pash.
-            ((LocalRunspace)this._context.CurrentRunspace).CommandManager.SetFunction(functionInfo);
-
+            _context.SessionState.Function.Set(functionDefinitionAst.Name, functionDefinitionAst.Body.GetScriptBlock());
             return AstVisitAction.SkipChildren;
         }
 

--- a/Source/System.Management/Pash/Implementation/IScriptBlockInfo.cs
+++ b/Source/System.Management/Pash/Implementation/IScriptBlockInfo.cs
@@ -1,0 +1,19 @@
+// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Management.Automation.Language;
+using System.Management.Automation;
+
+namespace Pash.Implementation
+{
+    internal interface IScriptBlockInfo
+    {
+        ScopeUsages ScopeUsage { get; }
+        ScriptBlock ScriptBlock { get; }
+        ReadOnlyCollection<ParameterAst> GetParameters();
+    }
+}
+
+

--- a/Source/System.Management/Pash/Implementation/LocalPipeline.cs
+++ b/Source/System.Management/Pash/Implementation/LocalPipeline.cs
@@ -34,7 +34,7 @@ namespace Pash.Implementation
             _pipelineStateInfo = new PipelineStateInfo(PipelineState.NotStarted);
 
             if (!string.IsNullOrEmpty(command))
-                Commands.Add(command);
+                Commands.AddScript(command, false);
         }
 
         protected override void Dispose(bool disposing)
@@ -112,6 +112,7 @@ namespace Pash.Implementation
 
             SetPipelineState(PipelineState.NotStarted);
 
+            //why do we clone the execution context?
             ExecutionContext context = _runspace.ExecutionContext.Clone();
             RerouteExecutionContext(context);
 

--- a/Source/System.Management/Pash/Implementation/LocalRunspace.cs
+++ b/Source/System.Management/Pash/Implementation/LocalRunspace.cs
@@ -134,7 +134,7 @@ namespace Pash.Implementation
         #region OpenXXX Runspace
         public override void Open()
         {
-            CommandManager = new CommandManager(ExecutionContext);
+            CommandManager = new CommandManager(this);
             InitializeSession();
             InitializeProviders();
         }

--- a/Source/System.Management/Pash/Implementation/ScopeUsages.cs
+++ b/Source/System.Management/Pash/Implementation/ScopeUsages.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Pash.Implementation
+{
+    public enum ScopeUsages
+    {
+        CurrentScope,
+        NewScope,
+        NewScriptScope
+    }
+}
+

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -354,7 +354,6 @@
     <Compile Include="Automation\RuntimeException.cs" />
     <Compile Include="Automation\ScopedItemOptions.cs" />
     <Compile Include="Automation\ScriptBlock.cs" />
-    <Compile Include="Automation\ScriptInfo.cs" />
     <Compile Include="Automation\SecurityDescriptorCmdletProviderIntrinsics.cs" />
     <Compile Include="Automation\SessionCapabilities.cs" />
     <Compile Include="Automation\SessionState.cs" />
@@ -444,7 +443,6 @@
     <Compile Include="Pash\Implementation\PipelineProcessor.cs" />
     <Compile Include="Pash\Implementation\ProviderRuntime.cs" />
     <Compile Include="Pash\Implementation\PSObjectPipelineReader.cs" />
-    <Compile Include="Pash\Implementation\ScriptProcessor.cs" />
     <Compile Include="Pash\Implementation\SessionStateGlobal.cs" />
     <Compile Include="Pash\ParserIntrinsics\AstBuilder.cs" />
     <Compile Include="Pash\ParserIntrinsics\BacktickLineContinuationTerminal.cs" />
@@ -467,6 +465,10 @@
     <Compile Include="Pash\Implementation\AliasIntrinsics.cs" />
     <Compile Include="Pash\Implementation\FunctionIntrinsics.cs" />
     <Compile Include="Pash\Implementation\IScopedItem.cs" />
+    <Compile Include="Pash\Implementation\ScriptBlockProcessor.cs" />
+    <Compile Include="Automation\ScriptInfo.cs" />
+    <Compile Include="Pash\Implementation\IScriptBlockInfo.cs" />
+    <Compile Include="Pash\Implementation\ScopeUsages.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/TestHost/DotSourceTests.cs
+++ b/Source/TestHost/DotSourceTests.cs
@@ -100,5 +100,39 @@ namespace TestHost
 
             Assert.AreEqual(result, string.Format("script output{0}", Environment.NewLine));
         }
+
+        [Test]
+        public void DotSourceScriptBlockVariableTest()
+        {
+            string statement = "$a=0; Write-Host $a; . { $a = 10; Write-Host $a }; Write-Host $a;";
+            string result = TestHost.Execute(statement);
+            string expected = String.Join(Environment.NewLine, new string[] { "0", "10", "10" }) + Environment.NewLine;
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void DotSourceVariableScriptBlockVariableTest()
+        {
+            string statement = "$a=0; Write-Host $a; $b = { $a = 10; Write-Host $a }; . $b; Write-Host $a;";
+            string result = TestHost.Execute(statement);
+            string expected = String.Join(Environment.NewLine, new string[] { "0", "10", "10" }) + Environment.NewLine;
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void DotSourceOverwriteFunctionTest()
+        {
+            string fileName = CreateScript("function foo { Write-Host 'bar' };");
+            string result = TestHost.Execute(
+                "function foo { Write-Host 'foo' }",
+                "foo;", //prints "foo"
+                string.Format("$fileName = '{0}'", fileName),
+                ". $fileName",
+                "foo;" //was overwritten and prints now "bar"
+            );
+            string expected = String.Join(Environment.NewLine, new string[] { "foo", "bar" }) + Environment.NewLine;
+
+            Assert.AreEqual(expected, result);
+        }
     }
 }

--- a/Source/TestHost/ScopeTests.cs
+++ b/Source/TestHost/ScopeTests.cs
@@ -1,0 +1,162 @@
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace TestHost
+{
+    [TestFixture]
+    public class ScopeTests
+    {
+        public ScopeTests()
+        {
+        }
+
+        [TearDown]
+        public void RemoveScriptFile()
+        {
+            File.Delete(GetScriptFileName());
+        }
+
+        private string formatLines(string[] lines)
+        {
+            return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+        }
+
+        private string GetScriptFileName()
+        {
+            string directory = Path.GetDirectoryName(typeof(ScopeTests).Assembly.Location);
+            return Path.Combine(directory, "ScopeTests.ps1");
+        }
+
+        private string CreateScript(string script)
+        {
+            string fileName = GetScriptFileName();
+            File.WriteAllText(fileName, script);
+
+            return fileName;
+        }
+
+        [Test]
+        public void ScriptBlockVariableTest()
+        {
+            string statement = "$a=0; Write-Host $a; & { $a = 10; Write-Host $a }; Write-Host $a;";
+            string result = TestHost.Execute(statement);
+            Assert.AreEqual(formatLines(new string[] {"0", "10", "0"}), result);
+        }
+
+        [Test]
+        public void DotSourceScriptBlockVariableTest()
+        {
+            string statement = "$a=0; Write-Host $a; . { $a = 10; Write-Host $a }; Write-Host $a;";
+            string result = TestHost.Execute(statement);
+            Assert.AreEqual(formatLines(new string[] {"0", "10", "10"}), result);
+        }
+
+        //the following test corresponds to the VariableAccessTest, but with user input instead of using the internals
+        [TestCase("x", "f")] //correct x is fetched in general (from function scope)
+        [TestCase("local:x", null, Explicit = true)] //local scope has no variable x
+        [TestCase("script:x", null, Explicit = true)] //sx is private in the script scope
+        [TestCase("global:x", "g")]
+        [TestCase("y", "l")] //the overridden y in the local scope
+        [TestCase("local:y", "l")] //also the local one, but explicitly
+        [TestCase("script:y", "s")]
+        [TestCase("global:y", "g")]
+        [TestCase("z", "s")] //ignores the private z in function scope
+        public void ComplexVariableScopeTest(string varname, string expected)
+        {
+            string script = CreateScript(formatLines(new string[] {
+                "$private:x = \"s\";",
+                "$y=\"s\";",
+                "$z=\"s\";",
+                "function foo",
+                "{",
+                "  $x=\"f\";",
+                "  $y=\"f\";",
+                "  $private:z=\"f\";",
+                "  & {",
+                "      $y=\"l\";",
+                String.Format("Write-Host ${0};", varname),
+                "  };",
+                "};",
+                "foo"
+            }));
+
+            string statement = formatLines(new string[] {
+                "$x=\"g\";",
+                "$y=\"g\";",
+                String.Format("& '{0}';", script)
+            });
+            string result = TestHost.Execute(statement);
+            Assert.AreEqual(expected + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ExecuteScriptBlockInNewScopeTest()
+        {
+            string statement = "$a=0; Write-Host $a; & { $a = 10; Write-Host $a }; Write-Host $a;";
+            string result = TestHost.Execute(statement);
+            Assert.AreEqual(formatLines(new string[] {"0", "10", "0"}), result);
+        }
+
+        [Test]
+        public void FunctionScopeTest()
+        {
+            string script = CreateScript(formatLines(new string[] {
+                "function foo { Write-Host 'sfoo'; };",
+                "function bar { Write-Host 'sbar'; };",
+                "function private:baz { Write-Host 'sbaz'; };",
+                " & {",
+                "   function bar { Write-Host 'lbar'; };",
+                "   bar; script:bar; global:bar;", //prints "lbar", "sbar", "gbar"
+                "   baz;", //prints "gbaz", because script baz is private
+                "   foo;", //"prints sfoo"
+                " };",
+                "foo; bar; baz;" //prints "sfoo", "sbar", "sbaz"
+            }));
+            var statement = formatLines(new string[] {
+                "function foo { Write-Host 'gfoo'; };",
+                "function bar { Write-Host 'gbar'; };",
+                "function baz { Write-Host 'gbaz'; };",
+                String.Format("& '{0}';", script),
+                "foo; bar; baz;" //prints "gfoo", "gbar", "gbaz"
+            });
+            string expected = formatLines(new string[] {
+                "lbar", "sbar", "gbar",
+                "gbaz",
+                "sfoo",
+                "sfoo", "sbar", "sbaz",
+                "gfoo", "gbar", "gbaz"
+            });
+            Assert.AreEqual(expected, TestHost.Execute(statement));
+        }
+
+        [Test]
+        public void FunctionOverwriteScopeTest()
+        {
+            string script = CreateScript(formatLines(new string[] {
+                "function global:foo { Write-Host 'sfoo'; };",
+                "function bar { Write-Host 'sbar'; };",
+                "bar;", //prints "sbar"
+                " & {",
+                "  function script:bar { Write-Host 'lbar'; };", //ovewrites script's bar function
+                "};",
+                "bar;" //prints "lbar" now
+            }));
+            var statement = formatLines(new string[] {
+                "function foo { Write-Host 'gfoo'; };",
+                "function bar { Write-Host 'gbar'; };",
+                "foo; bar;", //prints "gfoo", "gbar"
+                String.Format("& '{0}';", script),
+                "foo; bar;", //prints "sfoo", "gbar"
+            });
+            string expected = formatLines(new string[] {
+                "gfoo", "gbar",
+                "sbar",
+                "lbar",
+                "sfoo", "gbar"
+            });
+            Assert.AreEqual(expected, TestHost.Execute(statement));
+        }
+    }
+}
+

--- a/Source/TestHost/SessionStateScopeTests.cs
+++ b/Source/TestHost/SessionStateScopeTests.cs
@@ -43,7 +43,7 @@ namespace TestHost
             states.Add(AvailableStates.Function, functionState);
             states.Add(AvailableStates.Local, localState);
 
-            hostCommandManager = new CommandManager(hostRunspace.ExecutionContext);
+            hostCommandManager = new CommandManager(hostRunspace as LocalRunspace);
         }
 
         #region general scope related

--- a/Source/TestHost/TestHost.cs
+++ b/Source/TestHost/TestHost.cs
@@ -57,7 +57,7 @@ namespace TestHost
             {
                 using (var currentPipeline = myRunSpace.CreatePipeline())
                 {
-                    currentPipeline.Commands.Add(statement);
+                    currentPipeline.Commands.AddScript(statement, false);
                     currentPipeline.Commands.Add("Out-Default");
                     currentPipeline.Invoke();
                 }

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -98,7 +98,8 @@
     <Compile Include="FileSystemTests\FileSystemTestBaseTests.cs" />
     <Compile Include="FileSystemTests\FileSystemNavigationTests.cs" />
     <Compile Include="System.Management\PathNavigationTests.cs" />
-    <Compile Include="SessionStateScopeTests.cs" />  
+    <Compile Include="SessionStateScopeTests.cs" />
+    <Compile Include="ScopeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Management\Microsoft.Commands.Management.csproj">

--- a/Source/TestHost/Tests.cs
+++ b/Source/TestHost/Tests.cs
@@ -276,7 +276,7 @@ namespace TestHost
             // notice typo
             var result = TestHost.ExecuteWithZeroErrors("Get-ChlidItem");
 
-            Assert.AreEqual("Exception: Command 'Get-ChlidItem' not found.", result);
+            Assert.AreEqual("CommandNotFoundException: Command 'Get-ChlidItem' not found.", result);
         }
 
         [Test]


### PR DESCRIPTION
As the last major step of the scope integration, the command invocation methods were
updated in order to use the new scope architecture. Main changes:
- Pash distinguishes correctly between scripts, functions, and script blocks.
- The ScriptProcessor is now a more general ScriptBlockProcessor that is able to
  process all script-block-like structures (functions, scripts, and script-blocks)
- Depending on invocation method and type, Pash creates new scopes if needed
  and updates the runspace's execution context if a command is (temporarily)
  executed in a new scope. Therefore the CommandManager depends on the
  Runspace, as it needs access to the currently active scope.
- The dot-sourcing implementation was fixed to work correctly. It only supported
  scripts so far. Now dot-sourcing and ampersand invocation work with scripts,
  script blocks, expression resulting in a script name and script blocks stored
  in variables.
- There are new "end-to-end" unit tests that assure scopes work as intended for
  variables and functions
- The way commands are parsed, found and executed changed in order to be easier,
  less redundant and more straight-forward to understand.
  A "command" is now a real command, i.e. one specific word. So Pash strongly
  distiguishes between input, which needs to be parsed, and commands, that
  are searched and processed. Parsable input is a Command with the IsScript flag,
  which is also the desired behavior of the specification, while real commands
  set this flag to false.
  As a result Pash doesn't just try to parse the CommandText, if it didn't find a
  command, but knows exactly when to parse input and when to search for a command.

With these changes, Pash fully supports scopes.
