### PR TITLE
Use the optional newline workaround for more keywords

### DIFF
--- a/Source/ReferenceTests/Language/IfElseTests.cs
+++ b/Source/ReferenceTests/Language/IfElseTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ReferenceTests.Language
+{
+    [TestFixture]
+    public class IfElseTests : ReferenceTestBase
+    {
+        [Test]
+        public void NewlinesCanSeparateIfAndElse()
+        {
+            var cmd = NewlineJoin("if ($false) { 1 }", "else { 2 }");
+            ExecuteAndCompareTypedResult(cmd, 2);
+        }
+
+        [Test]
+        public void NewlinesCanSeparateIfAndElseif()
+        {
+            var cmd = NewlineJoin("if ($false) { 1 }", "elseif ($true) { 2 }", "else { 3 }");
+            ExecuteAndCompareTypedResult(cmd, 2);
+        }
+    }
+}
+

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>ReferenceTests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -92,6 +92,7 @@
     <Compile Include="Language\Operators\PostfixIncrementDecrementTests_7_1_5.cs" />
     <Compile Include="GithubIssues\Issue200.cs" />
     <Compile Include="GithubIssues\Issue20.cs" />
+    <Compile Include="Language\IfElseTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">


### PR DESCRIPTION
Fixes issue #279.
Uses the same approach for the fix which was discussed in #244 and implemented for the param block in #321.
