### PR TITLE
Introduced Exit and Return Management

### DIFF
--- a/PowershellReferenceTests/PowershellReferenceTests.csproj
+++ b/PowershellReferenceTests/PowershellReferenceTests.csproj
@@ -49,6 +49,9 @@
     <Compile Include="..\Source\ReferenceTests\CmdletParameterTests.cs">
       <Link>CmdletParameterTests.cs</Link>
     </Compile>
+    <Compile Include="..\Source\ReferenceTests\ExitTests.cs">
+      <Link>ExitTests.cs</Link>
+    </Compile>
     <Compile Include="..\Source\ReferenceTests\PipelineExecutionTests.cs">
       <Link>PipelineExecutionTests.cs</Link>
     </Compile>
@@ -58,10 +61,14 @@
     <Compile Include="..\Source\ReferenceTests\ReferenceTestBase.cs">
       <Link>ReferenceTestBase.cs</Link>
     </Compile>
+    <Compile Include="..\Source\ReferenceTests\ReturnTests.cs">
+      <Link>ReturnTests.cs</Link>
+    </Compile>
     <Compile Include="..\Source\TestPSSnapIn\TestCommands.cs">
       <Link>TestCommands.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReferenceTestInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/PowershellReferenceTests/ReferenceTestInfo.cs
+++ b/PowershellReferenceTests/ReferenceTestInfo.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ReferenceTests
+{
+    static class ReferenceTestInfo
+    {
+        public const string SHELL_NAME = "Windows Powershell";
+        public const string SHELL_EXECUTABLE = "powershell";
+        public const bool IS_PASH = false;
+    }
+}

--- a/Source/PashConsole/Program.cs
+++ b/Source/PashConsole/Program.cs
@@ -35,8 +35,8 @@ namespace Pash
                 commands.Append("; ");
             }
 
-            FullHost p = new FullHost();
-            return p.Run(interactive, commands.ToString());
+            FullHost p = new FullHost(interactive);
+            return p.Run(commands.ToString());
         }
     }
 }

--- a/Source/PashConsole/Properties/AssemblyInfo.cs
+++ b/Source/PashConsole/Properties/AssemblyInfo.cs
@@ -38,3 +38,4 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("TestHost")]
 [assembly: InternalsVisibleTo("PashConsole.Tests")]
+[assembly: InternalsVisibleTo("ReferenceTests")]

