### PR TITLE
Support file redirection

### DIFF
--- a/Source/ReferenceTests/Language/FileRedirectionTests.cs
+++ b/Source/ReferenceTests/Language/FileRedirectionTests.cs
@@ -27,6 +27,18 @@ namespace ReferenceTests.Language
             Assert.AreEqual(NewlineJoin(lines), NewlineJoin(ReadLinesFromFile(fileName)));
         }
 
+        private void AssertTempFileContainsSubstring(string expectedText)
+        {
+            string output = NewlineJoin(ReadLinesFromFile(_tempFileName));
+            StringAssert.Contains(expectedText, output);
+        }
+
+        private void AssertTempFileDoesNotContainSubstring(string expectedText)
+        {
+            string output = NewlineJoin(ReadLinesFromFile(_tempFileName));
+            StringAssert.DoesNotContain(expectedText, output);
+        }
+
         [Test]
         public void OutputStreamToFile()
         {
@@ -142,6 +154,42 @@ namespace ReferenceTests.Language
             ReferenceHost.Execute("$null, $null, $null > " + fileName);
 
             AssertTempFileContains("");
+        }
+
+        /// <summary>
+        /// TODO: Errors should be formatted.
+        /// </summary>
+        [Test]
+        public void ErrorStreamToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("write-error 'ErrorText' 2> " + fileName);
+
+            AssertTempFileContainsSubstring("ErrorText");
+        }
+
+        [Test]
+        public void ErrorStreamOverwritesExistingFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute(new string[] {
+                "write-error 'ErrorText1' 2> " + fileName,
+                "write-error 'ErrorText2' 2> " + fileName});
+
+            AssertTempFileDoesNotContainSubstring("ErrorText1");
+            AssertTempFileContainsSubstring("ErrorText2");
+        }
+
+        [Test]
+        public void ErrorStreamAppendedToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute(new string[] {
+                "write-error 'ErrorText1' 2> " + fileName,
+                "write-error 'ErrorText2' 2>> " + fileName});
+
+            AssertTempFileContainsSubstring("ErrorText1");
+            AssertTempFileContainsSubstring("ErrorText2");
         }
     }
 }

--- a/Source/ReferenceTests/Language/FileRedirectionTests.cs
+++ b/Source/ReferenceTests/Language/FileRedirectionTests.cs
@@ -98,5 +98,23 @@ namespace ReferenceTests.Language
         {
             Assert.DoesNotThrow(() => ReferenceHost.Execute("'abc' > $filename", throwOnError: true));
         }
+
+        [Test]
+        public void OutputIntegerArrayToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("1..4 > " + fileName);
+
+            AssertTempFileContains("1", "2", "3", "4");
+        }
+
+        [Test]
+        public void OutputStringArrayToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("'abc', 'def', 'ghi' > " + fileName);
+
+            AssertTempFileContains("abc", "def", "ghi");
+        }
     }
 }

--- a/Source/ReferenceTests/Language/FileRedirectionTests.cs
+++ b/Source/ReferenceTests/Language/FileRedirectionTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Language
+{
+    [TestFixture]
+    public class FileRedirectionTests : ReferenceTestBase
+    {
+        private string _tempFileName;
+
+        private string GenerateTempFileName(string fileName = "outputfile.txt")
+        {
+            _tempFileName = Path.Combine(Path.GetTempPath(), fileName);
+            AddCleanupFile(_tempFileName);
+            return _tempFileName;
+        }
+
+        private void AssertTempFileContains(params string[] lines)
+        {
+            AssertFileContains(_tempFileName, lines);
+        }
+
+        private void AssertFileContains(string fileName, params string[] lines)
+        {
+            Assert.AreEqual(NewlineJoin(lines), NewlineJoin(ReadLinesFromFile(fileName)));
+        }
+
+        [Test]
+        public void OutputStreamToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute(new string[] {
+                "$i = 10",
+                "$i > " + fileName});
+
+            AssertTempFileContains("10");
+        }
+
+        [Test]
+        public void OutputStreamToFileNameInSingleQuotes()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("'foobar' > '" + fileName + "'");
+
+            AssertTempFileContains("foobar");
+        }
+
+        [Test]
+        public void CommandOutputToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("get-command | ? { $_.name -eq 'where-object' } | % { $_.name } > " + fileName);
+
+            AssertTempFileContains("Where-Object");
+        }
+
+        [Test]
+        public void OutputStreamToSameFileTwiceShouldOverwriteExistingFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute(new string[] {
+                "'abc' > " + fileName,
+                "'def' > " + fileName});
+
+            AssertTempFileContains("def");
+        }
+
+        [Test]
+        public void AppendOutputStreamToFileThatDoesNotExist()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("'abc' >> " + fileName);
+
+            AssertTempFileContains("abc");
+        }
+
+        [Test]
+        public void AppendOutputStreamToSameFileShouldNotOverwriteExistingFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute(new string[] {
+                "'abc' > " + fileName,
+                "'def' >> " + fileName});
+
+            AssertTempFileContains("abc", "def");
+        }
+    }
+}

