### PR TITLE
TEST: Fix Add-Type tests on other locales.

### DIFF
--- a/Source/ReferenceTests/AddTypeCommandTests.cs
+++ b/Source/ReferenceTests/AddTypeCommandTests.cs
@@ -67,9 +67,8 @@ Add-Type -typedefinition $source
         public void AddTypeDefinitionWithInvalidCSharpCode()
         {
             Exception ex = Assert.Throws(Is.InstanceOf(typeof(Exception)), () => {
-                ReferenceHost.RawExecute("Add-Type -TypeDefinition 'public class ErrorTest --'");
+                ReferenceHost.RawExecute("Add-Type -TypeDefinition 'public class ErrorTest --'", false);
             });
-            Assert.AreEqual("Cannot add type. There were compilation errors.", ex.Message);
             // TODO: Exception should be CmdletInvocationException
             // TODO: Does not work with pash. Pash does not have the error records in the pipeline.
             // They are in a nested pipeline but do not reach the main pipeline
@@ -171,9 +170,8 @@ $obj.WriteLine()
         public void AddMemberDefinitionWithInvalidCSharp()
         {
             Exception ex = Assert.Throws(Is.InstanceOf(typeof(Exception)), () => {
-                ReferenceHost.RawExecute("add-type -name Test -memberdefinition 'public WriteLine() ---'");
+                ReferenceHost.RawExecute("add-type -name Test -memberdefinition 'public WriteLine() ---'", false);
             });
-            Assert.AreEqual("Cannot add type. There were compilation errors.", ex.Message);
             // TODO: Exception should be CmdletInvocationException
             // TODO: Does not work with pash. Pash does not have the error records in the pipeline.
             // They are in a nested pipeline but do not reach the main pipeline
@@ -207,9 +205,8 @@ $obj.WriteLine()
             string fileName = CreateTempFile("AddTypeFromCSharpSourceFileWithInvalidCode.cs", @"public class ErrorTest --");
             Exception ex = Assert.Throws(Is.InstanceOf(typeof(Exception)), () =>
             {
-                ReferenceHost.RawExecute("Add-Type -Path '" + fileName + "'");
+                ReferenceHost.RawExecute("Add-Type -Path '" + fileName + "'", false);
             });
-            Assert.AreEqual("Cannot add type. There were compilation errors.", ex.Message);
         }
 
         [Test]

--- a/Source/ReferenceTests/ReferenceHost.cs
+++ b/Source/ReferenceTests/ReferenceHost.cs
@@ -49,12 +49,12 @@ namespace ReferenceTests
             return LastResults;
         }
 
-        public static Collection<PSObject> RawExecute(string cmd)
+        public static Collection<PSObject> RawExecute(string cmd, bool throwMethodInvocationException = true)
         {
-            return RawExecute(new string[] { cmd });
+            return RawExecute(new string[] { cmd }, throwMethodInvocationException);
         }
 
-        public static Collection<PSObject> RawExecute(string[] commands)
+        public static Collection<PSObject> RawExecute(string[] commands, bool throwMethodInvocationException = true)
         {
             LastRawResults = null;
             LastUsedRunspace = InitialSessionState == null ?
@@ -78,7 +78,7 @@ namespace ReferenceTests
                         }
                         throw;
                     }
-                    if (pipeline.Error.Count > 0)
+                    if (throwMethodInvocationException && pipeline.Error.Count > 0)
                     {
                         throw new MethodInvocationException(String.Join(Environment.NewLine, pipeline.Error.ReadToEnd()));
                     }

--- a/Source/TestHost/Cmdlets/AddTypeCommandTests.cs
+++ b/Source/TestHost/Cmdlets/AddTypeCommandTests.cs
@@ -42,16 +42,12 @@ namespace TestHost.Cmdlets
         {
             string result = TestHost.ExecuteWithZeroErrors(
                 "Add-Type -TypeDefinition 'public class ErrorTest --'",
-                "'error[0].Exception.Message=' + $error[0].Exception.Message",
-                "'error[0].FullyQualifiedErrorId=' + $error[0].FullyQualifiedErrorId",
                 "$compilerErrorCount = 0",
                 "$error | ForEach-Object { if ( $_.FullyQualifiedErrorId -eq 'SOURCE_CODE_ERROR,Microsoft.PowerShell.Commands.AddTypeCommand') { $compilerErrorCount += 1 } }",
                 "if ($compilerErrorCount -gt 0) { 'Compiler error reported' }"
             );
 
-            StringAssert.Contains("error[0].Exception.Message=Cannot add type. There were compilation errors.", result);
             // TODO: Original error record information is lost.
-            //StringAssert.Contains("error[0].FullyQualifiedErrorId=COMPILER_ERRORS,Microsoft.PowerShell.Commands.AddTypeCommand", result);
             StringAssert.Contains("Compiler error reported", result);
         }
 
@@ -60,16 +56,12 @@ namespace TestHost.Cmdlets
         {
             string result = TestHost.ExecuteWithZeroErrors(
                 "add-type -name Test -memberdefinition 'public WriteLine() ---'",
-                "'error[0].Exception.Message=' + $error[0].Exception.Message",
-                "'error[0].FullyQualifiedErrorId=' + $error[0].FullyQualifiedErrorId",
                 "$compilerErrorCount = 0",
                 "$error | ForEach-Object { if ( $_.FullyQualifiedErrorId -eq 'SOURCE_CODE_ERROR,Microsoft.PowerShell.Commands.AddTypeCommand') { $compilerErrorCount += 1 } }",
                 "if ($compilerErrorCount -gt 0) { 'Multiple Compiler Errors' }"
             );
 
-            StringAssert.Contains("error[0].Exception.Message=Cannot add type. There were compilation errors.", result);
             // TODO: Original error record information is lost.
-            //StringAssert.Contains("error[0].FullyQualifiedErrorId=COMPILER_ERRORS,Microsoft.PowerShell.Commands.AddTypeCommand", result);
             StringAssert.Contains("Multiple Compiler Errors", result);
         }
 
@@ -79,14 +71,11 @@ namespace TestHost.Cmdlets
             string fileName = CreateTempFile("AddTypeDefinitionFromFileWithInvalidCSharpCode.cs", "public class ErrorTest --");
             string result = TestHost.ExecuteWithZeroErrors(
                 "Add-Type -Path '" + fileName + "'",
-                "'error[0].Exception.Message=' + $error[0].Exception.Message",
-                "'error[0].FullyQualifiedErrorId=' + $error[0].FullyQualifiedErrorId",
                 "$compilerErrorCount = 0",
                 "$error | ForEach-Object { if ( $_.FullyQualifiedErrorId -eq 'SOURCE_CODE_ERROR,Microsoft.PowerShell.Commands.AddTypeCommand') { $compilerErrorCount += 1 } }",
                 "if ($compilerErrorCount -gt 0) { 'Compiler error reported' }"
             );
 
-            StringAssert.Contains("error[0].Exception.Message=Cannot add type. There were compilation errors.", result);
             // TODO: Original error record information is lost.
             //StringAssert.Contains("error[0].FullyQualifiedErrorId=COMPILER_ERRORS,Microsoft.PowerShell.Commands.AddTypeCommand", result);
             StringAssert.Contains("Compiler error reported", result);


### PR DESCRIPTION
Updated tests so they no longer check for text from exceptions that are locale specific.

Currently unable to use the FullyQualifiedErrorId for the terminating error due to #245
