### PR TITLE
Refactor: "params" in NewlineJoin saves lots of syntax.

### DIFF
--- a/Source/ReferenceTests/ArrayTests.cs
+++ b/Source/ReferenceTests/ArrayTests.cs
@@ -25,7 +25,7 @@ namespace ReferenceTests
         {
             var cmd = String.Format("$a = {0}; $a.GetType().FullName", definition);
             var result = ReferenceHost.Execute(cmd);
-            Assert.AreEqual(typeof(object[]).FullName + Environment.NewLine, result);
+            Assert.AreEqual(NewlineJoin(typeof(object[]).FullName), result);
         }
 
         [Test]
@@ -47,25 +47,25 @@ namespace ReferenceTests
         [Test]
         public void ElementsFromPipelineAreStoredAsArray()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = @('foo', 'bar', 'baz') | " + CmdletName(typeof(TestCmdletPhasesCommand)),
                 "$a.GetType().FullName"
-            }));
-            Assert.AreEqual(typeof(object[]).FullName + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin(typeof(object[]).FullName), result);
         }
 
         [Test]
         public void ArrayInParenthesisIsStillArray()
         {
             var result = ReferenceHost.Execute("(@(1,2)).GetType().FullName");
-            Assert.AreEqual(typeof(object[]).FullName + Environment.NewLine, result);
+            Assert.AreEqual(NewlineJoin(typeof(object[]).FullName), result);
         }
 
         [Test] // issue #116
         public void SingleArrayElementIsStillArray()
         {
             var result = ReferenceHost.Execute("@(1).GetType().FullName; @(1).Count");
-            Assert.AreEqual(NewlineJoin(new string[] { typeof(object[]).FullName, "1"}), result);
+            Assert.AreEqual(NewlineJoin(typeof(object[]).FullName, "1"), result);
         }
 
         [Test]

--- a/Source/ReferenceTests/CmdletParameterTests.cs
+++ b/Source/ReferenceTests/CmdletParameterTests.cs
@@ -27,7 +27,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestNoMandatoriesCommand));
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual("Reversed:  " + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin("Reversed:  "), res);
         }
 
         [TestCase("'foo'", "Correct: 1 2")]
@@ -36,7 +36,7 @@ namespace ReferenceTests
         {
             var cmd = pipeInput + " | " + CmdletName(typeof(TestNoMandatoriesCommand)) + " -One '1' -Two '2'";
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual(expected + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin(expected), res);
         }
 
         [TestCase("-RandomString '4'", "Correct: 1 2")]
@@ -45,7 +45,7 @@ namespace ReferenceTests
         {
             var cmd = String.Format(CmdletName(typeof(TestNoMandatoriesCommand)) + " {0} '1' '2'", parameter);
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual(expected + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin(expected), res);
         }
 
         [TestCase("'foo'", "Correct: 2 1")] // right set was chosen, but positional bound by defualt set
@@ -54,7 +54,7 @@ namespace ReferenceTests
         {
             var cmd = pipeInput + " | " + CmdletName(typeof(TestNoMandatoriesCommand)) + " '1' '2'";
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual(expected + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin(expected), res);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestMandatoryInOneSetCommand)) + " 'works' 'foo'";
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual("works" + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin("works"), res);
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestSwitchAndPositionalCommand)) + " -Switch 'test'";
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual("test" + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin("test"), res);
         }
 
         [Test]
@@ -143,7 +143,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestDefaultParameterSetDoesntExistCommand));
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual("works" + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin("works"), res);
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestNoMandatoriesCommand)) + " -One 1 -Tw 2"; // note Tw instead of "Two"
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual("Reversed: 1 2" + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin("Reversed: 1 2"), res);
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestNoParametersCommand));
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual("works" + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin("works"), res);
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestDefaultSetIsAllParameterSetAndTwoParameterSetsCommand));
             var res = ReferenceHost.Execute(cmd);
-            Assert.AreEqual("First: null" + Environment.NewLine, res);
+            Assert.AreEqual(NewlineJoin("First: null"), res);
         }
 
         [Test]

