### PR TITLE
Fixed c# method invocation bug with null, enabled tests

### DIFF
--- a/Source/ReferenceTests/Integration/RosettaCode.cs
+++ b/Source/ReferenceTests/Integration/RosettaCode.cs
@@ -1165,7 +1165,7 @@ namespace ReferenceTests.Integration
             Assert.AreEqual(expected, actual);
         }
 
-        [Test, Explicit("Scope modifiers don't work in strings yet")]
+        [Test]
         // Taken from http://rosettacode.org/wiki/Scope_modifiers#PowerShell
         public void ScopeModifiers1()
         {
@@ -1182,7 +1182,7 @@ namespace ReferenceTests.Integration
             Assert.AreEqual(expected, actual);
         }
 
-        [Test, Explicit("NullReferenceException in Ast.cs:44")]
+        [Test]
         // Taken from http://rosettacode.org/wiki/Scope_modifiers#PowerShell
         public void ScopeModifiers2()
         {
@@ -1618,7 +1618,7 @@ namespace ReferenceTests.Integration
             Assert.AreEqual(expected, actual);
         }
 
-        [Test, Explicit("NullReferenceException in Ast.cs:44")]
+        [Test]
         // Taken from http://rosettacode.org/wiki/Variables#PowerShell
         public void Variables()
         {

--- a/Source/ReferenceTests/Language/ObjectMemberTests.cs
+++ b/Source/ReferenceTests/Language/ObjectMemberTests.cs
@@ -149,6 +149,12 @@ namespace ReferenceTests.Language
         }
 
         [Test]
+        public void CanInvokeMethodWithNullArg()
+        {
+            ExecuteAndCompareTypedResult("[string]::IsNullOrEmpty($null)", true);
+        }
+
+        [Test]
         public void PSObjectIsntCopiedAndPropertyIsUpdatable()
         {
             var result = ReferenceHost.Execute(NewlineJoin(

--- a/Source/System.Management/Automation/PSMethod.cs
+++ b/Source/System.Management/Automation/PSMethod.cs
@@ -133,22 +133,25 @@ namespace System.Management.Automation
             var candidates = new List<Tuple<MethodInfo, object[]>>();
             var numArgs = arguments.Length;
             // try direct match first
-            var argTypes = (from arg in arguments
-                                     select arg.GetType()).ToArray();
-            var methodInfo = _classType.GetMethod(Name, argTypes);
-            if (methodInfo != null && methodInfo.IsPublic && methodInfo.IsStatic != IsInstance)
+            if (!arguments.Contains(null))
             {
-                // this doesn't mean that we got all arguments for methodInfo, e.g. we'd have a
-                // methodInfo for a method that takes an optional argument although argTypes doesn't
-                // include it. As old mono versions don't support invoking with optional arguments
-                // we need to take care of it
-                object[] fittingArgs;
-                if (MethodFitsArgs(methodInfo, arguments, out fittingArgs))
+                var argTypes = (from arg in arguments
+                                    select arg.GetType()).ToArray();
+                var methodInfo = _classType.GetMethod(Name, argTypes);
+                if (methodInfo != null && methodInfo.IsPublic && methodInfo.IsStatic != IsInstance)
                 {
-                    newArguments = fittingArgs;
-                    return methodInfo;
+                    // this doesn't mean that we got all arguments for methodInfo, e.g. we'd have a
+                    // methodInfo for a method that takes an optional argument although argTypes doesn't
+                    // include it. As old mono versions don't support invoking with optional arguments
+                    // we need to take care of it
+                    object[] fittingArgs;
+                    if (MethodFitsArgs(methodInfo, arguments, out fittingArgs))
+                    {
+                        newArguments = fittingArgs;
+                        return methodInfo;
+                    }
+                    // if we weren't successful (shouldn't be the case, but who knows), we try all overloads
                 }
-                // if we weren't successful (shouldn't be the case, but who knows), we try all overloads
             }
 
             // then check methods with conersion, optionall parameters or "params" parameter


### PR DESCRIPTION
There were some crashes when a method was invoked with $null like in the added test.