--- a/Source/ReferenceTests/ExitTests.cs
+++ b/Source/ReferenceTests/ExitTests.cs
@@ -1,0 +1,148 @@
+// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using NUnit.Framework;
+
+namespace ReferenceTests
+{
+    [TestFixture]
+    public class ExitTests : ReferenceTestBase
+    {
+        [TearDown]
+        public void Cleanup()
+        {
+            RemoveCreatedScripts();
+        }
+
+        [Test]
+        public void ExitWorks()
+        {
+            Assert.DoesNotThrow(
+                delegate() { ReferenceHost.Execute("exit 4"); }
+            );
+        }
+
+        [Test]
+        public void ExitInterruptsCommands()
+        {
+            var result = ReferenceHost.Execute("'foo'; exit 4; 'bar'");
+            Assert.AreEqual("foo" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ExitInScriptOnlyEndsScript()
+        {
+            var scriptname = CreateScript(NewlineJoin(new[] {
+                "'foo'",
+                "exit 4",
+                "'bar'"
+            }));
+            var command = NewlineJoin(new[] {
+                String.Format(". '{0}'", scriptname),
+                "$LastExitCode"
+            });
+            var expected = NewlineJoin(new[] { "foo", "4" });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("0", "'some string'")]
+        [TestCase("8", "4 + 4")]
+        [TestCase("3", "& { 3 }")]
+        public void ExpressionsAreValidExitCodes(string expectedExitCode, string exitExpression)
+        {
+            var scriptname = CreateScript(NewlineJoin(new[] {
+                "exit " + exitExpression
+            }));
+            var command = NewlineJoin(new[] {
+                String.Format(". '{0}'", scriptname),
+                "$LastExitCode"
+            });
+            var expected = NewlineJoin(new[] { expectedExitCode });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("False", "-1", true)]
+        [TestCase("True", "0", true)]
+        [TestCase("False", "92", true)]
+        [TestCase("True", "'some string'", false)]
+        public void ExitCodeDefinesSuccess(string success, string exitCode, bool exitCodeValid)
+        {
+            var scriptname = CreateScript(NewlineJoin(new[] {
+                "exit " + exitCode
+            }));
+            var command = NewlineJoin(new[] {
+                String.Format(". '{0}'", scriptname),
+                "$?",
+                "$LastExitCode"
+            });
+            var expected = NewlineJoin(new[] { success, exitCodeValid ? exitCode : "0" });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ScriptWithoutExitIsSuccessfull()
+        {
+            var scriptname = CreateScript(NewlineJoin(new[] {
+                "'foo'"
+            }));
+            var command = NewlineJoin(new[] {
+                String.Format(". '{0}'", scriptname),
+                "$?",
+                "$LastExitCode"
+            });
+            var expected = NewlineJoin(new[] { "foo", "True", "" });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test, Explicit("Pipeline on-demand processing doesn't work")]
+        public void ExitInScriptBlockExitsCompletely()
+        {
+            var command = NewlineJoin(new[] {
+                "'foo'",
+                "& { 'bar'; exit; 'baz'; }",
+                "'blub'"
+            });
+            var expected = NewlineJoin(new[] { "foo", "bar" });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test, Explicit("Pipeline on-demand processing doesn't work")]
+        public void ExitInFunctionExitsCompletely()
+        {
+            var command = NewlineJoin(new[] {
+                "function testfun { 'bar'; exit; 'baz'; }",
+                "'foo'",
+                "testfun",
+                "'blub'"
+            });
+            var expected = NewlineJoin(new[] { "foo", "bar" });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ExitCodeIsProcessExitCode()
+        {
+            var process = CreatePowershellOrPashProcess("exit 5");
+            Assert.True(process.Start());
+            FinishProcess(process);
+            Assert.AreEqual(5, process.ExitCode);
+        }
+
+        [Test, Explicit("Pipeline on-demand processing doesn't work")]
+        public void ProcessExistsAndPrintsFirst()
+        {
+            var process = CreatePowershellOrPashProcess("'foo'; & { exit 5; 'bar'; }; 'baz'");
+            Assert.True(process.Start());
+            var expectedOutput = NewlineJoin(new[] { "foo" });
+            var output = FinishProcess(process);
+            Assert.AreEqual(5, process.ExitCode);
+            Assert.AreEqual(expectedOutput, output);
+        }
+    }
+}
+

--- a/Source/ReferenceTests/PipelineExecutionTests.cs
+++ b/Source/ReferenceTests/PipelineExecutionTests.cs
@@ -28,7 +28,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestCmdletPhasesCommand));
             var res = ReferenceHost.Execute(cmd);
-            var expected = OutputString(new string[] { "Begin", "Process", "End" });
+            var expected = NewlineJoin(new string[] { "Begin", "Process", "End" });
             Assert.AreEqual(expected, res);
         }
 
@@ -37,7 +37,7 @@ namespace ReferenceTests
         {
             var cmd = "$null | " + CmdletName(typeof(TestCmdletPhasesCommand));
             var res = ReferenceHost.Execute(cmd);
-            var expected = OutputString(new string[] { "Begin", "Process", "End" });
+            var expected = NewlineJoin(new string[] { "Begin", "Process", "End" });
             Assert.AreEqual(expected, res);
         }
 
@@ -46,9 +46,18 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestDummyCommand)) + " | " + CmdletName(typeof(TestCmdletPhasesCommand));
             var res = ReferenceHost.Execute(cmd);
-            var expected = OutputString(new string[] { "Begin", "End" });
+            var expected = NewlineJoin(new string[] { "Begin", "End" });
             Assert.AreEqual(expected, res);
         }
+
+        [Test]
+        public void MultipleObjectsAsPipelineCommandScriptsReturnLastObject()
+        {
+            var expected = NewlineJoin(new string[] { "bar" });
+            var result = ReferenceHost.Execute(new [] { "'foo'", "'bar'" });
+            Assert.AreEqual(expected, result);
+        }
+
     }
 }
 

