### PR TITLE
Fix New-Object for System.Uri with UriKind parameter.

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Utility/NewObjectCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/NewObjectCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.Commands.Utility
         {
             Type type = new TypeName(this.TypeName).GetReflectionType();
 
-            var result = PSObject.AsPSObject(Activator.CreateInstance(type, this.ArgumentList));
+            var result = PSObject.AsPSObject(Activator.CreateInstance(type, GetArguments()));
 
             if (Property != null)
             {
@@ -40,6 +40,17 @@ namespace Microsoft.PowerShell.Commands.Utility
             }
 
             WriteObject(result);
+        }
+
+        private object[] GetArguments()
+        {
+            if (ArgumentList == null)
+            {
+                return new object[0];
+            }
+
+            return (from arg in ArgumentList
+                    select PSObject.Unwrap(arg)).ToArray();
         }
 
         private void AddProperties(PSObject psobj)

--- a/Source/ReferenceTests/Commands/NewObjectTests.cs
+++ b/Source/ReferenceTests/Commands/NewObjectTests.cs
@@ -52,6 +52,17 @@ namespace ReferenceTests.Commands
                 Assert.AreEqual(expected[key], res.Properties[key].Value);
             }
         }
+
+        [Test]
+        public void CreateSystemUriUsingUriKindParameter()
+        {
+            string result = ReferenceHost.Execute(NewlineJoin(new string[] {
+                "$projectUri = new-object Uri('http://pash-project.github.io/', [System.UriKind]::Absolute)",
+                "$projectUri.AbsoluteUri"
+            }));
+
+            Assert.AreEqual("http://pash-project.github.io/" + Environment.NewLine, result);
+        }
     }
 }
 


### PR DESCRIPTION
Running the following command:

```
New-Object Uri('http://example.org', [System.UriKind]::Absolute)
```

Would fail with the error:

```
Constructor on type 'System.Uri' not found.
```

The problem was that the UriKind argument was a PSObject and needed
to be unwrapped before it was passed to Activator.CreateInstance(...)