--- a/Source/ReferenceTests/ExitTests.cs
+++ b/Source/ReferenceTests/ExitTests.cs
@@ -25,22 +25,22 @@ namespace ReferenceTests
         public void ExitInterruptsCommands()
         {
             var result = ReferenceHost.Execute("'foo'; exit 4; 'bar'");
-            Assert.AreEqual("foo" + Environment.NewLine, result);
+            Assert.AreEqual(NewlineJoin("foo"), result);
         }
 
         [Test]
         public void ExitInScriptOnlyEndsScript()
         {
-            var scriptname = CreateScript(NewlineJoin(new[] {
+            var scriptname = CreateScript(NewlineJoin(
                 "'foo'",
                 "exit 4",
                 "'bar'"
-            }));
-            var command = NewlineJoin(new[] {
+            ));
+            var command = NewlineJoin(
                 String.Format(". '{0}'", scriptname),
                 "$LastExitCode"
-            });
-            var expected = NewlineJoin(new[] { "foo", "4" });
+            );
+            var expected = NewlineJoin("foo", "4");
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -50,14 +50,12 @@ namespace ReferenceTests
         [TestCase("3", "& { 3 }")]
         public void ExpressionsAreValidExitCodes(string expectedExitCode, string exitExpression)
         {
-            var scriptname = CreateScript(NewlineJoin(new[] {
-                "exit " + exitExpression
-            }));
-            var command = NewlineJoin(new[] {
+            var scriptname = CreateScript(NewlineJoin("exit " + exitExpression));
+            var command = NewlineJoin(
                 String.Format(". '{0}'", scriptname),
                 "$LastExitCode"
-            });
-            var expected = NewlineJoin(new[] { expectedExitCode });
+            );
+            var expected = NewlineJoin(expectedExitCode);
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -68,15 +66,13 @@ namespace ReferenceTests
         [TestCase("True", "'some string'", false)]
         public void ExitCodeDefinesSuccess(string success, string exitCode, bool exitCodeValid)
         {
-            var scriptname = CreateScript(NewlineJoin(new[] {
-                "exit " + exitCode
-            }));
-            var command = NewlineJoin(new[] {
+            var scriptname = CreateScript(NewlineJoin("exit " + exitCode));
+            var command = NewlineJoin(
                 String.Format(". '{0}'", scriptname),
                 "$?",
                 "$LastExitCode"
-            });
-            var expected = NewlineJoin(new[] { success, exitCodeValid ? exitCode : "0" });
+            );
+            var expected = NewlineJoin(success, exitCodeValid ? exitCode : "0");
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -84,15 +80,13 @@ namespace ReferenceTests
         [Test]
         public void ScriptWithoutExitIsSuccessfull()
         {
-            var scriptname = CreateScript(NewlineJoin(new[] {
-                "'foo'"
-            }));
-            var command = NewlineJoin(new[] {
+            var scriptname = CreateScript(NewlineJoin("'foo'"));
+            var command = NewlineJoin(
                 String.Format(". '{0}'", scriptname),
                 "$?",
                 "$LastExitCode"
-            });
-            var expected = NewlineJoin(new[] { "foo", "True", "" });
+            );
+            var expected = NewlineJoin("foo", "True", "");
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -100,12 +94,12 @@ namespace ReferenceTests
         [Test, Explicit("Pipeline on-demand processing doesn't work")]
         public void ExitInScriptBlockExitsCompletely()
         {
-            var command = NewlineJoin(new[] {
+            var command = NewlineJoin(
                 "'foo'",
                 "& { 'bar'; exit; 'baz'; }",
                 "'blub'"
-            });
-            var expected = NewlineJoin(new[] { "foo", "bar" });
+            );
+            var expected = NewlineJoin("foo", "bar");
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -113,13 +107,13 @@ namespace ReferenceTests
         [Test, Explicit("Pipeline on-demand processing doesn't work")]
         public void ExitInFunctionExitsCompletely()
         {
-            var command = NewlineJoin(new[] {
+            var command = NewlineJoin(
                 "function testfun { 'bar'; exit; 'baz'; }",
                 "'foo'",
                 "testfun",
                 "'blub'"
-            });
-            var expected = NewlineJoin(new[] { "foo", "bar" });
+            );
+            var expected = NewlineJoin("foo", "bar");
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -138,7 +132,7 @@ namespace ReferenceTests
         {
             var process = CreatePowershellOrPashProcess("'foo'; & { exit 5; 'bar'; }; 'baz'");
             Assert.True(process.Start());
-            var expectedOutput = NewlineJoin(new[] { "foo" });
+            var expectedOutput = NewlineJoin("foo");
             var output = FinishProcess(process);
             Assert.AreEqual(5, process.ExitCode);
             Assert.AreEqual(expectedOutput, output);

--- a/Source/ReferenceTests/ObjectCommandTests.cs
+++ b/Source/ReferenceTests/ObjectCommandTests.cs
@@ -33,11 +33,11 @@ namespace ReferenceTests
         [Test]
         public void AddMemberCanAddNoteProperties()
         {
-            var results = ReferenceHost.RawExecute(NewlineJoin(new string[] {
+            var results = ReferenceHost.RawExecute(NewlineJoin(
                 "$a = New-Object -Type PSObject",
                 "$a | Add-Member -Type NoteProperty -Name TestName -Value TestValue",
                 "$a"
-            }));
+            ));
             Assert.AreEqual(1, results.Count, "No results");
             var obj = results[0];
             Assert.NotNull(obj.Members["TestName"]);
@@ -47,119 +47,113 @@ namespace ReferenceTests
         [Test]
         public void CustomPSObjectPropertiesCanBeAccessedCaseInsensitive()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = New-Object -Type PSObject",
                 "$a | Add-Member -Type NoteProperty -Name TestName -Value TestValue",
                 "$a.testname"
-            }));
-            Assert.AreEqual("TestValue" + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin("TestValue"), result);
         }
 
         [Test]
         public void AccessingNonExistingPropertiesDoesntFail()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = New-Object -Type PSObject",
                 "$a.testname"
-            }));
-            Assert.AreEqual(Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin(), result);
         }
 
         [Test]
         public void CanGetCustomCSharpObjectAndIdentifyType()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)),
                 "$a.GetType().FullName"
