### PR TITLE
Type conversions using type converter

### DIFF
--- a/PowershellReferenceTests/PowershellReferenceTests.csproj
+++ b/PowershellReferenceTests/PowershellReferenceTests.csproj
@@ -73,6 +73,9 @@
     <Compile Include="..\Source\ReferenceTests\ReturnTests.cs">
       <Link>ReturnTests.cs</Link>
     </Compile>
+    <Compile Include="..\Source\ReferenceTests\TypeConverterTests.cs">
+      <Link>TypeConverterTests.cs</Link>
+    </Compile>
     <Compile Include="..\Source\TestPSSnapIn\TestCommands.cs">
       <Link>TestCommands.cs</Link>
     </Compile>

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="PSObjectTests.cs" />
     <Compile Include="ObjectCommandTests.cs" />
     <Compile Include="ArrayTests.cs" />
+    <Compile Include="TypeConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/ReferenceTests/TypeConverterTests.cs
+++ b/Source/ReferenceTests/TypeConverterTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Management.Automation;
+using NUnit.Framework;
+using TestPSSnapIn;
+
+namespace ReferenceTests
+{
+    [TestFixture]
+    public class TypeConverterTests : ReferenceTestBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            ImportTestCmdlets();
+        }
+
+        [TearDown]
+        public void CleanUp()
+        {
+            RemoveCreatedScripts();
+        }
+
+        [Test]
+        public void ConvertFromStringToTypeWithTypeConverterUsesTypeConverter()
+        {
+            string cmdletName = CmdletName(typeof(TestParameterUsesCustomTypeWithTypeConverterCommand));
+            string command = string.Format("{0} Parameter1", cmdletName);
+            string result = ReferenceHost.Execute(command);
+
+            Assert.AreEqual("CustomType.Id='Parameter1'" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void LanguagePrimitivesConvertToTypeWithTypeConverter()
+        {
+            var result = LanguagePrimitives.ConvertTo("abc", typeof(Custom));
+        
+            Assert.IsInstanceOf(typeof(Custom), result);
+            Assert.AreEqual("abc", ((Custom)result).Id);
+        }
+    }
+}

--- a/Source/System.Management.Tests/LanguagePrimitivesTests.cs
+++ b/Source/System.Management.Tests/LanguagePrimitivesTests.cs
@@ -2,6 +2,8 @@ using NUnit.Framework;
 using System;
 using System.Management.Automation;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
 
 namespace System.Management.Tests
 {
@@ -36,6 +38,26 @@ namespace System.Management.Tests
                 throw new InvalidOperationException("Wrong object type to compare to");
             }
             return _msg2.Equals(otherChild._msg2) && base.EqualsIgnoreCase(otherChild);
+        }
+    }
+
+    [TypeConverter(typeof(CustomTypeConverter))]
+    public class Custom
+    {
+        public string Id { get; set; }
+    }
+
+    public class CustomTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            string stringValue = value as string;
+            return new Custom { Id = stringValue };
         }
     }
 
@@ -191,6 +213,15 @@ namespace System.Management.Tests
             var result = LanguagePrimitives.ConvertTo(input, typeof(string[]));
             Assert.AreEqual(expected.GetType(), result.GetType());
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConvertToConvertsTypeWithTypeConverter()
+        {
+            string input = "MyId";
+            var result = LanguagePrimitives.ConvertTo(input, typeof(Custom));
+            Assert.AreEqual(typeof(Custom), result.GetType());
+            Assert.AreEqual("MyId", ((Custom)result).Id);
         }
     }
 }

--- a/Source/System.Management/Automation/LanguagePrimitives.cs
+++ b/Source/System.Management/Automation/LanguagePrimitives.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Globalization;
 using System.Reflection;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace System.Management.Automation
 {
@@ -242,6 +243,12 @@ namespace System.Management.Automation
                 return new SwitchParameter(true);
             }
 
+            object result = null;
+            if (valueToConvert != null && TryConvertUsingTypeConverter(valueToConvert, resultType, out result))
+            {
+                return result;
+            }
+
             return DefaultConvertOrCast(valueToConvert, resultType);
 
         }
@@ -388,6 +395,25 @@ namespace System.Management.Automation
         }
 
         #endregion
+
+        private static bool TryConvertUsingTypeConverter(object value, Type type, out object result)
+        {
+            TypeConverter converter = TypeDescriptor.GetConverter(type);
+            if (converter != null && converter.CanConvertFrom(value.GetType()))
+            {
+                try
+                {
+                    result = converter.ConvertFrom(value);
+                    return true;
+                }
+                catch
+                {
+                }
+            }
+
+            result = null;
+            return false;
+        }
 
         private static object DefaultConvertOrCast(object value, Type type)
         {

--- a/Source/TestPSSnapIn/TestCommands.cs
+++ b/Source/TestPSSnapIn/TestCommands.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Management.Automation;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Globalization;
 
 namespace TestPSSnapIn
 {
@@ -347,6 +350,38 @@ namespace TestPSSnapIn
         protected override void ProcessRecord()
         {
             WriteObject(Foo.GetMessage());
+        }
+    }
+
+    [Cmdlet(VerbsDiagnostic.Test, "ParameterUsesCustomTypeWithTypeConverter")]
+    public sealed class TestParameterUsesCustomTypeWithTypeConverterCommand : PSCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        public Custom CustomTypeParameter { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            WriteObject(string.Format("CustomType.Id='{0}'", CustomTypeParameter.Id));
+        }
+    }
+
+    [TypeConverter(typeof(CustomTypeConverter))]
+    public class Custom
+    {
+        public string Id { get; set; }
+    }
+
+    public class CustomTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            string stringValue = value as string;
+            return new Custom { Id = stringValue };
         }
     }
 }


### PR DESCRIPTION
A cmdlet can now have a parameter that uses a custom type that has a custom TypeConverter defined. Pash will now try to convert a parameter passed on the command line to the custom type using this
TypeConverter.

``` C#
    [TypeConverter(typeof(CustomTypeConverter))]
    public class Custom
    {
    }
```

One real world example of this is NuGet's Install-Package command which has a Version property that uses a custom TypeConverter to convert from a string to the SemanticVersion type.
