### PR TITLE
Conversion from null and to bool

### DIFF
--- a/Source/ReferenceTests/Language/Operators/ConversionTests.cs
+++ b/Source/ReferenceTests/Language/Operators/ConversionTests.cs
@@ -7,6 +7,19 @@ namespace ReferenceTests.Language.Operators
     [TestFixture]
     public class ConversionTests : ReferenceTestBase
     {
+        [TestCase("[string]$notExisting", "")]
+        [TestCase("[string]$null", "")]
+        [TestCase("[int]$notExisting", 0)]
+        [TestCase("[int]$null", 0)]
+        [TestCase("[bool]$notExisting", false)]
+        [TestCase("[bool]$null", false)]
+        [TestCase("[float]$notExisting", 0.0f)]
+        [TestCase("[float]$null", 0.0f)]
+        public void NullIsCorrectlyConverted(string cmd, object expected)
+        {
+            ExecuteAndCompareTypedResult(cmd, expected);
+        }
+
         [TestCase("[string]5", "5")]
         [TestCase("[int]'5'", 5)]
         [TestCase("[int]2.7", 3)]
@@ -29,6 +42,28 @@ namespace ReferenceTests.Language.Operators
         public void CanConvertHexStringToInt()
         {
             ExecuteAndCompareTypedResult("[int]'0x1a'", (int)26);
+        }
+
+        [TestCase("[bool]1", true)]
+        [TestCase("[bool]-1", true)]
+        [TestCase("[bool]0", false)]
+        [TestCase("[bool]0.0D", false)]
+        [TestCase("[bool]0.1D", true)]
+        [TestCase("[bool]0.0", false)]
+        [TestCase("[bool]0.1", true)]
+        [TestCase("[bool]$null", false)]
+        [TestCase("[bool]$notExisting", false)]
+        [TestCase("[bool]@()", false)]
+        [TestCase("[bool]@(1)", true)]
+        [TestCase("[bool]@{}", true)]
+        [TestCase("[bool]@{a='b'}", true)]
+        [TestCase("[bool]''", false)]
+        [TestCase("[bool]'false'", true)]
+        [TestCase("[bool][Boolean]$true", true)]
+        [TestCase("[bool][Boolean]$false", false)]
+        public void ConvertToBoolWorks(string cmd, bool expected)
+        {
+            ExecuteAndCompareTypedResult(cmd, expected);
         }
 
         [TestCase("'-0x1a'")]

--- a/Source/System.Management/Automation/LanguagePrimitives.cs
+++ b/Source/System.Management/Automation/LanguagePrimitives.cs
@@ -235,9 +235,34 @@ namespace System.Management.Automation
                 return valueToConvert;
             }
 
-            if (valueToConvert != null && resultType == typeof(String))
+            if (resultType == typeof(String))
             {
-                return valueToConvert.ToString();
+                if (valueToConvert != null)
+                {
+                    return valueToConvert.ToString();
+                }
+                return "";
+            }
+
+            if (resultType == typeof(bool))
+            {
+                if (valueToConvert == null)
+                {
+                    return false;
+                }
+                else if (valueToConvert is string)
+                {
+                    return ((string)valueToConvert).Length != 0;
+                }
+                else if (valueToConvert is Array)
+                {
+                    return ((Array)valueToConvert).Length != 0;
+                }
+                else if (valueToConvert.GetType().IsNumeric())
+                {
+                    return ((dynamic)valueToConvert) != 0;
+                }
+                return true; // any object that's not null
             }
 
             if (valueToConvert != null && resultType.IsEnum) // enums have to be parsed
@@ -245,7 +270,7 @@ namespace System.Management.Automation
                 return Enum.Parse(resultType, valueToConvert.ToString(), true);
             }
 
-            if (valueToConvert != null && resultType.IsNumeric())
+            if (resultType.IsNumeric())
             {
                 try
                 {


### PR DESCRIPTION
`null` is now correctly converted to primitive types (numerics, bool, string).
General support for the conversion to boolean values.

Fixes one of the two issues of #269
