### PR TITLE
Fixed support for case-insensitive parameter prefixes

### DIFF
--- a/Source/ReferenceTests/Language/CmdletParameterTests.cs
+++ b/Source/ReferenceTests/Language/CmdletParameterTests.cs
@@ -126,6 +126,14 @@ namespace ReferenceTests
         }
 
         [Test]
+        public void NamedParameterOnlyNeedsCaseInsensitiveStart()
+        {
+            var cmd = CmdletName(typeof(TestParametersByPipelinePropertyNamesCommand)) + " -f 'test'";
+            var res = ReferenceHost.Execute(cmd);
+            Assert.AreEqual(NewlineJoin("test "), res);
+        }
+
+        [Test]
         public void CmdletParameterWithSameAliasDontWork()
         {
             var cmd = CmdletName(typeof(TestSameAliasesCommand));

--- a/Source/System.Management/Automation/CmdletInfo.cs
+++ b/Source/System.Management/Automation/CmdletInfo.cs
@@ -95,7 +95,7 @@ namespace System.Management.Automation
 
             // if we didn't find it by name or alias, try to find it by prefix
             var candidates = (from key in ParameterInfoLookupTable.Keys
-                              where key.StartsWith(name)
+                              where key.StartsWith(name, StringComparison.OrdinalIgnoreCase)
                               select key).ToList();
             if (candidates.Count < 1)
             {


### PR DESCRIPTION
The patch speaks for itself: It should only be necessary to provide a case-insensitive prefix of a named parameter.