--- a/Source/ReferenceTests/ReferenceHost.cs
+++ b/Source/ReferenceTests/ReferenceHost.cs
@@ -31,7 +31,7 @@ namespace ReferenceTests
             {
                 foreach (var command in commands)
                 {
-                    pipeline.Commands.AddScript(command, false);
+                    pipeline.Commands.AddScript(command, true);
                 }
                 results = pipeline.Invoke();
                 if (pipeline.Error.Count > 0)

--- a/Source/ReferenceTests/ReferenceTestBase.cs
+++ b/Source/ReferenceTests/ReferenceTestBase.cs
@@ -1,11 +1,106 @@
 // Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Management.Automation;
+using System.Text.RegularExpressions;
 
 namespace ReferenceTests
 {
     public class ReferenceTestBase
     {
+        private List<string> _createdScripts;
+        private string _assemblyDirectory;
+        private Regex _whiteSpaceRegex;
+        private bool _isMonoRuntime;
+
+        public ReferenceTestBase()
+        {
+            _createdScripts = new List<string>();
+            _assemblyDirectory = Path.GetDirectoryName(new Uri(GetType().Assembly.CodeBase).LocalPath);
+            _whiteSpaceRegex = new Regex(@"\s");
+            _isMonoRuntime = ReferenceTestInfo.IS_PASH && Type.GetType("Mono.Runtime") != null;
+        }
+
+        private String QuoteWithSpace(string input)
+        {
+            if (_whiteSpaceRegex.IsMatch(input))
+            {
+                return String.Format(@"""{0}""", input);
+            }
+            return input;
+        }
+
+        private Process CreateDotNetProcess(string command, params string[] args)
+        {
+            string realCmd = null;
+            List<string> realArgs = new List<string>();
+            if (_isMonoRuntime)
+            {
+                realCmd = "mono";
+                realArgs.Add(QuoteWithSpace(command));
+            }
+            else
+            {
+                realCmd = command;
+            }
+
+            foreach (var arg in args)
+            {
+                realArgs.Add(QuoteWithSpace(arg));
+            }
+            var process = new Process();
+            process.StartInfo.FileName = realCmd;
+            process.StartInfo.Arguments = String.Join(" ", realArgs);
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardInput = true;
+            return process;
+        }
+
+        public Process CreatePowershellOrPashProcess(params string[] args)
+        {
+            // NOTE: make sure when using functions with "args", that the arguments
+            // only use *SINGLE* quotes itself
+
+            return CreateDotNetProcess(ReferenceTestInfo.SHELL_EXECUTABLE, args);
+        }
+
+        public string FinishProcess(Process process, bool closeInput = true)
+        {
+            if (closeInput)
+            {
+                process.StandardInput.Flush();
+                process.StandardInput.Close();
+            }
+            var output = process.StandardOutput.ReadToEnd();
+            if (!process.WaitForExit(3000))
+            {
+                process.Kill();
+                throw new Exception(ReferenceTestInfo.SHELL_NAME + " didn't exit");
+            }
+            return output;
+        }
+
+        public string CreateScript(string script)
+        {
+            string fileName = Path.Combine(_assemblyDirectory, String.Format("TempScript{0}.ps1", _createdScripts.Count));
+            File.WriteAllText(fileName, script);
+            _createdScripts.Add(fileName);
+
+            return fileName;
+        }
+
+        public void RemoveCreatedScripts()
+        {
+            foreach (var file in _createdScripts)
+            {
+                File.Delete(file);
+            }
+            _createdScripts.Clear();
+        }
 
         public static string CmdletName(Type cmdletType)
         {
@@ -14,7 +109,7 @@ namespace ReferenceTests
             return string.Format("{0}-{1}", attribute.VerbName, attribute.NounName);
         }
 
-        public static string OutputString(string[] parts)
+        public static string NewlineJoin(string[] parts)
         {
             return String.Join(Environment.NewLine, parts) + Environment.NewLine;
         }

--- a/Source/ReferenceTests/ReferenceTestInfo.cs
+++ b/Source/ReferenceTests/ReferenceTestInfo.cs
@@ -1,0 +1,18 @@
+// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Management.Automation;
+using System.Text.RegularExpressions;
+
+namespace ReferenceTests
+{
+    class ReferenceTestInfo
+    {
+        public const string SHELL_NAME = "Pash";
+        public static string SHELL_EXECUTABLE = new Uri(typeof(Pash.Program).Assembly.CodeBase).LocalPath;
+        public const bool IS_PASH = true;
+    }
+}
+

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -49,6 +49,9 @@
     <Compile Include="ReferenceHost.cs" />
     <Compile Include="PipelineExecutionTests.cs" />
     <Compile Include="ReferenceTestBase.cs" />
+    <Compile Include="ExitTests.cs" />
+    <Compile Include="ReferenceTestInfo.cs" />
+    <Compile Include="ReturnTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">
@@ -70,6 +73,10 @@
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Utility\Microsoft.PowerShell.Commands.Utility.csproj">
       <Project>{0E1D573C-C57D-4A83-A739-3A38E719D87E}</Project>
       <Name>Microsoft.PowerShell.Commands.Utility</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\PashConsole\PashConsole.csproj">
+      <Project>{BB348EAD-1713-4760-9953-BC721A203885}</Project>
+      <Name>PashConsole</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/ReferenceTests/ReturnTests.cs
+++ b/Source/ReferenceTests/ReturnTests.cs
@@ -1,0 +1,77 @@
+using System;
+using NUnit.Framework;
+
+namespace ReferenceTests
+{
+    [TestFixture]
+    public class ReturnTests : ReferenceTestBase
+    {
+        [TearDown]
+        public void Cleanup()
+        {
+            RemoveCreatedScripts();
+        }
+
+        [Test]
+        public void ReturnWritesToPipeline()
+        {
+            var expected = "foobar" + Environment.NewLine;
+            var result = ReferenceHost.Execute("return 'foobar'");
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ReturnEndsScriptBlockAndWritesToPipeline()
+        {
+            var expected = NewlineJoin(new [] { "foo", "bar", "bla" });
+            var command = NewlineJoin(new [] {
+                "'foo'",
+                "& { return 'bar'; 'baz' }",
+                "'bla'"
+            });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ReturnEndsFunctionAndWritesToPipeline()
+        {
+            var expected = NewlineJoin(new [] { "foo", "bar", "bla" });
+            var command = NewlineJoin(new [] {
+                "function testfun { 'foo'; return 'bar'; 'baz' }",
+                "testfun",
+                "'bla'"
+            });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ReturnEndsScriptAndWritesToPipeline()
+        {
+            var expected = NewlineJoin(new [] { "foo", "bar", "bla" });
+            var scriptname = CreateScript("'foo'; return 'bar'; 'baz'");
+            var command = NewlineJoin(new [] {
+                String.Format("& '{0}'", scriptname),
+                "'bla'"
+            });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("5", "3 + 2")]
+        [TestCase("abcd", "& { return 'abcd' }")]
+        [TestCase("TESTVALUE", "$testvar")]
+        public void ReturnEvaluatesExpression(string returnValue, string returnExpression)
+        {
+            var expected = NewlineJoin(new [] { "foo", returnValue, "bla" });
+            var command = NewlineJoin(new [] {
+                "& { $testvar = 'TESTVALUE'; 'foo'; return " + returnExpression + "; 'baz' }",
+                "'bla'"
+            });
+            var result = ReferenceHost.Execute(command);
+            Assert.AreEqual(expected, result);
+        }
+    }
+}
+

--- a/Source/System.Management/Automation/CommandInvocationIntrinsics.cs
+++ b/Source/System.Management/Automation/CommandInvocationIntrinsics.cs
@@ -41,6 +41,7 @@ namespace System.Management.Automation
             {
                 ScriptBlock scriptBlock = NewScriptBlock(script);
                 var executionVisitor = new ExecutionVisitor(context, commandRuntime);
+                // sburnicki - handle ExitException
                 scriptBlock.Ast.Visit(executionVisitor);
             }
             finally //make sure we set back the old execution context, no matter what happened

--- a/Source/System.Management/Automation/ExternalScriptInfo.cs
+++ b/Source/System.Management/Automation/ExternalScriptInfo.cs
@@ -4,14 +4,34 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
+using Pash.Implementation;
+using System.Management.Automation.Language;
+using System.Collections.Generic;
+using Pash.ParserIntrinsics;
 
 namespace System.Management.Automation
 {
     /// <summary>
     /// Provides information on scripts executable by Pash but are external to it.
     /// </summary>
-    public class ExternalScriptInfo : CommandInfo
+    public class ExternalScriptInfo : CommandInfo, IScriptBlockInfo
     {
+        private ScriptBlock _scriptBlock;
+        private string _scriptContents;
+
+        public string Path { get; private set; }
+        public string ScriptContents
+        {
+            get
+            {
+                if (_scriptContents == null)
+                {
+                    _scriptContents = File.ReadAllText(Path);
+                }
+                return _scriptContents;
+            }
+        }
+
         public override string Definition
         {
             get
@@ -20,7 +40,43 @@ namespace System.Management.Automation
             }
         }
 
-        public string Path { get; private set; }
+        internal ExternalScriptInfo(string path, ScopeUsages scopeUsage = ScopeUsages.NewScope)
+            : base(path, CommandTypes.ExternalScript)
+        {
+            Path = path;
+            ScopeUsage = scopeUsage;
+            _scriptContents = null;
+            _scriptBlock = null;
+        }
+
+        #region IScriptBlockInfo Members
+
+        public ScriptBlock ScriptBlock
+        {
+            get
+            {
+                if (_scriptBlock == null)
+                {
+                    _scriptBlock = PowerShellGrammar.ParseInteractiveInput(ScriptContents).GetScriptBlock();
+                }
+                return _scriptBlock;
+            }
+        }
+
+        public ScopeUsages ScopeUsage{ get; set; }
+
+        public ReadOnlyCollection<ParameterAst> GetParameters()
+        {
+            var scriptBlockAst = (ScriptBlockAst)ScriptBlock.Ast;
+            if (scriptBlockAst.ParamBlock != null)
+                return scriptBlockAst.ParamBlock.Parameters;
+
+            return new ReadOnlyCollection<ParameterAst>(new List<ParameterAst>());
+        }
+
+        #endregion
+
+        public override string ToString() { return Definition; }
     }
 }
 

--- a/Source/System.Management/Pash/Implementation/CommandManager.cs
+++ b/Source/System.Management/Pash/Implementation/CommandManager.cs
@@ -123,6 +123,7 @@ namespace Pash.Implementation
                     return new CommandProcessor(commandInfo as CmdletInfo);
 
                 case CommandTypes.Script:
+                case CommandTypes.ExternalScript:
                 case CommandTypes.Function:
                     return new ScriptBlockProcessor(commandInfo as IScriptBlockInfo, commandInfo);
                 default:
@@ -161,15 +162,7 @@ namespace Pash.Implementation
             }
             if (Path.GetExtension(path) == ".ps1")
             {
-                // TODO: this should be an ExternalScriptInfo object, not ScriptInfo
-                // I don't feel very well about how this is handled atm.
-                // I think we should be using a ScriptFile parser, but this will do for now.
-                
-                var scriptBlockAst = PowerShellGrammar.ParseInteractiveInput(File.ReadAllText(path));
-                //notice that we have an external script here. This means we create either a new *script*scope
-                //or run it in the currrent one
-                return new ScriptInfo(path, new ScriptBlock(scriptBlockAst),
-                                            useLocalScope ? ScopeUsages.NewScriptScope : ScopeUsages.CurrentScope);
+                return new ExternalScriptInfo(path, useLocalScope ? ScopeUsages.NewScriptScope : ScopeUsages.CurrentScope);
             }
             //otherwise it's an application
             return new ApplicationInfo(Path.GetFileName(path), path, Path.GetExtension(path));

--- a/Source/System.Management/Pash/Implementation/CommandProcessor.cs
+++ b/Source/System.Management/Pash/Implementation/CommandProcessor.cs
@@ -65,7 +65,7 @@ namespace System.Management.Automation
             var inputObjects = CommandRuntime.InputStream.Read();
             foreach (var curInput in inputObjects)
             {
-                // TODO: sburnicki - determine the correct second argument
+                // TODO: determine the correct second arg: true if this commandProcessor is the first command in pipeline
                 _argumentBinder.BindPipelineParameters(curInput, true);
                 Command.DoProcessRecord();
             }
@@ -78,6 +78,7 @@ namespace System.Management.Automation
         public override void EndProcessing()
         {
             Command.DoEndProcessing();
+            ExecutionContext.SetVariable("global:?", true); // only false if we got an exception
         }
 
         /// <summary>

--- a/Source/System.Management/Pash/Implementation/ExecutionContext.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionContext.cs
@@ -128,7 +128,11 @@ namespace Pash.Implementation
                 // TODO: this should never happen as the variable is const. but anyway
                 return;
             }
-            records.Insert(0, errorRecord);
+            // make sure it's not added multiple times (e.g. *same* exception thrown through multiple nested pipelines)
+            if (!records.Contains(errorRecord))
+            {
+                records.Insert(0, errorRecord);
+            }
         }
     }
 }

