### PR TITLE
Fixed path for the reference tests in Pash.proj.

### DIFF
--- a/Pash.proj
+++ b/Pash.proj
@@ -4,17 +4,17 @@
   <!--=====================================================================-->
   <Target Name="Build">
     <MSBuild Projects="Source\Pash.sln" />
-    <MsBuild Projects="PowershellReferenceTests\PowershellReferenceTests.csproj" Condition="'$(OS)' == 'Windows_NT'"/>
+    <MsBuild Projects="WindowsPowershellReferenceTests\WindowsPowershellReferenceTests.csproj" Condition="'$(OS)' == 'Windows_NT'"/>
   </Target>
 
   <Target Name="Clean">
     <MSBuild Projects="Source\Pash.sln" Targets="Clean" />
-    <MsBuild Projects="PowershellReferenceTests\PowershellReferenceTests.csproj" Condition="'$(OS)' == 'Windows_NT'"/>
+    <MsBuild Projects="WindowsPowershellReferenceTests\WindowsPowershellReferenceTests.csproj" Condition="'$(OS)' == 'Windows_NT'"/>
   </Target>
 
   <Target Name="Rebuild">
     <MSBuild Projects="Source\Pash.sln" Targets="Rebuild" />
-    <MsBuild Projects="PowershellReferenceTests\PowershellReferenceTests.csproj" Condition="'$(OS)' == 'Windows_NT'"/>
+    <MsBuild Projects="WindowsPowershellReferenceTests\WindowsPowershellReferenceTests.csproj" Condition="'$(OS)' == 'Windows_NT'"/>
   </Target>
 
 
@@ -39,7 +39,7 @@
   <Target Name="RefTest"
           DependsOnTargets="Build"
           >
-    <Exec Command="$(NUnitCommandLine) PowershellReferenceTests.nunit" Condition="'$(OS)' == 'Windows_NT'"/>
+    <Exec Command="$(NUnitCommandLine) WindowsPowershellReferenceTests.nunit" Condition="'$(OS)' == 'Windows_NT'"/>
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
Building with msbuild or xbuild now works again.
