### PR TITLE
Undefined variables evaluate to null

### DIFF
--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -424,7 +424,8 @@ namespace System.Management.Pash.Implementation
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
             var variable = GetVariable(variableExpressionAst);
-            this._pipelineCommandRuntime.WriteObject(variable.Value, true);
+            var value = (variable != null) ? variable.Value : null;
+            this._pipelineCommandRuntime.WriteObject(value, true);
 
             return AstVisitAction.SkipChildren;
         }

--- a/Source/TestHost/Tests.cs
+++ b/Source/TestHost/Tests.cs
@@ -649,6 +649,13 @@ namespace TestHost
             StringAssert.AreEqualIgnoringCase(expected + Environment.NewLine, result);
         }
 
+        [Test]
+        public void UndefinedVariableIsNull()
+        {
+            var result = TestHost.Execute("$a -eq $null");
+            Assert.AreEqual("True" + Environment.NewLine, result);
+        }
+
         [TestFixture]
         class ThrowTests
         {


### PR DESCRIPTION
Undefined variables always caused a NullReferenceException.
However, this is not the standard behavior of powershell, which can lead
to problems. Therefore, as in powershell, undefined variables will
evaluate to null if they are used in a normal expression.
