### PR TITLE
Don't parse 1|2 as real literal.

### DIFF
--- a/Source/System.Management.Tests/Ast/Ast.Tests.cs
+++ b/Source/System.Management.Tests/Ast/Ast.Tests.cs
@@ -1809,6 +1809,17 @@ ls
             }
 
             [Test]
+            public void IncorrectExponentPartPattern()
+            {
+                // The grammar incorrectly accepted 1|2 as a real literal, but
+                // would generate an OverflowException for it. Thus, we test
+                // that the grammar does not even attempt to parse it as a real
+                // literal and gives us the expected PipelineAst instead.
+                ScriptBlockAst ast = ParseInput("1|2");
+                Assert.IsInstanceOfType(typeof(PipelineAst), ast.EndBlock.Statements[0]);
+            }
+
+            [Test]
             [TestCase("1.5mb", 1572864)]
             [TestCase("1.5MB", 1572864)]
             [TestCase("1.5kb", 1536)]

--- a/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.Terminals.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.Terminals.cs
@@ -453,7 +453,7 @@ namespace Pash.ParserIntrinsics
         ////        exponent_part:
         ////            e   sign_opt   decimal_digits
         public readonly RegexBasedTerminal exponent_part = null; // Initialized by reflection
-        const string exponent_part_pattern = "(?<exponent_part>" + "[e|E]" + sign_pattern + "?" + decimal_digits_pattern + ")";
+        const string exponent_part_pattern = "(?<exponent_part>" + "e" + sign_pattern + "?" + decimal_digits_pattern + ")";
 
 
         ////        sign:   one of


### PR DESCRIPTION
Typo in the grammar caused `1|2` to be parsed as a real literal (though it still would throw an OverflowException).

I'm not sure if the test is in the correct spot, so if it should be put somewhere else, let me know.
