### PR TITLE
Significantly improved startup time

### DIFF
--- a/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
@@ -180,6 +180,7 @@ namespace Pash.ParserIntrinsics
         public readonly NonTerminal array_literal_expression = null; // Initialized by reflection.
         public readonly NonTerminal unary_expression = null; // Initialized by reflection.
         public readonly NonTerminal expression_with_unary_operator = null; // Initialized by reflection.
+/* TODO: all subexpressions of expression_with_unary_operator are currently merged into one for performance
         public readonly NonTerminal _unary_array_expression = null; // Initialized by reflection.
         public readonly NonTerminal _unary_not_expression = null; // Initialized by reflection.
         public readonly NonTerminal _unary_bang_expression = null; // Initialized by reflection.
@@ -190,7 +191,10 @@ namespace Pash.ParserIntrinsics
         public readonly NonTerminal _unary_join_expression = null; // Initialized by reflection.
         public readonly NonTerminal pre_increment_expression = null; // Initialized by reflection.
         public readonly NonTerminal pre_decrement_expression = null; // Initialized by reflection.
+// They are all replaced by the following:
+*/
         public readonly NonTerminal _unary_operator_expression = null;
+        public readonly NonTerminal _joined_unary_operator_expression = null;
         public readonly NonTerminal cast_expression = null; // Initialized by reflection.
         public readonly NonTerminal primary_expression = null; // Initialized by reflection.
         public readonly NonTerminal value = null; // Initialized by reflection.
@@ -1089,7 +1093,8 @@ namespace Pash.ParserIntrinsics
             // TODO: the following expresion covers all the different cases mentioned above as the original
             // implementation increases the creation time of the grammar extremely (about 5 seconds)
             // If someone has good ideas and is an grammar pro, feel free to change this again!
-            expression_with_unary_operator.Rule = _unary_operator_expression + unary_expression;
+            expression_with_unary_operator.Rule = cast_expression | _joined_unary_operator_expression;
+            _joined_unary_operator_expression.Rule = _unary_operator_expression + unary_expression;
             _unary_operator_expression.Rule =
                 _operator_not
                 |
@@ -1109,11 +1114,10 @@ namespace Pash.ParserIntrinsics
                 |
                 "++"
                 |
-                dashdash
-                |
-                cast_expression;
+                dashdash;
 
-            /* Original code that splits the rule in different expressions:
+            /* See Pash issue #214
+             * Original code that splits the rule in different expressions:
 
             expression_with_unary_operator.Rule =
                 _unary_array_expression
@@ -1156,12 +1160,11 @@ namespace Pash.ParserIntrinsics
             ////            dashdash   new_lines_opt   unary_expression
             pre_decrement_expression.Rule =
                 dashdash + unary_expression;
-
+            */
             ////        cast_expression:
             ////            type_literal   unary_expression
             cast_expression.Rule =
                 type_literal + unary_expression;
-            */
 
             ////        primary_expression:
             ////            value


### PR DESCRIPTION
As mentioned in issue #214, the expression_with_unary_operator rule caused trouble which lead to a long construction time of the grammar and therefore to a very long startup time of Pash (and tests).

The proposed fix is maybe not very pretty, but it decreases startup time from about 3,4s to 0,8s on my computer.
All unary operator expressions except the cast expresions are now joined in one rule. The AstBuilder later on differentiates between them.
The cast expression had to stay a seperate rule, because double casting like "[string][int]'5'" wouldn't parse anymore. I don't know exactly why this is, but having cast_expression as a seperate rule doesn't seem to have a big influence on the startup time.