--- a/Source/System.Management/Pash/Implementation/ExitException.cs
+++ b/Source/System.Management/Pash/Implementation/ExitException.cs
@@ -1,0 +1,15 @@
+// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+
+namespace System.Management.Pash.Implementation
+{
+    public class ExitException : Exception
+    {
+        public int ExitCode { get; private set; }
+        public ExitException(int exitCode)
+        {
+            ExitCode = exitCode;
+        }
+    }
+}
+

--- a/Source/System.Management/Pash/Implementation/LocalRunspace.cs
+++ b/Source/System.Management/Pash/Implementation/LocalRunspace.cs
@@ -79,12 +79,6 @@ namespace Pash.Implementation
         // unusued - NYI
         public override event EventHandler<RunspaceStateEventArgs> StateChanged = delegate { };
 
-        public override Pipeline CreateNestedPipeline()
-        {
-            // TODO: make sure to fail if not Open
-            return CreatePipeline();
-        }
-
         internal override SessionStateProxy GetSessionStateProxy()
         {
             return new SessionStateProxy(this);
@@ -107,10 +101,16 @@ namespace Pash.Implementation
         }
 
         #region CreateXXX Pipeline
+
+        public override Pipeline CreateNestedPipeline()
+        {
+            return CreateNestedPipeline("", false);
+        }
+
         public override Pipeline CreateNestedPipeline(string command, bool addToHistory)
         {
             // TODO: make sure to fail if not Open
-            throw new NotImplementedException();
+            return new LocalPipeline(this, command, true);
         }
 
         public override Pipeline CreatePipeline()