--- a/Source/ReferenceTests/Language/FileRedirectionTests.cs
+++ b/Source/ReferenceTests/Language/FileRedirectionTests.cs
@@ -116,5 +116,32 @@ namespace ReferenceTests.Language
 
             AssertTempFileContains("abc", "def", "ghi");
         }
+
+        [Test]
+        public void NullOutputToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("$null > " + fileName);
+
+            AssertTempFileContains("");
+        }
+
+        [Test]
+        public void OutputStringArrayWithNullsToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("'abc', $null, 'ghi' > " + fileName);
+
+            AssertTempFileContains("abc", "ghi");
+        }
+
+        [Test]
+        public void OutputArrayWithOnlyNullsToFile()
+        {
+            string fileName = GenerateTempFileName();
+            ReferenceHost.Execute("$null, $null, $null > " + fileName);
+
+            AssertTempFileContains("");
+        }
     }
 }

--- a/Source/ReferenceTests/Language/FileRedirectionTests.cs
+++ b/Source/ReferenceTests/Language/FileRedirectionTests.cs
@@ -86,5 +86,17 @@ namespace ReferenceTests.Language
 
             AssertTempFileContains("abc", "def");
         }
+
+        [Test]
+        public void OutputStreamToNullFileName()
+        {
+            Assert.DoesNotThrow(() => ReferenceHost.Execute("'abc' > $null", throwOnError: true));
+        }
+
+        [Test]
+        public void OutputStreamToFileNameVariableWhichIsNull()
+        {
+            Assert.DoesNotThrow(() => ReferenceHost.Execute("'abc' > $filename", throwOnError: true));
+        }
     }
 }

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Commands\RemoveModuleTests.cs" />
     <Compile Include="Commands\WhereObjectTests.cs" />
     <Compile Include="Integration\RosettaCode.cs" />
+    <Compile Include="Language\FileRedirectionTests.cs" />
     <Compile Include="Language\ObjectMemberTests.cs" />
     <Compile Include="Language\Operators\FormatOperatorTests_7_5.cs" />
     <Compile Include="Language\Operators\BitwiseTests.cs" />

--- a/Source/System.Management.Tests/Ast/Ast.Tests.cs
+++ b/Source/System.Management.Tests/Ast/Ast.Tests.cs
@@ -2194,6 +2194,37 @@ ls
                 Assert.AreEqual(RedirectionStream.Output, redirectAst.FromStream);
                 Assert.AreEqual("out.txt", redirectFileNameAst.Value);
             }
