### PR TITLE
Add support for escaped wildcard characters.

### DIFF
--- a/Source/ReferenceTests/API/WildcardPatternTests.cs
+++ b/Source/ReferenceTests/API/WildcardPatternTests.cs
@@ -43,7 +43,7 @@ namespace ReferenceTests
                 Assert.IsFalse(WildcardPattern.ContainsWildcardCharacters(input));
         }
 
-        [Test, Explicit]
+        [Test]
         [TestCase("`[", false)]
         [TestCase("`[a", false)]
         [TestCase("a`[", false)]
@@ -99,7 +99,7 @@ namespace ReferenceTests
                 Assert.IsFalse(WildcardPattern.ContainsWildcardCharacters(input));
         }
 
-        [Test, Explicit]
+        [Test]
         [TestCase("````*", true)]
         [TestCase("`````*", false)]
         [TestCase("````````````*", true)]

--- a/Source/System.Management/Automation/WildcardPattern.cs
+++ b/Source/System.Management/Automation/WildcardPattern.cs
@@ -33,7 +33,8 @@ namespace System.Management.Automation
                 return false;
             }
 
-            return pattern.IndexOfAny(new char[] { '?', '*', '[', ']' }) != -1;
+            var index = pattern.IndexOfAny(new char[] { '?', '*', '[', ']' });
+            return index >= 0 && !IsEscaped(pattern, index - 1);
         }
 
         /// <summary>
@@ -128,6 +129,25 @@ namespace System.Management.Automation
                              .Replace("?", ".");
 
             return "^" + pattern + "$";
+        }
+
+        private static bool IsEscaped(string pattern, int index)
+        {
+            var result = false;
+
+            for(int i = index; i >= 0; i--)
+            {
+                if (pattern[i] == '`')
+                {
+                    result = !result;
+                }
+                else
+                {
+                    return result;
+                }
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
This pull request enables tests previously marked `explicit` and fixes the resulting test failures by adding support for detecting escaped wildcard characters in a given string.