@@ -129,9 +129,7 @@ namespace Pash.Implementation
         {
             // TODO: take care of the command history
             // TODO: make sure to fail if not Open
-            LocalPipeline pipeline = new LocalPipeline(this, command);
-
-            return pipeline;
+            return new LocalPipeline(this, command, false);
         }
         #endregion
 

--- a/Source/System.Management/Pash/Implementation/ReturnException.cs
+++ b/Source/System.Management/Pash/Implementation/ReturnException.cs
@@ -1,0 +1,15 @@
+// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+
+namespace System.Management.Pash.Implementation
+{
+    public class ReturnException : Exception
+    {
+        public object Value { get; set; }
+        public ReturnException(object returnValue)
+        {
+            Value = returnValue;
+        }
+    }
+}
+

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -301,9 +301,12 @@ namespace Pash.ParserIntrinsics
 
         private StatementAst BuildExitStatementAst(ParseTreeNode parseTreeNode)
         {
+            VerifyTerm(parseTreeNode, this._grammar._flow_control_statement_exit);
+
+            var pipeline = parseTreeNode.ChildNodes.Count > 1 ? BuildPipelineAst(parseTreeNode.ChildNodes[1]) : null;
             return new ExitStatementAst(
                 new ScriptExtent(parseTreeNode),
-                null
+                pipeline
                 );
         }
 
