### PR TITLE
Made parsing robust to internal parser errors

### DIFF
--- a/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
@@ -321,7 +321,7 @@ namespace Pash.ParserIntrinsics
                 var msg = "The parser internally crashed and gets reinitialized." + Environment.NewLine +
                           "Although this shouldn't happen, it's likely that it happened because of invalid syntax.";
                 Parser = new Parser(Instance);
-                throw new SystemException(msg);
+                throw new InvalidOperationException(msg);
             }
 
             if (parseTree.HasErrors())


### PR DESCRIPTION
Some syntax, like `"foo".Contains(o)` caused the Parser to crash
and reach an invalid state. Though the syntax is wrong, the parser
shouldn't throw an NPE, but return errors instead.
However, until this is fixed, we need a fallback to reinitialize the
parser, so Pash doesn't also get in an invalid state.

This commit doesn't really "fix" the issue, but is a valid workaround, s.t. things as reported it #302 won't happen again.
