### PR TITLE
Fix null reference exception when parameters not passed to script.

### DIFF
--- a/Source/System.Management/Pash/Implementation/ScriptBlockProcessor.cs
+++ b/Source/System.Management/Pash/Implementation/ScriptBlockProcessor.cs
@@ -51,7 +51,12 @@ namespace Pash.Implementation
             {
                 return parameter.Value;
             }
-            return _scopedExecutionVisitor.EvaluateAst(scriptParameter.DefaultValue);;
+
+            if (scriptParameter.DefaultValue != null)
+            {
+                return _scopedExecutionVisitor.EvaluateAst(scriptParameter.DefaultValue);
+            }
+            return null;
         }
 
         private CommandParameter GetParameterByPosition(int position)

--- a/Source/TestHost/ScriptParameterTests.cs
+++ b/Source/TestHost/ScriptParameterTests.cs
@@ -62,5 +62,21 @@ Write-Host $param1");
 
             Assert.AreEqual(result, string.Format("defaultValue{0}", Environment.NewLine));
         }
+
+        [Test]
+        public void NoParametersPassedToScriptThatTakesOneParameterNoDefaultValueCausesDefaultNullToBePassedAsParameter()
+        {
+            string fileName = CreateScript(@"param ($param1)
+
+if ($param1 -eq $null) {
+    Write-Host '$param1 is null'
+}
+");
+            string statement = string.Format("& '{0}'", fileName);
+
+            string result = TestHost.Execute(statement);
+
+            Assert.AreEqual(result, string.Format("$param1 is null{0}", Environment.NewLine));
+        }
     }
 }


### PR DESCRIPTION
A null reference exception would be thrown if a PowerShell script file containing a param script block, with one or more parameters, was run and no parameters were passed in the command line.

```
PASH> MyScript.ps1
```

MyScript.ps1 file:

```
 param ($a)
```