-            }));
-            Assert.AreEqual(typeof(CustomTestClass).FullName + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin(typeof(CustomTestClass).FullName), result);
         }
 
         [Test]
         public void CanAccessCSharpObjectProperty()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)) + " 'foo' 'bar'",
                 "$a.MessageProperty"
-            }));
-            Assert.AreEqual("foo" + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin("foo"), result);
         }
 
         [Test]
         public void CanSetCSharpObjectProperty()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)) + " 'foo' 'bar'",
                 "$a.MessageProperty = 'baz'",
                 "$a.MessageProperty"
-            }));
-            Assert.AreEqual("baz" + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin("baz"), result);
         }
 
         [Test]
         public void CanAccessCSharpObjectField()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)) + " 'foo' 'bar'",
                 "$a.MessageField"
-            }));
-            Assert.AreEqual("bar" + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin("bar"), result);
         }
 
         [Test]
         public void CanSetCSharpObjectField()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)) + " 'foo' 'bar'",
                 "$a.MessageField = 'baz'",
                 "$a.MessageField"
-            }));
-            Assert.AreEqual("baz" + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin("baz"), result);
         }
 
         [Test]
         public void CanInvokeCSharpObjectMethodAndGetResult()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)) + " 'foo' 'bar'",
                 "$b = $a.Combine()",
                 "$b.GetType().FullName",
-                "$b",
-            }));
-            var expected = NewlineJoin(new string[] {
-                typeof(string).FullName,
-                "foobar"
-            });
+                "$b"
+            ));
+            var expected = NewlineJoin(typeof(string).FullName, "foobar");
             Assert.AreEqual(expected, result);
         }
 
         [Test]
         public void CanInvokeCSharpObjectMethodWithArguments()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)) + " 'foo' 'bar'",
                 "$a.SetMessages('bla', 'blub')",
                 "$a.MessageProperty",
-                "$a.MessageField",
-            }));
-            var expected = NewlineJoin(new string[] {
-                "bla",
-                "blub"
-            });
+                "$a.MessageField"
+            ));
+            var expected = NewlineJoin("bla", "blub");
             Assert.AreEqual(expected, result);
         }
 
         [Test]
         public void CanGetCSharpObjectMethodAndInvokeLater()
         {
-            var result = ReferenceHost.Execute(NewlineJoin(new string[] {
+            var result = ReferenceHost.Execute(NewlineJoin(
                 "$a = " + CmdletName(typeof(TestCreateCustomObjectCommand)) + " 'foo' 'bar'",
                 "$b = $a.SetMessages",
                 "$c = $a.Combine",
                 "$b.Invoke('bla', 'blub')",
                 "$c.Invoke()"
-            }));
-            Assert.AreEqual("blablub" + Environment.NewLine, result);
+            ));
+            Assert.AreEqual(NewlineJoin("blablub"), result);
         }
     }
 }

--- a/Source/ReferenceTests/PipelineExecutionTests.cs
+++ b/Source/ReferenceTests/PipelineExecutionTests.cs
@@ -28,7 +28,7 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestCmdletPhasesCommand));
             var res = ReferenceHost.Execute(cmd);
-            var expected = NewlineJoin(new string[] { "Begin", "Process", "End" });
+            var expected = NewlineJoin("Begin", "Process", "End");
             Assert.AreEqual(expected, res);
         }
 
