### PR TITLE
Fixed FileSystemProvider behavior with relative path

### DIFF
--- a/Source/ReferenceTests/FileSystemProviderTests.cs
+++ b/Source/ReferenceTests/FileSystemProviderTests.cs
@@ -14,6 +14,20 @@ namespace ReferenceTests
             AddCleanupDir(dir);
             var items = ReferenceHost.Execute(NewlineJoin(
                 String.Format("New-Item -path '{0}' -type directory | foreach-object {{$_.FullName}}", dir))
+                                              );
+            var dirinfo = new DirectoryInfo(dir);
+            Assert.True(dirinfo.Exists, "Directory was not created");
+            Assert.AreEqual(NewlineJoin(dirinfo.FullName), items);
+        }
+
+        [Test]
+        public void CanCreateRelativeDir()
+        {
+            Environment.CurrentDirectory = Path.GetTempPath();
+            var dir = Path.Combine(".", "__tempdir");
+            AddCleanupDir(dir);
+            var items = ReferenceHost.Execute(NewlineJoin(
+                String.Format("New-Item -path '{0}' -type directory | foreach-object {{$_.FullName}}", dir))
             );
             var dirinfo = new DirectoryInfo(dir);
             Assert.True(dirinfo.Exists, "Directory was not created");

--- a/Source/ReferenceTests/ReferenceTestBase.cs
+++ b/Source/ReferenceTests/ReferenceTestBase.cs
@@ -18,6 +18,7 @@ namespace ReferenceTests
         private string _assemblyDirectory;
         private Regex _whiteSpaceRegex;
         private bool _isMonoRuntime;
+        private string _startDir;
 
         public ReferenceTestBase()
         {
@@ -35,6 +36,7 @@ namespace ReferenceTests
         public virtual void SetUp()
         {
             ImportTestCmdlets();
+            _startDir = Environment.CurrentDirectory;
         }
 
         [TearDown]
@@ -42,6 +44,10 @@ namespace ReferenceTests
         {
             CleanImports();
             RemoveCreatedFiles();
+            if (!String.IsNullOrEmpty(_startDir) && !_startDir.Equals(Environment.CurrentDirectory))
+            {
+                Environment.CurrentDirectory = _startDir;
+            }
         }
 
         private String QuoteWithSpace(string input)

--- a/Source/System.Management/Automation/ItemCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ItemCmdletProviderIntrinsics.cs
@@ -30,7 +30,7 @@ namespace System.Management.Automation
             {
                 normalizedPath = normalizedPath.Combine(name);
             }
-            normalizedPath = normalizedPath.MakePath(drive.Name).NormalizeSlashes();
+            normalizedPath = normalizedPath.NormalizeSlashes();
             return provider;
         }
 


### PR DESCRIPTION
Path.MakePath(drive) just prepends the drive without caring about relative path (don't know if this is really the desired behavior), so the internally used path didn't match the desired location.