+
+            [Test]
+            public void OutputErrorStreamToFile()
+            {
+                CommandAst commandAst = Parse("Get-Process 2> out.txt");
+                var firstCommandElementAst = commandAst.CommandElements.FirstOrDefault() as StringConstantExpressionAst;
+                var redirectAst = commandAst.Redirections.FirstOrDefault() as FileRedirectionAst;
+                var redirectFileNameAst = redirectAst.Location as StringConstantExpressionAst;
+
+                Assert.AreEqual(1, commandAst.CommandElements.Count);
+                Assert.IsNotNull(firstCommandElementAst);
+                Assert.AreEqual("Get-Process", firstCommandElementAst.Value);
+                Assert.AreEqual(1, commandAst.Redirections.Count);
+                Assert.IsFalse(redirectAst.Append);
+                Assert.AreEqual(RedirectionStream.Error, redirectAst.FromStream);
+                Assert.IsNotNull(redirectFileNameAst);
+                Assert.AreEqual("out.txt", redirectFileNameAst.Value);
+            }
+
+            [Test]
+            public void ErrorStreamAppendedToFile()
+            {
+                CommandAst commandAst = Parse("Get-Process 2>> out.txt");
+                var firstCommandElementAst = commandAst.CommandElements.FirstOrDefault() as StringConstantExpressionAst;
+                var redirectAst = commandAst.Redirections.FirstOrDefault() as FileRedirectionAst;
+                var redirectFileNameAst = redirectAst.Location as StringConstantExpressionAst;
+
+                Assert.IsTrue(redirectAst.Append);
+                Assert.AreEqual(RedirectionStream.Error, redirectAst.FromStream);
+                Assert.AreEqual("out.txt", redirectFileNameAst.Value);
+            }
         }
     }
 }

--- a/Source/System.Management/Automation/Runspaces/Command.cs
+++ b/Source/System.Management/Automation/Runspaces/Command.cs
@@ -2,12 +2,12 @@
 using System;
 using Pash.Implementation;
 using System.Management.Automation.Language;
+using System.Management.Pash.Implementation;
 
 namespace System.Management.Automation.Runspaces
 {
     public sealed class Command
     {
-
         internal ScriptBlockAst ScriptBlockAst { get; set; }
 
         public string CommandText { get; private set; }
@@ -81,6 +81,7 @@ namespace System.Management.Automation.Runspaces
             cmdProcBase.ExecutionContext = executionContext;
             cmdProcBase.AddParameters(Parameters);
             SetMergeResultOptions(cmdProcBase);
+            cmdProcBase.RedirectionVisitor = RedirectionVisitor;
             return cmdProcBase;
         }
 
@@ -94,5 +95,7 @@ namespace System.Management.Automation.Runspaces
 
         internal PipelineResultTypes MergeMyResult { get; private set; }
         internal PipelineResultTypes MergeToResult { get; private set; }
+
+        internal RedirectionVisitor RedirectionVisitor { get; set; }
     }
 }

