### PR TITLE
Change default script scope to global.

### DIFF
--- a/Source/ReferenceTests/DefaultScriptScopeTests.cs
+++ b/Source/ReferenceTests/DefaultScriptScopeTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using NUnit.Framework;
+
+namespace ReferenceTests
+{
+    [TestFixture]
+    class DefaultScriptScopeTests
+    {
+        [Test]
+        public void CommandCollectionAddScriptDefaultLocalScopeIsFalse()
+        {
+            var state = InitialSessionState.CreateDefault();
+            Runspace runspace = RunspaceFactory.CreateRunspace(state);
+            runspace.Open();
+            Pipeline pipeline = runspace.CreatePipeline();
+            pipeline.Commands.AddScript("$a = 12");
+            pipeline.Invoke();
+
+            pipeline = runspace.CreatePipeline();
+            pipeline.Commands.AddScript("$a");
+            List<string> objects = pipeline.Invoke().AsEnumerable().Select(obj => obj.ToString()).ToList();
+
+            Assert.AreEqual("12", objects[0]);
+        }
+    }
+}

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CmdletParameterTests.cs" />
+    <Compile Include="DefaultScriptScopeTests.cs" />
     <Compile Include="FunctionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReferenceHost.cs" />

--- a/Source/System.Management/Automation/Runspaces/CommandCollection.cs
+++ b/Source/System.Management/Automation/Runspaces/CommandCollection.cs
@@ -13,7 +13,7 @@ namespace System.Management.Automation.Runspaces
 
         public void AddScript(string scriptContents)
         {
-            AddScript(scriptContents, true); //per default a script runs in  its own scope
+            AddScript(scriptContents, false); //per default a script runs in global scope
         }
 
         public void AddScript(string scriptContents, bool useLocalScope)


### PR DESCRIPTION
With Microsoft's PowerShell the following:

```
Pipeline.Commands.AddScript(script);
```

is equivalent to:

```
Pipeline.Commands.AddScript(script, useLocalScope: false);
```

Added a reference test for check this behaviour.