@@ -37,7 +37,7 @@ namespace ReferenceTests
         {
             var cmd = "$null | " + CmdletName(typeof(TestCmdletPhasesCommand));
             var res = ReferenceHost.Execute(cmd);
-            var expected = NewlineJoin(new string[] { "Begin", "Process", "End" });
+            var expected = NewlineJoin("Begin", "Process", "End");
             Assert.AreEqual(expected, res);
         }
 
@@ -46,14 +46,14 @@ namespace ReferenceTests
         {
             var cmd = CmdletName(typeof(TestDummyCommand)) + " | " + CmdletName(typeof(TestCmdletPhasesCommand));
             var res = ReferenceHost.Execute(cmd);
-            var expected = NewlineJoin(new string[] { "Begin", "End" });
+            var expected = NewlineJoin("Begin", "End");
             Assert.AreEqual(expected, res);
         }
 
         [Test]
         public void MultipleObjectsAsPipelineCommandScriptsReturnLastObject()
         {
-            var expected = NewlineJoin(new string[] { "bar" });
+            var expected = NewlineJoin("bar");
             var result = ReferenceHost.Execute(new [] { "'foo'", "'bar'" });
             Assert.AreEqual(expected, result);
         }

--- a/Source/ReferenceTests/ReferenceTestBase.cs
+++ b/Source/ReferenceTests/ReferenceTestBase.cs
@@ -123,7 +123,7 @@ namespace ReferenceTests
             return string.Format("{0}-{1}", attribute.VerbName, attribute.NounName);
         }
 
-        public static string NewlineJoin(string[] parts)
+        public static string NewlineJoin(params string[] parts)
         {
             return String.Join(Environment.NewLine, parts) + Environment.NewLine;
         }

--- a/Source/ReferenceTests/ReturnTests.cs
+++ b/Source/ReferenceTests/ReturnTests.cs
@@ -15,7 +15,7 @@ namespace ReferenceTests
         [Test]
         public void ReturnWritesToPipeline()
         {
-            var expected = "foobar" + Environment.NewLine;
+            var expected = NewlineJoin("foobar");
             var result = ReferenceHost.Execute("return 'foobar'");
             Assert.AreEqual(expected, result);
         }
@@ -23,12 +23,12 @@ namespace ReferenceTests
         [Test]
         public void ReturnEndsScriptBlockAndWritesToPipeline()
         {
-            var expected = NewlineJoin(new [] { "foo", "bar", "bla" });
-            var command = NewlineJoin(new [] {
+            var expected = NewlineJoin("foo", "bar", "bla" );
+            var command = NewlineJoin(
                 "'foo'",
                 "& { return 'bar'; 'baz' }",
                 "'bla'"
-            });
+            );
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -36,12 +36,12 @@ namespace ReferenceTests
         [Test]
         public void ReturnEndsFunctionAndWritesToPipeline()
         {
-            var expected = NewlineJoin(new [] { "foo", "bar", "bla" });
-            var command = NewlineJoin(new [] {
+            var expected = NewlineJoin("foo", "bar", "bla");
+            var command = NewlineJoin(
                 "function testfun { 'foo'; return 'bar'; 'baz' }",
                 "testfun",
                 "'bla'"
-            });
+            );
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -49,12 +49,9 @@ namespace ReferenceTests
         [Test]
         public void ReturnEndsScriptAndWritesToPipeline()
         {
-            var expected = NewlineJoin(new [] { "foo", "bar", "bla" });
+            var expected = NewlineJoin("foo", "bar", "bla");
             var scriptname = CreateScript("'foo'; return 'bar'; 'baz'");
-            var command = NewlineJoin(new [] {
-                String.Format("& '{0}'", scriptname),
-                "'bla'"
-            });
+            var command = NewlineJoin(String.Format("& '{0}'", scriptname), "'bla'");
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }
@@ -64,11 +61,11 @@ namespace ReferenceTests
         [TestCase("TESTVALUE", "$testvar")]
         public void ReturnEvaluatesExpression(string returnValue, string returnExpression)
         {
-            var expected = NewlineJoin(new [] { "foo", returnValue, "bla" });
-            var command = NewlineJoin(new [] {
+            var expected = NewlineJoin("foo", returnValue, "bla");
+            var command = NewlineJoin(
                 "& { $testvar = 'TESTVALUE'; 'foo'; return " + returnExpression + "; 'baz' }",
                 "'bla'"
-            });
+            );
             var result = ReferenceHost.Execute(command);
             Assert.AreEqual(expected, result);
         }


### PR DESCRIPTION
I don't know why I didn't think of it when I introduced that function.
NewlineJoin with variable parameters now provides a simple way to generate
expected output strings, multiline commands, scripts, etc. All without much
syntax overhead.