--- a/Source/System.Management/Pash/Implementation/CommandProcessor.cs
+++ b/Source/System.Management/Pash/Implementation/CommandProcessor.cs
@@ -115,6 +115,7 @@ namespace System.Management.Automation
             {
                 Command.DoEndProcessing();
                 ExecutionContext.SetSuccessVariable(true); // only false if we got an exception
+                ProcessRedirects();
             }
             catch (CmdletInvocationException)
             {

--- a/Source/System.Management/Pash/Implementation/CommandProcessorBase.cs
+++ b/Source/System.Management/Pash/Implementation/CommandProcessorBase.cs
@@ -2,6 +2,7 @@
 using System.Management.Automation.Runspaces;
 using System.Management.Automation;
 using System.Collections.ObjectModel;
+using System.Management.Pash.Implementation;
 
 namespace Pash.Implementation
 {
@@ -91,5 +92,15 @@ namespace Pash.Implementation
         /// Last but not least this is for cleanup of the CommandProcessor itself.
         /// </summary>
         public abstract void EndProcessing();
+
+        internal RedirectionVisitor RedirectionVisitor { get; set; }
+
+        internal void ProcessRedirects()
+        {
+            if (RedirectionVisitor != null)
+            {
+                RedirectionVisitor.Visit(CommandRuntime);
+            }
+        }
     }
 }

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionOperator.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionOperator.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using Irony.Parsing;
+using System.Management.Automation.Language;
+
+namespace System.Management.Pash.Implementation
+{
+    class FileRedirectionOperator
+    {
+        FileRedirectionOperator(RedirectionStream redirectionStream, bool append = false)
+        {
+            FromStream = redirectionStream;
+            IsAppend = append;
+        }
+
+        public RedirectionStream FromStream { get; private set; }
+        public bool IsAppend { get; private set; }
+
+        public static FileRedirectionOperator Get(ParseTreeNode parseTreeNode)
+        {
+            switch (parseTreeNode.Token.ValueString)
+            {
+                case ">":
+                    return new FileRedirectionOperator(RedirectionStream.Output);
+                case ">>":
+                    return new FileRedirectionOperator(RedirectionStream.Output, true);
+                case "2>":
+                    return new FileRedirectionOperator(RedirectionStream.Error);
+                case "2>>":
+                    return new FileRedirectionOperator(RedirectionStream.Error, true);
+                default:
+                    throw new NotImplementedException(parseTreeNode.ToString());
+            }
+        }
+    }
+}

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionVisitor.cs
@@ -73,8 +73,11 @@ namespace System.Management.Pash.Implementation
 
         private void WritePSObject(StreamWriter writer, object obj)
         {
-            var psObject = PSObject.AsPSObject(obj);
-            writer.WriteLine(psObject.ToString());
+            if (obj != null)
+            {
+                var psObject = PSObject.AsPSObject(obj);
+                writer.WriteLine(psObject.ToString());
+            }
         }
 
         private void WriteEnumerable(StreamWriter writer, IEnumerator enumerable)

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionVisitor.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace System.Management.Pash.Implementation
+{
+    class FileRedirectionVisitor
+    {
+        ExecutionVisitor _visitor;
+        PipelineCommandRuntime _runtime;
+
+        public FileRedirectionVisitor(ExecutionVisitor visitor, PipelineCommandRuntime runtime)
+        {
+            _visitor = visitor;
+            _runtime = runtime;
+        }
+
+        public AstVisitAction Visit(FileRedirectionAst redirectionAst)
+        {
+            string outputPath = _visitor.EvaluateAst(redirectionAst.Location, false).ToString();
+
+            FileMode fileMode = GetFileMode(redirectionAst);
+            FileStream file = File.Open(outputPath, fileMode, FileAccess.Write);
+            using (var streamWriter = new StreamWriter(file, Encoding.Unicode))
+            {
+                foreach (object o in _runtime.OutputStream.Read())
+                {
+                    var psObject = PSObject.AsPSObject(o);
+                    streamWriter.WriteLine(psObject.ToString());
+                }
+            }
+            return AstVisitAction.SkipChildren;
+        }
+
+        private FileMode GetFileMode(FileRedirectionAst redirectionAst)
+        {
+            if (redirectionAst.Append)
+            {
+                return FileMode.Append;
+            }
+            return FileMode.Create;
+        }
+    }
+}

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/FileRedirectionVisitor.cs
@@ -20,7 +20,11 @@ namespace System.Management.Pash.Implementation
 
         public AstVisitAction Visit(FileRedirectionAst redirectionAst)
         {
-            string outputPath = _visitor.EvaluateAst(redirectionAst.Location, false).ToString();
+            string outputPath = GetOutputFileName(redirectionAst);
+            if (outputPath == null)
+            {
+                return AstVisitAction.SkipChildren;
+            }
 
             FileMode fileMode = GetFileMode(redirectionAst);
             FileStream file = File.Open(outputPath, fileMode, FileAccess.Write);
@@ -33,6 +37,16 @@ namespace System.Management.Pash.Implementation
                 }
             }
             return AstVisitAction.SkipChildren;
