### PR TITLE
Supporting for loops with less than three arguments.

### DIFF
--- a/Source/System.Management.Tests/Ast/Ast.Tests.cs
+++ b/Source/System.Management.Tests/Ast/Ast.Tests.cs
@@ -1319,9 +1319,27 @@ ls
         }
 
         [Test]
-        public void For()
+        public void For3Arguments()
         {
             ForStatementAst forStatementAst = ParseStatement("for ($i = 0; $i -ile 10; $i++) {Write-Host $i}");
+        }
+
+        [Test]
+        public void For2Arguments()
+        {
+            ForStatementAst forStatementAst = ParseStatement("for ($i = 0; $i -ile 10) {Write-Host $i}");
+        }
+
+        [Test]
+        public void For1Argument()
+        {
+            ForStatementAst forStatementAst = ParseStatement("for ($i = 0) {Write-Host $i}");
+        }
+
+        [Test]
+        public void ForEmpty()
+        {
+            ForStatementAst forStatementAst = ParseStatement("for () {Write-Host $i}");
         }
 
         [Test]

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -1035,12 +1035,18 @@ namespace System.Management.Pash.Implementation
              * expression tests True.
              */
 
-            EvaluateAst(forStatementAst.Initializer);
+            if (forStatementAst.Initializer != null)
+            {
+                EvaluateAst(forStatementAst.Initializer);
+            }
 
-            while ((bool)((PSObject)EvaluateAst(forStatementAst.Condition)).BaseObject)
+            while (forStatementAst.Condition != null ? (bool)((PSObject)EvaluateAst(forStatementAst.Condition)).BaseObject : true)
             {
                 this._pipelineCommandRuntime.WriteObject(EvaluateAst(forStatementAst.Body, false), true);
-                EvaluateAst(forStatementAst.Iterator);
+                if (forStatementAst.Iterator != null)
+                {
+                    EvaluateAst(forStatementAst.Iterator);
+                }
             }
 
             return AstVisitAction.SkipChildren;

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -426,9 +426,21 @@ namespace Pash.ParserIntrinsics
         {
             VerifyTerm(parseTreeNode, this._grammar.for_statement);
 
-            var initializerAst = BuildPipelineAst(parseTreeNode.ChildNodes[2].ChildNodes[0]);
-            var conditionAst = BuildPipelineAst(parseTreeNode.ChildNodes[2].ChildNodes[1]);
-            var iteratorAst = BuildPipelineAst(parseTreeNode.ChildNodes[2].ChildNodes[2]);
+            var headerAst = parseTreeNode.ChildNodes[2];
+
+            var initializerAst =
+                headerAst.ChildNodes.Count >= 1
+                    ? BuildPipelineAst(parseTreeNode.ChildNodes[2].ChildNodes[0])
+                    : null;
+            var conditionAst =
+                headerAst.ChildNodes.Count >= 2
+                    ? BuildPipelineAst(parseTreeNode.ChildNodes[2].ChildNodes[1])
+                    : null;
+            var iteratorAst =
+                headerAst.ChildNodes.Count == 3
+                    ? BuildPipelineAst(parseTreeNode.ChildNodes[2].ChildNodes[2])
+                    : null;
+
             var bodyAst = BuildStatementBlockAst(parseTreeNode.ChildNodes[4]);
 
             return new ForStatementAst(


### PR DESCRIPTION
Still unsolved: More than three arguments. The (our) grammar currently allows for that and it feels a bit wrong to throw an exception while building the AST (which would be at a very similar place here) instead of while matching the grammar. Not quite sure, though.