@@ -1350,7 +1353,10 @@ namespace Pash.ParserIntrinsics
             {
                 return new VariableExpressionAst(new ScriptExtent(parseTreeNode), parseTreeNode.Token.Text.Substring(1), false);
             }
-
+            else if (match.Groups[this._grammar._variable_dollar_question.Name].Success)
+            {
+                return new VariableExpressionAst(new ScriptExtent(parseTreeNode), "?", false);
+            }
             throw new NotImplementedException(parseTreeNode.ToString());
         }
 

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -471,6 +471,8 @@
     <Compile Include="Pash\Implementation\ScopeUsages.cs" />
     <Compile Include="Automation\Runspaces\InvalidPipelineStateException.cs" />
     <Compile Include="Pash\Implementation\CmdletParameterBinder.cs" />
+    <Compile Include="Pash\Implementation\ExitException.cs" />
+    <Compile Include="Pash\Implementation\ReturnException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/TestHost/FullHostTests.cs
+++ b/Source/TestHost/FullHostTests.cs
@@ -12,17 +12,17 @@ namespace TestHost
         internal TestHostUserInterface HostUI;
         internal FullHost FullHost;
 
-        [SetUp]
-        public void CreateFreshHostAndUI()
+        private void CreateFreshHostAndUI(bool interactive)
         {
             HostUI = new TestHostUserInterface();
-            FullHost = new FullHost();
+            FullHost = new FullHost(interactive);
             FullHost.LocalHost.SetHostUserInterface(HostUI);
         }
 
         [Test]
         public void RunAndInteractiveExit()
         {
+            CreateFreshHostAndUI(true);
             HostUI.SetInput("exit");
             FullHost.Run();
             var outlines = HostUI.GetOutput().Split(new string[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
@@ -33,8 +33,9 @@ namespace TestHost
         [Test]
         public void RunAndNoInteraction()
         {
+            CreateFreshHostAndUI(false);
             HostUI.SetInput("exit"); // just in case, so the test case exits
-            FullHost.Run(false, null);
+            FullHost.Run(null);
             var outlines = HostUI.GetOutput().Split(new string[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
             Assert.AreEqual(1, outlines.Length); // banner only, no prompt because of autoexit
             outlines.ShouldContain(FullHost.BannerText);
@@ -43,8 +44,9 @@ namespace TestHost
         [Test]
         public void RunWithScriptAndInteractiveInput()
         {
+            CreateFreshHostAndUI(true);
             HostUI.SetInput("exit");
-            FullHost.Run(true, @"Write-Host ""foo""; Write-Host ""bar"";");
+            FullHost.Run(@"Write-Host ""foo""; Write-Host ""bar"";");
             var outlines = HostUI.GetOutput().Split(new string[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
             Assert.AreEqual(3, outlines.Length); // 2x output of command, and prompt
             outlines.ShouldContain("foo");
@@ -54,8 +56,9 @@ namespace TestHost
         [Test]
         public void RunWithScriptAndNoInteraction()
         {
+            CreateFreshHostAndUI(false);
             HostUI.SetInput("exit"); // just in case, so the test case exits
-            FullHost.Run(false, @"Write-Host ""foo""; Write-Host ""bar"";");
+            FullHost.Run(@"Write-Host ""foo""; Write-Host ""bar"";");
             var outlines = HostUI.GetOutput().Split(new string[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
             Assert.AreEqual(2, outlines.Length); // 2x output of command, no prompt
             outlines.ShouldContain("foo");

--- a/Source/TestHost/TestHost.cs
+++ b/Source/TestHost/TestHost.cs
@@ -11,9 +11,11 @@ namespace TestHost
     internal class TestHost : PSHost
     {
         readonly PSHostUserInterface _ui = new TestHostUserInterface();
+        private static bool _doExit = false;
 
         public static InitialSessionState InitialSessionState { get; set; }
         public static Runspace LastUsedRunspace { get; private set; }
+        public static int? LastExitCode;
 
         public static string Execute(params string[] statements)
         {
@@ -48,9 +50,15 @@ namespace TestHost
             // use public static property, so we can access e.g. the ExecutionContext after execution
             LastUsedRunspace = CreateRunspace(host);
             LastUsedRunspace.Open();
+            _doExit = false;
+            LastExitCode = null;
 
             foreach (var statement in statements)
             {
+                if (_doExit)
+                {
+                    break;
+                }
                 using (var currentPipeline = LastUsedRunspace.CreatePipeline())
                 {
                     currentPipeline.Commands.AddScript(statement, false);
@@ -147,7 +155,8 @@ namespace TestHost
 
         public override void SetShouldExit(int exitCode)
         {
-            throw new NotImplementedException();
+            _doExit = true;
+            LastExitCode = exitCode;
         }
     }
 }

--- a/Source/TestPSSnapIn/TestCommands.cs
+++ b/Source/TestPSSnapIn/TestCommands.cs
@@ -97,6 +97,16 @@ namespace TestPSSnapIn
         }
     }
 
+    [Cmdlet(VerbsDiagnostic.Test, "ThrowError")]
+    public class TestThrowErrorCommand : PSCmdlet
+    {
+        protected override void ProcessRecord()
+        {
+            ThrowTerminatingError(new ErrorRecord(new Exception("testerror"), "TestError",
+                                                  ErrorCategory.InvalidOperation, null));
+        }
+    }
+
     [Cmdlet(VerbsDiagnostic.Test, "Dummy")]
     public class TestDummyCommand : PSCmdlet
     {


### PR DESCRIPTION
"exit" now allows to have an exit code which is properly handled.
In a script, the script simply exits and $LastExitCode will be set.
There is now also support for $? which simply indicates whether the last command was successful.
Outside a script, the complete process exits and the exit code of the process is set accordingly.

Also return statements now allow a value. However, this is nothing special
as
  return 5;
is the same as
  5;
  return;
in Powershell.
ReferenceTests have been added to make sure this behavior fits PS.
The reference testing framework was adjusted for this and is now more powerfull to test even more things
like the PS/Pash process behavior.