+        }
+
+        private string GetOutputFileName(FileRedirectionAst redirectionAst)
+        {
+            object outputPath = _visitor.EvaluateAst(redirectionAst.Location, false);
+            if (outputPath != null)
+            {
+                return outputPath.ToString();
+            }
+            return null;
         }
 
         private FileMode GetFileMode(FileRedirectionAst redirectionAst)

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/RedirectionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/RedirectionVisitor.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace System.Management.Pash.Implementation
+{
+    class RedirectionVisitor
+    {
+        ExecutionVisitor _visitor;
+        List<RedirectionAst> _redirections;
+
+        public RedirectionVisitor(ExecutionVisitor visitor, IEnumerable<RedirectionAst> redirections)
+        {
+            _visitor = visitor;
+            _redirections = redirections.ToList();
+        }
+
+        public void Visit(PipelineCommandRuntime runtime)
+        {
+            foreach (RedirectionAst redirectionAst in _redirections)
+            {
+                var fileRedirectionAst = redirectionAst as FileRedirectionAst;
+                if (fileRedirectionAst != null)
+                {
+                    var redirectionVisitor = new FileRedirectionVisitor(_visitor, runtime);
+                    redirectionVisitor.Visit(fileRedirectionAst);
+                }
+                else
+                {
+                    throw new NotImplementedException(redirectionAst.ToString());
+                }
+            }
+        }
+    }
+}

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -2207,30 +2207,17 @@ namespace Pash.ParserIntrinsics
 
             if (parseTreeNode.ChildNodes[0].Term == this._grammar.file_redirection_operator)
             {
+                FileRedirectionOperator redirectionOperator = FileRedirectionOperator.Get(parseTreeNode.ChildNodes[0]);
+
                 return new FileRedirectionAst(
                     new ScriptExtent(parseTreeNode),
-                    RedirectionStream.Output,
+                    redirectionOperator.FromStream,
                     BuildCommandArgumentAst(parseTreeNode.ChildNodes[1].ChildNodes[0]),
-                    IsFileRedirectionAppendOperator(parseTreeNode.ChildNodes[0]));
+                    redirectionOperator.IsAppend);
             }
             else
             {
                 throw new NotImplementedException(parseTreeNode.ToString());
-            }
-        }
-
-        private bool IsFileRedirectionAppendOperator(ParseTreeNode parseTreeNode)
-        {
-            VerifyTerm(parseTreeNode, this._grammar.file_redirection_operator);
-
-            switch (parseTreeNode.Token.ValueString)
-            {
-                case ">>":
-                    return true;
-                case ">":
-                    return false;
-                default:
-                    throw new NotImplementedException(parseTreeNode.ToString());
             }
         }
     }

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -423,6 +423,7 @@
     <Compile Include="Pash\BitwiseOperation.cs" />
     <Compile Include="Pash\Implementation\CommonCmdlet.cs" />
     <Compile Include="Pash\Implementation\CommonCmdletParameters.cs" />
+    <Compile Include="Pash\Implementation\ExecutionVisitorHelper\FileRedirectionOperator.cs" />
     <Compile Include="Pash\Implementation\ExecutionVisitorHelper\FileRedirectionVisitor.cs" />
     <Compile Include="Pash\Implementation\ExecutionVisitorHelper\RedirectionVisitor.cs" />
     <Compile Include="Pash\Implementation\getline.cs" />
@@ -529,7 +530,5 @@
   <ItemGroup>
     <Content Include="Pash\ParserIntrinsics\README.TXT" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Pash\Implementation\ExecutionVisitorHelper\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -423,6 +423,8 @@
     <Compile Include="Pash\BitwiseOperation.cs" />
     <Compile Include="Pash\Implementation\CommonCmdlet.cs" />
     <Compile Include="Pash\Implementation\CommonCmdletParameters.cs" />
+    <Compile Include="Pash\Implementation\ExecutionVisitorHelper\FileRedirectionVisitor.cs" />
+    <Compile Include="Pash\Implementation\ExecutionVisitorHelper\RedirectionVisitor.cs" />
     <Compile Include="Pash\Implementation\getline.cs" />
     <Compile Include="Pash\Implementation\CommandManager.cs" />
     <Compile Include="Pash\Implementation\CommandProcessor.cs" />


### PR DESCRIPTION
Support file redirection for the output and error stream.

The following statements now run in Pash:

    'abc' > output.txt
    'def' >> output.txt
    Write-Error 'Error' 2> output.txt
    Write-Error 'Error' 2>> output.txt

Currently the outputted objects are not using the standard formatters so the generated text in the file can be wrong if it is not a simple type such as a string.