### PR TITLE
Fixed bug in FormatGenerator to process exceptions

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Utility/Format/FormatGenerator.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/Format/FormatGenerator.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.Commands.Utility
             }
             else if (errorData.BaseObject is IContainsErrorRecord)
             {
-                errorRecord = ((IContainsErrorRecord)errorData).ErrorRecord;
+                errorRecord = ((IContainsErrorRecord)errorData.BaseObject).ErrorRecord;
             }
             else if (errorData.BaseObject is Exception)
             {

--- a/Source/TestHost/FullHostTests.cs
+++ b/Source/TestHost/FullHostTests.cs
@@ -132,6 +132,18 @@ namespace TestHost
             Assert.AreEqual(8, outlines.Length); // Banner + 5 x Prompts (per input line) + result + new prompt
             Assert.That(outlines[6], Is.EqualTo("foo"));
         }
+
+        [Test]
+        public void ParseErrorOnInputIsPrinted()
+        {
+            CreateFreshHostAndUI(true);
+            HostUI.OnWriteErrorLineString = s => HostUI.WriteLine(s); // we want to see errors in output
+            HostUI.SetInput("$" + Environment.NewLine); // simple parse error
+            FullHost.Run();
+            var outlines = HostUI.GetOutput().Split(new string[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
+            Assert.AreEqual(6, outlines.Length); // Banner + prompt + 3 error lines + prompt
+            Assert.That(outlines[2], Is.StringStarting("Parse error"));
+        }
     }
 }
 


### PR DESCRIPTION
I noticed this bug because of the new way of directly parsing input.
If a parse error occurs, "out-default" will be executed with the exception as input object.
