### PR TITLE
Support for drive providers, New-PSDrive, Get-PSDrive, Remove-PSDrive

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Management/CoreCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/CoreCommandBase.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
+using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 using Pash.Implementation;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -12,12 +14,9 @@ namespace Microsoft.PowerShell.Commands
         public virtual string[] Exclude { get; set; }
         public virtual string Filter { get; set; }
         public virtual SwitchParameter Force { get; set; }
-        public bool SupportsShouldProcess { get; protected set; }
+        protected virtual bool ProviderSupportsShouldProcess { get { return true; } }
 
-        protected CoreCommandBase()
-        {
-            SupportsShouldProcess = true;
-        }
+        public bool SupportsShouldProcess { get { return ProviderSupportsShouldProcess; } }
 
         protected bool DoesProviderSupportShouldProcess(string[] paths)
         {
@@ -29,13 +28,16 @@ namespace Microsoft.PowerShell.Commands
             throw new NotImplementedException();
         }
 
-        internal ProviderRuntime ProviderRuntime
+        internal virtual ProviderRuntime ProviderRuntime
         {
             get
             {
-                ProviderRuntime providerRuntime = new ProviderRuntime(this);
-                // TODO: set the Force, Filter, Include, Exlude on the runtime
-                return providerRuntime;
+                var runtime = new ProviderRuntime(this);
+                runtime.Include = Include == null ? new Collection<string>() : new Collection<string>(Include.ToList());
+                runtime.Exclude = Exclude == null ? new Collection<string>() : new Collection<string>(Exclude.ToList());
+                runtime.Filter = Filter;
+                runtime.Force = Force;
+                return runtime;
             }
         }
     }

--- a/Source/Microsoft.PowerShell.Commands.Management/CoreCommandWithCredentialsBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/CoreCommandWithCredentialsBase.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Management.Automation;
+using Pash.Implementation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public class CoreCommandWithCredentialsBase : CoreCommandBase
+    {
+        [Credential]
+        [Parameter(ValueFromPipelineByPropertyName=true)]
+        public PSCredential Credential { get; set; }
+
+        protected CoreCommandWithCredentialsBase()
+        {
+        }
+
+        internal virtual ProviderRuntime ProviderRuntime
+        {
+            get
+            {
+                var runtime = base.ProviderRuntime;
+                runtime.Credential = Credential;
+                return runtime;
+            }
+        }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Commands.Management/DriveMatchingCoreCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/DriveMatchingCoreCommandBase.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Linq;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -12,28 +13,40 @@ namespace Microsoft.PowerShell.Commands
 
         }
 
-        internal List<PSDriveInfo> GetDrivesByName(string driveName, string[] providerNames)
+        internal List<PSDriveInfo> GetDrives(string[] literalName, string[] name, string[] providerNames, string scope)
         {
-            List<PSDriveInfo> list = new List<PSDriveInfo>();
-            if ((providerNames == null) || (providerNames.Length == 0))
-            {
-                // TODO: make sure to find the drive names via patterns
-                providerNames = new string[] { "" };
-            }
-            foreach (string str in providerNames)
-            {
-                // TODO: try to get the drive from all the providers SessionState.Provider.Get(providerName)
+            var drives = SessionState.Drive.GetAllAtScope(scope);
+            var filtered = FilterDriveByProvider(drives, providerNames);
+            filtered = FilterDriveByName(filtered, literalName, name);
+            return filtered.ToList();
+        }
 
-                foreach (PSDriveInfo info in SessionState.Drive.GetAll())
-                {
-                    if (string.Equals(info.Name, driveName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        list.Add(info);
-                    }
-                }
+
+        internal IEnumerable<PSDriveInfo> FilterDriveByProvider(IEnumerable<PSDriveInfo> drives, string[] providerNames)
+        {
+            if (providerNames == null)
+            {
+                return drives;
             }
-            list.Sort();
-            return list;
+            return from d in drives where d.Provider.IsAnyNameMatch(providerNames) select d;
+        }
+
+        internal IEnumerable<PSDriveInfo> FilterDriveByName(IEnumerable<PSDriveInfo> drives, string[] literalName, string[] name)
+        {
+            if (literalName != null)
+            {
+                return from d in drives
+                       where literalName.Contains(d.Name, StringComparer.InvariantCultureIgnoreCase)
+                       select d;
+            }
+            if (name == null || name.Length == 0)
+            {
+                return drives;
+            }
+            var wildcards = (from n in name select new WildcardPattern(n, WildcardOptions.IgnoreCase)).ToArray();
+            return from d in drives
+                   where WildcardPattern.IsAnyMatch(wildcards, d.Name)
+                   select d;
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/DriveMatchingCoreCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/DriveMatchingCoreCommandBase.cs
@@ -15,7 +15,8 @@ namespace Microsoft.PowerShell.Commands
 
         internal List<PSDriveInfo> GetDrives(string[] literalName, string[] name, string[] providerNames, string scope)
         {
-            var drives = SessionState.Drive.GetAllAtScope(scope);
+            var drives = String.IsNullOrEmpty(scope) ? SessionState.Drive.GetAll() 
+                                                     : SessionState.Drive.GetAllAtScope(scope);
             var filtered = FilterDriveByProvider(drives, providerNames);
             filtered = FilterDriveByName(filtered, literalName, name);
             return filtered.ToList();

--- a/Source/Microsoft.PowerShell.Commands.Management/GetLocationCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/GetLocationCommand.cs
@@ -36,14 +36,10 @@ namespace Microsoft.PowerShell.Commands
                 if ((PSDrive != null) && (PSDrive.Length > 0))
                 {
                     // If location is requested for a specific drive
-                    foreach (string str in PSDrive)
+                    List<PSDriveInfo> list = GetDrives(PSDrive, null, PSProvider, "local");
+                    foreach (PSDriveInfo pdi in list)
                     {
-                        List<PSDriveInfo> list = GetDrivesByName(str, PSProvider);
-
-                        foreach (PSDriveInfo pdi in list)
-                        {
-                            WriteObject(new PathInfo(pdi, pdi.Provider, pdi.CurrentLocation.MakePath(pdi.Name), SessionState));
-                        }
+                        WriteObject(new PathInfo(pdi, pdi.Provider, pdi.CurrentLocation.MakePath(pdi.Name), SessionState));
                     }
                 }
                 else if ((PSProvider != null) && (PSProvider.Length > 0))

--- a/Source/Microsoft.PowerShell.Commands.Management/GetPSDriveCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/GetPSDriveCommand.cs
@@ -24,35 +24,8 @@ namespace Microsoft.PowerShell.Commands
 
         protected override void ProcessRecord()
         {
-            var drives = SessionState.Drive.GetAllAtScope(Scope);
-            WriteObject(FilterDriveByName(FilterDriveByProvider(drives)), true);
-        }
-
-        private IEnumerable<PSDriveInfo> FilterDriveByProvider(IEnumerable<PSDriveInfo> drives)
-        {
-            if (PSProvider == null)
-            {
-                return drives;
-            }
-            return from d in drives where d.Provider.IsAnyNameMatch(PSProvider) select d;
-        }
-
-        private IEnumerable<PSDriveInfo> FilterDriveByName(IEnumerable<PSDriveInfo> drives)
-        {
-            if (LiteralName != null)
-            {
-                return from d in drives
-                       where LiteralName.Contains(d.Name, StringComparer.InvariantCultureIgnoreCase)
-                       select d;
-            }
-            if (Name == null)
-            {
-                return drives;
-            }
-            var wildcards = (from n in Name select new WildcardPattern(n, WildcardOptions.IgnoreCase)).ToArray();
-            return from d in drives
-                   where WildcardPattern.IsAnyMatch(wildcards, d.Name)
-                   select d;
+            var drives = GetDrives(LiteralName, Name, PSProvider, Scope);
+            WriteObject(drives, true);
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/GetPSProviderCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/GetPSProviderCommand.cs
@@ -1,4 +1,6 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Linq;
 using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands
@@ -9,16 +11,16 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
         public string[] PSProvider { get; private set; }
 
-        public GetPSProviderCommand()
-        {
-            PSProvider = new string[0];
-        }
-
         protected override void ProcessRecord()
         {
+            var providers = PSProvider == null ? new [] { "*" } : PSProvider;
+            var patterns = (from p in providers select new WildcardPattern(p, WildcardOptions.IgnoreCase)).ToArray();
             foreach (ProviderInfo info in SessionState.Provider.GetAll())
             {
-                WriteObject(info);
+                if (WildcardPattern.IsAnyMatch(patterns, info.Name))
+                {
+                    WriteObject(info);
+                }
             }
         }
     }

--- a/Source/Microsoft.PowerShell.Commands.Management/GetPSProviderCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/GetPSProviderCommand.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerShell.Commands
     public class GetPSProviderCommand : PSCmdlet
     {
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
-        public string[] PSProvider { get; private set; }
+        public string[] PSProvider { get; set; }
 
         protected override void ProcessRecord()
         {

--- a/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
@@ -86,6 +86,8 @@
     <Compile Include="StopProcessCommand.cs" />
     <Compile Include="StopServiceCommand.cs" />
     <Compile Include="SuspendServiceCommand.cs" />
+    <Compile Include="NewPSDriveCommand.cs" />
+    <Compile Include="CoreCommandWithCredentialsBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{91225A72-A021-4B7D-BA56-5E1B7AC02F03}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -41,6 +41,8 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <WarningLevel>4</WarningLevel>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -50,6 +52,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -88,6 +91,7 @@
     <Compile Include="SuspendServiceCommand.cs" />
     <Compile Include="NewPSDriveCommand.cs" />
     <Compile Include="CoreCommandWithCredentialsBase.cs" />
+    <Compile Include="RemovePSDriveCommand.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/Microsoft.PowerShell.Commands.Management/NewPSDriveCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/NewPSDriveCommand.cs
@@ -33,8 +33,9 @@ namespace Microsoft.PowerShell.Commands
         protected override void ProcessRecord()
         {
             var provider = SessionState.Provider.GetOne(PSProvider);
-            var drive = new PSDriveInfo(Name, provider, Root, Description, Credential);
-            SessionState.Drive.New(drive, Scope ?? "local", ProviderRuntime);
+            var driveInfo = new PSDriveInfo(Name, provider, Root, Description, Credential);
+            var realDrive = SessionState.Drive.New(driveInfo, Scope ?? "local", ProviderRuntime);
+            WriteObject(realDrive);
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/NewPSDriveCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/NewPSDriveCommand.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [CmdletAttribute("New", "PSDrive", SupportsShouldProcess=true /* , SupportsTransactions=true,
+                     HelpUri="http://go.microsoft.com/fwlink/?LinkID=113357"*/)] 
+    public class NewPSDriveCommand : CoreCommandWithCredentialsBase
+    {
+        [Parameter(Position=0, Mandatory=true, ValueFromPipelineByPropertyName=true)]
+        public string Name { get; set; }
+
+        [Parameter(Position=1, Mandatory=true, ValueFromPipelineByPropertyName=true)]
+        public string PSProvider { get; set; }
+
+        [Parameter(Position=2, Mandatory=true, ValueFromPipelineByPropertyName=true)]
+        [AllowEmptyString]
+        public string Root { get; set; }
+
+        [Parameter(ValueFromPipelineByPropertyName=true)]
+        public string Description { get; set; }
+
+        [ParameterAttribute(ValueFromPipelineByPropertyName=true)]
+        public string Scope { get; set; }
+
+        /*
+        [Parameter(ValueFromPipelineByPropertyName=true)] 
+        public SwitchParameter Persist { get; set; }
+        */
+
+        protected override bool ProviderSupportsShouldProcess { get { return true; } }
+
+        protected override void ProcessRecord()
+        {
+            var provider = SessionState.Provider.GetOne(PSProvider);
+            var drive = new PSDriveInfo(Name, provider, Root, Description, Credential);
+            SessionState.Drive.New(drive, Scope ?? "local", ProviderRuntime);
+        }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Commands.Management/RemovePSDriveCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/RemovePSDriveCommand.cs
@@ -27,7 +27,11 @@ namespace Microsoft.PowerShell.Commands
 
         protected override void ProcessRecord()
         {
-
+            var drives = GetDrives(LiteralName, Name, PSProvider, Scope);
+            foreach (var drive in drives)
+            {
+                SessionState.Drive.Remove(drive, Scope, ProviderRuntime);
+            }
         }
 
     }

--- a/Source/Microsoft.PowerShell.Commands.Management/RemovePSDriveCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/RemovePSDriveCommand.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [Cmdlet("Remove", "PSDrive", DefaultParameterSetName="Name", SupportsShouldProcess=true
+                    /*, SupportsTransactions=true, HelpUri="http://go.microsoft.com/fwlink/?LinkID=113376"*/)] 
+    public class RemovePSDriveCommand : DriveMatchingCoreCommandBase
+    {
+        [Parameter(Position=0, ParameterSetName="LiteralName", Mandatory=true, ValueFromPipeline=false,
+                            ValueFromPipelineByPropertyName=true)]
+        public string[] LiteralName { get; set; }
+
+        [AllowEmptyCollection]
+        [AllowNull]
+        [Parameter(Position=0, ParameterSetName="Name", Mandatory=true, ValueFromPipelineByPropertyName=true)]
+        public string[] Name { get; set; }
+
+        [ParameterAttribute(ValueFromPipelineByPropertyName=true)]
+        public string Scope { get; set; }
+
+        [Parameter(ValueFromPipelineByPropertyName=true)]
+        public string[] PSProvider { get; set; }
+
+        [Parameter]
+        public override SwitchParameter Force { get; set; }
+
+        protected override void ProcessRecord()
+        {
+
+        }
+
+    }
+}
+

--- a/Source/ReferenceTests/Commands/ModuleCommandTestBase.cs
+++ b/Source/ReferenceTests/Commands/ModuleCommandTestBase.cs
@@ -8,19 +8,6 @@ namespace ReferenceTests
 {
     public class ModuleCommandTestBase : ReferenceTestBase
     {
-        private string _binaryTestModule;
-        public string BinaryTestModule
-        {
-            get
-            {
-                if (_binaryTestModule == null)
-                {
-                    _binaryTestModule = new UriBuilder(typeof(TestCommand).Assembly.CodeBase).Path;
-                }
-                return _binaryTestModule;
-            }
-        }
-
         public string CreateManifest(Dictionary<string, string> args )
         {
             return CreateManifest(null, null, null, null, null, null, null, null, args);

--- a/Source/ReferenceTests/Providers/DriveCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/DriveCmdletProviderTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using NUnit.Framework;
+using TestPSSnapIn;
+
+namespace ReferenceTests.Providers
+{
+    // the auto-loaded test module also imports all test providers, so we can simply use them
+    [TestFixture]
+    public class DriveCmdletProviderTests : ReferenceTestBaseWithTestModule
+    {
+        [Test]
+        public void DriveCmdletProviderCanCreateDefaultDrive()
+        {
+            var cmd = NewlineJoin(
+                "$d = Get-PSDrive -PSProvider " + TestDriveProvider.ProviderName,
+                "$d.Name", // should be only one
+                "$d.Root" // is '/'
+            );
+            ExecuteAndCompareTypedResult(cmd, TestDriveProvider.DefaultDriveName, "/");
+        }
+
+        [Test]
+        public void DriveCmdletProviderCanCreateDrive()
+        {
+            var cmd = NewlineJoin(
+                "$d = New-PSDrive -Name 'testDrive' -Root '/test' -PSProvider " + TestDriveProvider.ProviderName,
+                "[object].ReferenceEquals((Get-PSDrive -Name 'testDrive'), $d)", // make sure it's listed by Get-PSDrive
+                "$d.GetType().FullName", // is a custom type
+                "$d.Root", // check if correctly passed
+                "$d.IsRemoved" // property of the custom type
+            );
+            ExecuteAndCompareTypedResult(cmd,
+                true, // listed by Get-PSDrive
+                typeof(TestDrive).FullName, // of correct custom type
+                "/test", // with correct root
+                false // correct value of custom property
+            );
+        }
+
+        [Test]
+        public void DriveCmdletProviderCanRemoveDrive()
+        {
+            var cmd = NewlineJoin(
+                "$d = New-PSDrive -Name 'testDrive' -Root '/test' -PSProvider " + TestDriveProvider.ProviderName,
+                "$d.IsRemoved", // property of the custom type is false by default
+                "$r = Remove-PSDrive -Name 'testDri*' -PSProvider " + TestDriveProvider.ProviderName,
+                "[object]::ReferenceEquals($d, $r)", // make sure it's the same object
+                "$d.IsRemoved", // should be true now, because of uninitialization
+                "Get-PSDrive -Name 'testDrive'" // should be null, as it's removed
+            );
+            ExecuteAndCompareTypedResult(cmd,
+                false, // custom property is false
+                true, // same object reference,
+                true, // custom property is now true
+                null // not listed anymore
+            );
+        }
+    }
+}
+

--- a/Source/ReferenceTests/Providers/DriveCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/DriveCmdletProviderTests.cs
@@ -24,7 +24,7 @@ namespace ReferenceTests.Providers
         {
             var cmd = NewlineJoin(
                 "$d = New-PSDrive -Name 'testDrive' -Root '/test' -PSProvider " + TestDriveProvider.ProviderName,
-                "[object].ReferenceEquals((Get-PSDrive -Name 'testDrive'), $d)", // make sure it's listed by Get-PSDrive
+                "[object]::ReferenceEquals((Get-PSDrive -Name 'testDrive'), $d)", // make sure it's listed by Get-PSDrive
                 "$d.GetType().FullName", // is a custom type
                 "$d.Root", // check if correctly passed
                 "$d.IsRemoved" // property of the custom type
@@ -43,16 +43,14 @@ namespace ReferenceTests.Providers
             var cmd = NewlineJoin(
                 "$d = New-PSDrive -Name 'testDrive' -Root '/test' -PSProvider " + TestDriveProvider.ProviderName,
                 "$d.IsRemoved", // property of the custom type is false by default
-                "$r = Remove-PSDrive -Name 'testDri*' -PSProvider " + TestDriveProvider.ProviderName,
-                "[object]::ReferenceEquals($d, $r)", // make sure it's the same object
+                "Remove-PSDrive -Name 'testDri*' -PSProvider " + TestDriveProvider.ProviderName,
                 "$d.IsRemoved", // should be true now, because of uninitialization
-                "Get-PSDrive -Name 'testDrive'" // should be null, as it's removed
+                "(Get-PSDrive | where Name -eq 'testDrive') -eq $null" // should be true, because testDrive was removed
             );
             ExecuteAndCompareTypedResult(cmd,
                 false, // custom property is false
-                true, // same object reference,
                 true, // custom property is now true
-                null // not listed anymore
+                true // not listed anymore
             );
         }
     }

--- a/Source/ReferenceTests/Providers/ProviderLoadingTests.cs
+++ b/Source/ReferenceTests/Providers/ProviderLoadingTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using NUnit.Framework;
+using TestPSSnapIn;
+
+namespace ReferenceTests.Providers
+{
+    [TestFixture]
+    public class ProviderLoadingTests : ReferenceTestBase
+    {
+        [Test]
+        public void ProviderFromModuleIsLoadedAndInitialized()
+        {
+            var cmd = NewlineJoin(
+                "Get-PSProvider " + TestDriveProvider.ProviderName, // make sure it's not loaded
+                "Import-Module '" + BinaryTestModule + "'",
+                "$p = Get-PSProvider " + TestDriveProvider.ProviderName,
+                "$p.ImplementingType.FullName", // to verify it's not empty and is the correct type
+                "$p.IsStopped" // query a property which is from the custom TestProviderInfo
+            );
+            ExecuteAndCompareTypedResult(cmd,
+                null, // not loaded at first
+                typeof(TestDriveProvider).FullName, // make sure the provider is loaded
+                false // the custom property
+            );
+        }
+
+        [Test]
+        public void ProviderFromModuleCanBeRemovedAndUninitialized()
+        {
+            var cmd = NewlineJoin(
+                "Import-Module '" + BinaryTestModule + "'",
+                "$p = Get-PSProvider " + TestDriveProvider.ProviderName,
+                "$p.IsStopped", // verify that this custom property is false
+                "Remove-Module " + BinaryTestModuleName,
+                "$p.IsStopped", // should be true now because of unitialization
+                "Get-PSProvider " + TestDriveProvider.ProviderName // should be null now
+            );
+            ExecuteAndCompareTypedResult(cmd,
+                false, // custom value is false first
+                true, // custom value is true after uninitialization
+                null // provider isn't present anymore
+            );
+        }
+    }
+}
+

--- a/Source/ReferenceTests/Providers/ProviderLoadingTests.cs
+++ b/Source/ReferenceTests/Providers/ProviderLoadingTests.cs
@@ -22,7 +22,7 @@ namespace ReferenceTests.Providers
             );
         }
 
-        [Test, Ignore("When executed with PS 3.0 this doesn't work. The same commands work as a script."+
+        [Test, Explicit("When executed with PS 3.0 this doesn't work. The same commands work as a script."+
                       "I think PS doesn't get the connection between the provider and the module anymore when NUnit is used")]
         public void ProviderFromModuleCanBeRemovedAndUninitialized()
         {

--- a/Source/ReferenceTests/Providers/ProviderLoadingTests.cs
+++ b/Source/ReferenceTests/Providers/ProviderLoadingTests.cs
@@ -11,35 +11,29 @@ namespace ReferenceTests.Providers
         public void ProviderFromModuleIsLoadedAndInitialized()
         {
             var cmd = NewlineJoin(
-                "Get-PSProvider " + TestDriveProvider.ProviderName, // make sure it's not loaded
+                "(Get-PSProvider | ? name -eq " + TestDriveProvider.ProviderName + ") -eq $null", // make sure it's not loaded
                 "Import-Module '" + BinaryTestModule + "'",
                 "$p = Get-PSProvider " + TestDriveProvider.ProviderName,
-                "$p.ImplementingType.FullName", // to verify it's not empty and is the correct type
-                "$p.IsStopped" // query a property which is from the custom TestProviderInfo
+                "$p.ImplementingType.FullName" // to verify it's not empty and is the correct type
             );
             ExecuteAndCompareTypedResult(cmd,
-                null, // not loaded at first
-                typeof(TestDriveProvider).FullName, // make sure the provider is loaded
-                false // the custom property
+                true, // not loaded at first
+                typeof(TestDriveProvider).FullName // make sure the provider is loaded
             );
         }
 
-        [Test]
+        [Test, Ignore("When executed with PS 3.0 this doesn't work. The same commands work as a script."+
+                      "I think PS doesn't get the connection between the provider and the module anymore when NUnit is used")]
         public void ProviderFromModuleCanBeRemovedAndUninitialized()
         {
             var cmd = NewlineJoin(
                 "Import-Module '" + BinaryTestModule + "'",
                 "$p = Get-PSProvider " + TestDriveProvider.ProviderName,
-                "$p.IsStopped", // verify that this custom property is false
+                "$p -eq $null", // false
                 "Remove-Module " + BinaryTestModuleName,
-                "$p.IsStopped", // should be true now because of unitialization
-                "Get-PSProvider " + TestDriveProvider.ProviderName // should be null now
+                "(Get-PSProvider | ? name -eq " + TestDriveProvider.ProviderName + ") -eq $null"// should be true now
             );
-            ExecuteAndCompareTypedResult(cmd,
-                false, // custom value is false first
-                true, // custom value is true after uninitialization
-                null // provider isn't present anymore
-            );
+            ExecuteAndCompareTypedResult(cmd, false, true);
         }
     }
 }

--- a/Source/ReferenceTests/ReferenceTestBase.cs
+++ b/Source/ReferenceTests/ReferenceTestBase.cs
@@ -23,6 +23,27 @@ namespace ReferenceTests
 
         public string AssemblyDirectory { get; set; }
 
+        private string _binaryTestModule;
+        public string BinaryTestModule
+        {
+            get
+            {
+                if (_binaryTestModule == null)
+                {
+                    _binaryTestModule = new Uri(typeof(TestCommand).Assembly.CodeBase).LocalPath;
+                }
+                return _binaryTestModule;
+            }
+        }
+
+        public string BinaryTestModuleName
+        {
+            get
+            {
+                return Path.GetFileNameWithoutExtension(BinaryTestModule);
+            }
+        }
+
         public ReferenceTestBase()
         {
             _createdFiles = new List<string>();

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -102,6 +102,8 @@
     <Compile Include="GithubIssues\Issue200.cs" />
     <Compile Include="GithubIssues\Issue20.cs" />
     <Compile Include="Language\IfElseTests.cs" />
+    <Compile Include="Providers\ProviderLoadingTests.cs" />
+    <Compile Include="Providers\DriveCmdletProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
@@ -96,18 +96,18 @@ namespace System.Management.Automation
             }
         }
 
-        internal void Load(Assembly assembly, PSModuleInfo moduleInfo)
+        internal void Load(Assembly assembly, ExecutionContext executionContext, PSModuleInfo moduleInfo)
         {
-            Load(assembly, null, moduleInfo);
+            Load(assembly, executionContext, null, moduleInfo);
         }
 
-        internal void Load(Assembly assembly, PSSnapInInfo snapinInfo)
+        internal void Load(Assembly assembly, ExecutionContext executionContext, PSSnapInInfo snapinInfo)
         {
-            Load(assembly, snapinInfo, null);
+            Load(assembly, executionContext, snapinInfo, null);
         }
 
         // private method avoids that accidentally both snapin and module get specified
-        private void Load(Assembly assembly, PSSnapInInfo snapinInfo, PSModuleInfo moduleInfo)
+        private void Load(Assembly assembly, ExecutionContext executionContext, PSSnapInInfo snapinInfo, PSModuleInfo moduleInfo)
         {
             // first get name and type of all providers in this assembly
             var providers = from Type type in assembly.GetTypes()
@@ -121,7 +121,7 @@ namespace System.Management.Automation
             {
                 ProviderInfo providerInfo = new ProviderInfo(_sessionState.RootSessionState, curPair.Value,
                                     curPair.Key, string.Empty, string.Empty, string.Empty, snapinInfo, moduleInfo);
-                Add(providerInfo);
+                Add(providerInfo, executionContext);
             }
         }
 
@@ -151,11 +151,11 @@ namespace System.Management.Automation
             list.Remove(info);
         }
 
-        private CmdletProvider Add(ProviderInfo providerInfo)
+        private CmdletProvider Add(ProviderInfo providerInfo, ExecutionContext executionContext)
         {
             CmdletProvider provider = providerInfo.CreateInstance();
 
-            providerInfo = provider.DoStart(providerInfo, new ProviderRuntime(_sessionState._globalExecutionContext));
+            providerInfo = provider.DoStart(providerInfo, new ProviderRuntime(executionContext));
             provider.SetProviderInfo(providerInfo);
 
             // Cache the Provider's Info and instance

--- a/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
@@ -96,7 +96,18 @@ namespace System.Management.Automation
             }
         }
 
+        internal void Load(Assembly assembly, PSModuleInfo moduleInfo)
+        {
+            Load(assembly, null, moduleInfo);
+        }
+
         internal void Load(Assembly assembly, PSSnapInInfo snapinInfo)
+        {
+            Load(assembly, snapinInfo, null);
+        }
+
+        // private method avoids that accidentally both snapin and module get specified
+        private void Load(Assembly assembly, PSSnapInInfo snapinInfo, PSModuleInfo moduleInfo)
         {
             // first get name and type of all providers in this assembly
             var providers = from Type type in assembly.GetTypes()
@@ -109,7 +120,7 @@ namespace System.Management.Automation
             foreach (var curPair in providers)
             {
                 ProviderInfo providerInfo = new ProviderInfo(_sessionState.RootSessionState, curPair.Value,
-                    curPair.Key, string.Empty, snapinInfo);
+                                    curPair.Key, string.Empty, string.Empty, string.Empty, snapinInfo, moduleInfo);
                 Add(providerInfo);
             }
         }
@@ -184,7 +195,7 @@ namespace System.Management.Automation
                 try
                 {
                     // always to global scope
-                    // use DoSkipInit because the dafault drives are inited
+                    // use NewSkipInit because the dafault drives are inited
                     _sessionState.RootSessionState.Drive.NewSkipInit(driveInfo,
                         SessionStateScope<PSDriveInfo>.ScopeSpecifiers.Global.ToString());
                 }

--- a/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
@@ -1,38 +1,249 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation.Provider;
 using Pash.Implementation;
+using System.Reflection;
 
 namespace System.Management.Automation
 {
     public sealed class CmdletProviderManagementIntrinsics
     {
         private SessionStateGlobal _sessionState;
+        private Dictionary<string, List<ProviderInfo>> _providers;
+        private Dictionary<string, List<CmdletProvider>> _providerInstances;
+        //private Dictionary<ProviderInfo, PSDriveInfo> _providersCurrentDrive;
+
+        // Powershell seems to support multiple providers with the same name. So let's do it too
 
         internal CmdletProviderManagementIntrinsics(SessionStateGlobal sessionState)
         {
             _sessionState = sessionState;
+            _providers = new Dictionary<string, List<ProviderInfo>>(StringComparer.CurrentCultureIgnoreCase);
+            _providerInstances = new Dictionary<string, List<CmdletProvider>>(StringComparer.CurrentCultureIgnoreCase);
+            //_providersCurrentDrive = new Dictionary<ProviderInfo, PSDriveInfo>();
         }
 
         public Collection<ProviderInfo> Get(string name)
         {
-            return _sessionState.GetProvidersByName(name);
+            return GetProvidersByName(name);
         }
 
         public IEnumerable<ProviderInfo> GetAll()
         {
-            return _sessionState.Providers;
+            return Providers;
         }
 
         public ProviderInfo GetOne(string name)
         {
-            return _sessionState.GetProviderByName(name);
+            return GetProviderByName(name);
         }
 
-        // internals
-        //internal static bool CheckProviderCapabilities(ProviderCapabilities capability, ProviderInfo provider);
-        //internal int Count { get; }
+        //TODO: this should go into CmdletProviderManagementIntrinsics
+        internal IEnumerable<ProviderInfo> Providers
+        {
+            get
+            {
+                List<ProviderInfo> list = new List<ProviderInfo>();
+                foreach (List<ProviderInfo> sublist in _providers.Values)
+                {
+                    list.AddRange(sublist);
+                }
+                return list;
+            }
+        }
+
+        internal ProviderInfo GetProviderByName(string name)
+        {
+            Collection<ProviderInfo> providers = GetProvidersByName(name);
+
+            if (providers.Count > 0)
+                return providers[0];
+
+            return null;
+        }
+
+        internal Collection<ProviderInfo> GetProvidersByName(string name)
+        {
+            if (_providers.ContainsKey(name))
+                return new Collection<ProviderInfo>(_providers[name]);
+
+            return new Collection<ProviderInfo>();
+        }
+
+        internal Collection<ProviderInfo> GetProviders(PSSnapInInfo snapinInfo)
+        {
+            Collection<ProviderInfo> snapinProviders = new Collection<ProviderInfo>();
+            foreach (var pair in _providers)
+            {
+                foreach (var provider in pair.Value)
+                {
+                    if (provider.PSSnapIn.Equals(snapinInfo))
+                    {
+                        snapinProviders.Add(provider);
+                    }
+                }
+            }
+            return snapinProviders;
+        }
+
+
+        internal CmdletProvider GetProviderInstance(string name)
+        {
+            if (_providerInstances.ContainsKey(name))
+            {
+                List<CmdletProvider> instanceList = _providerInstances[name];
+
+                if (instanceList.Count > 0)
+                {
+                    // Take the first one
+                    return instanceList[0] as CmdletProvider;
+                }
+            }
+
+            return null;
+        }
+
+        private void RemoveProvider(string name)
+        {
+            if (!_providers.ContainsKey(name))
+            {
+                throw new ProviderNotFoundException(name, SessionStateCategory.CmdletProvider, "RemoveProviderNotFound",
+                    null);
+            }
+            //remove all drives. TODO: I think _providers[name].Drive
+            foreach (var drive in _sessionState.RootSessionState.Drive.GetAllForProvider(name))
+            {
+                //remove from all scopes, sub-scopes might created a new drive using this provider
+                _sessionState.RootSessionState.Drive.RemoveAtAllScopes(drive);
+            }
+
+            //now also stop and remove all instances
+            if (_providerInstances.ContainsKey(name))
+            {
+                var instances = _providerInstances[name];
+                foreach (var inst in instances)
+                {
+                    //TODO: it should be possible to notify the provider that it's removed. That's also the intention
+                    //of the provider's Stop() method. However, the specification says that Stop() is protected. So
+                    //we need another, internal method, that can be called. I called it DoStop(), but this should
+                    //certainly be changed. Like ghaving an internal Stop() method with a useful argument
+                    inst.DoStop();
+                }
+            }
+            _providers.Remove(name);
+        }
+
+        private CmdletProvider AddProvider(ProviderInfo providerInfo)
+        {
+            CmdletProvider provider = providerInfo.CreateInstance();
+
+            provider.Start(providerInfo, new ProviderRuntime(_sessionState._globalExecutionContext));
+            provider.SetProviderInfo(providerInfo);
+
+            // Cache the Provider's Info
+            if (!_providers.ContainsKey(providerInfo.Name))
+            {
+                _providers.Add(providerInfo.Name, new List<ProviderInfo>());
+            }
+            _providers[providerInfo.Name].Add(providerInfo);
+
+            return provider;
+        }
+
+        internal CmdletProvider GetInstance(ProviderInfo info)
+        {
+            // TODO: do it better
+            return _providerInstances[info.Name].First();
+        }
+
+
+        private void InitializeProvider(CmdletProvider providerInstance, ProviderInfo provider)
+        {
+            List<PSDriveInfo> drives = new List<PSDriveInfo>();
+            DriveCmdletProvider driveProvider = providerInstance as DriveCmdletProvider;
+
+            if (driveProvider != null)
+            {
+                Collection<PSDriveInfo> collection = driveProvider.DoInitializeDefaultDrives();
+                if ((collection != null) && (collection.Count > 0))
+                {
+                    drives.AddRange(collection);
+                    //_providersCurrentDrive[provider] = collection[0];
+                }
+            }
+
+            if (drives.Count > 0)
+            {
+                foreach (PSDriveInfo driveInfo in drives)
+                {
+                    if (driveInfo != null)
+                    {
+                        // TODO: need to set driveInfo.Root
+                        // TODO:this should be automatically called when using DriveIntrinsics.New! #providerSupport
+                        driveProvider.DoNewDrive(driveInfo);
+
+                        try
+                        {
+                            //always to global scope
+                            _sessionState.RootSessionState.Drive.New(driveInfo,
+                                SessionStateScope<PSDriveInfo>.ScopeSpecifiers.Global.ToString());
+                        }
+                        catch
+                        {
+                            // TODO: What should we do if the drive name is not unique?
+                            // => I guess overwrite the old one and write a warning (however this works from here)
+                        }
+                    }
+                }
+            }
+        }
+
+        internal void RemoveProviders(PSSnapInInfo snapinInfo)
+        {
+            foreach (var provider in GetProviders(snapinInfo))
+            {
+                try
+                {
+                    RemoveProvider(provider.Name);
+                }
+                catch (ProviderNotFoundException)
+                {
+                    //TODO: it would be great to have the possibilities to write warnings here. It'd be nice notifying
+                    //the user about this strange effect, but isn't worth aborting the whole action
+                }
+            }
+        }
+
+        internal void LoadProvidersFromAssembly(Assembly assembly, PSSnapInInfo snapinInfo)
+        {
+            // first get name and type of all providers in this assembly
+            var providers = from Type type in assembly.GetTypes()
+                    where !type.IsSubclassOf(typeof(Cmdlet))
+                    where type.IsSubclassOf(typeof(CmdletProvider))
+                from CmdletProviderAttribute providerAttr in
+                type.GetCustomAttributes(typeof(CmdletProviderAttribute), true)
+                select new KeyValuePair<string, Type>(providerAttr.ProviderName, type);
+            // then initialize all providers
+            foreach (var curPair in providers)
+            {
+                ProviderInfo providerInfo = new ProviderInfo(_sessionState.RootSessionState, curPair.Value,
+                    curPair.Key, string.Empty, snapinInfo);
+                CmdletProvider provider = AddProvider(providerInfo);
+                InitializeProvider(provider, providerInfo);
+
+                // Cache the provider's instance
+                if (!_providerInstances.ContainsKey(providerInfo.Name))
+                {
+                    _providerInstances.Add(providerInfo.Name, new List<CmdletProvider>());
+                }
+                List<CmdletProvider> instanceList = _providerInstances[providerInfo.Name];
+                instanceList.Add(provider);
+            }
+        }
+
+
     }
 }

--- a/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
@@ -54,8 +54,18 @@ namespace System.Management.Automation
 
         internal Collection<ProviderInfo> Get(PSSnapInInfo snapinInfo)
         {
-            var providers = (from p in GetAll() where p.PSSnapIn.Equals(snapinInfo) select p).ToList();
-            return new Collection<ProviderInfo>(providers);
+            var providers = from p in GetAll()
+                            where p.PSSnapIn != null && p.PSSnapIn.Equals(snapinInfo)
+                            select p;
+            return new Collection<ProviderInfo>(providers.ToList());
+        }
+
+        internal Collection<ProviderInfo> Get(PSModuleInfo moduleInfo)
+        {
+            var providers = from p in GetAll()
+                            where p.Module != null && p.Module.Equals(moduleInfo)
+                            select p;
+            return new Collection<ProviderInfo>(providers.ToList());
         }
 
         internal CmdletProvider GetInstance(string name)
@@ -78,6 +88,22 @@ namespace System.Management.Automation
         internal CmdletProvider GetInstance(ProviderInfo info)
         {
             return _providerInstances[info];
+        }
+
+        internal void Remove(PSModuleInfo moduleInfo, ExecutionContext executionContext)
+        {
+            foreach (var provider in Get(moduleInfo))
+            {
+                try
+                {
+                    Remove(provider, executionContext);
+                }
+                catch (ProviderNotFoundException)
+                {
+                    //TODO: it would be great to have the possibilities to write warnings here. It'd be nice notifying
+                    //the user about this strange effect, but isn't worth aborting the whole action
+                }
+            }
         }
 
         internal void Remove(PSSnapInInfo snapinInfo, ExecutionContext executionContext)

--- a/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
@@ -12,60 +12,20 @@ namespace System.Management.Automation
     public sealed class CmdletProviderManagementIntrinsics
     {
         private SessionStateGlobal _sessionState;
-        private Dictionary<string, List<ProviderInfo>> _providers;
-        private Dictionary<string, List<CmdletProvider>> _providerInstances;
-        //private Dictionary<ProviderInfo, PSDriveInfo> _providersCurrentDrive;
-
         // Powershell seems to support multiple providers with the same name. So let's do it too
+        private Dictionary<string, List<ProviderInfo>> _providers;
+        private Dictionary<ProviderInfo, CmdletProvider> _providerInstances;
 
         internal CmdletProviderManagementIntrinsics(SessionStateGlobal sessionState)
         {
             _sessionState = sessionState;
             _providers = new Dictionary<string, List<ProviderInfo>>(StringComparer.CurrentCultureIgnoreCase);
-            _providerInstances = new Dictionary<string, List<CmdletProvider>>(StringComparer.CurrentCultureIgnoreCase);
-            //_providersCurrentDrive = new Dictionary<ProviderInfo, PSDriveInfo>();
+            _providerInstances = new Dictionary<ProviderInfo, CmdletProvider>();
         }
+
+        #region public API
 
         public Collection<ProviderInfo> Get(string name)
-        {
-            return GetProvidersByName(name);
-        }
-
-        public IEnumerable<ProviderInfo> GetAll()
-        {
-            return Providers;
-        }
-
-        public ProviderInfo GetOne(string name)
-        {
-            return GetProviderByName(name);
-        }
-
-        //TODO: this should go into CmdletProviderManagementIntrinsics
-        internal IEnumerable<ProviderInfo> Providers
-        {
-            get
-            {
-                List<ProviderInfo> list = new List<ProviderInfo>();
-                foreach (List<ProviderInfo> sublist in _providers.Values)
-                {
-                    list.AddRange(sublist);
-                }
-                return list;
-            }
-        }
-
-        internal ProviderInfo GetProviderByName(string name)
-        {
-            Collection<ProviderInfo> providers = GetProvidersByName(name);
-
-            if (providers.Count > 0)
-                return providers[0];
-
-            return null;
-        }
-
-        internal Collection<ProviderInfo> GetProvidersByName(string name)
         {
             if (_providers.ContainsKey(name))
                 return new Collection<ProviderInfo>(_providers[name]);
@@ -73,141 +33,60 @@ namespace System.Management.Automation
             return new Collection<ProviderInfo>();
         }
 
-        internal Collection<ProviderInfo> GetProviders(PSSnapInInfo snapinInfo)
+        public IEnumerable<ProviderInfo> GetAll()
         {
-            Collection<ProviderInfo> snapinProviders = new Collection<ProviderInfo>();
-            foreach (var pair in _providers)
+            List<ProviderInfo> list = new List<ProviderInfo>();
+            foreach (List<ProviderInfo> sublist in _providers.Values)
             {
-                foreach (var provider in pair.Value)
-                {
-                    if (provider.PSSnapIn.Equals(snapinInfo))
-                    {
-                        snapinProviders.Add(provider);
-                    }
-                }
+                list.AddRange(sublist);
             }
-            return snapinProviders;
+            return list;
         }
 
-
-        internal CmdletProvider GetProviderInstance(string name)
+        public ProviderInfo GetOne(string name)
         {
-            if (_providerInstances.ContainsKey(name))
-            {
-                List<CmdletProvider> instanceList = _providerInstances[name];
+            return Get(name).FirstOrDefault();
+        }
 
-                if (instanceList.Count > 0)
-                {
-                    // Take the first one
-                    return instanceList[0] as CmdletProvider;
-                }
+        #endregion
+
+        #region internal functionality
+
+        internal Collection<ProviderInfo> Get(PSSnapInInfo snapinInfo)
+        {
+            var providers = (from p in GetAll() where p.PSSnapIn.Equals(snapinInfo) select p).ToList();
+            return new Collection<ProviderInfo>(providers);
+        }
+
+        internal CmdletProvider GetInstance(string name)
+        {
+            if (!_providers.ContainsKey(name))
+            {
+                return null;
+            }
+            List<ProviderInfo> providerList = _providers[name];
+
+            if (providerList.Count > 0)
+            {
+                // take first one or null
+                return _providerInstances[providerList[0]];
             }
 
             return null;
         }
 
-        private void RemoveProvider(string name)
-        {
-            if (!_providers.ContainsKey(name))
-            {
-                throw new ProviderNotFoundException(name, SessionStateCategory.CmdletProvider, "RemoveProviderNotFound",
-                    null);
-            }
-            //remove all drives. TODO: I think _providers[name].Drive
-            foreach (var drive in _sessionState.RootSessionState.Drive.GetAllForProvider(name))
-            {
-                //remove from all scopes, sub-scopes might created a new drive using this provider
-                _sessionState.RootSessionState.Drive.RemoveAtAllScopes(drive);
-            }
-
-            //now also stop and remove all instances
-            if (_providerInstances.ContainsKey(name))
-            {
-                var instances = _providerInstances[name];
-                foreach (var inst in instances)
-                {
-                    //TODO: it should be possible to notify the provider that it's removed. That's also the intention
-                    //of the provider's Stop() method. However, the specification says that Stop() is protected. So
-                    //we need another, internal method, that can be called. I called it DoStop(), but this should
-                    //certainly be changed. Like ghaving an internal Stop() method with a useful argument
-                    inst.DoStop();
-                }
-            }
-            _providers.Remove(name);
-        }
-
-        private CmdletProvider AddProvider(ProviderInfo providerInfo)
-        {
-            CmdletProvider provider = providerInfo.CreateInstance();
-
-            provider.Start(providerInfo, new ProviderRuntime(_sessionState._globalExecutionContext));
-            provider.SetProviderInfo(providerInfo);
-
-            // Cache the Provider's Info
-            if (!_providers.ContainsKey(providerInfo.Name))
-            {
-                _providers.Add(providerInfo.Name, new List<ProviderInfo>());
-            }
-            _providers[providerInfo.Name].Add(providerInfo);
-
-            return provider;
-        }
-
         internal CmdletProvider GetInstance(ProviderInfo info)
         {
-            // TODO: do it better
-            return _providerInstances[info.Name].First();
+            return _providerInstances[info];
         }
 
-
-        private void InitializeProvider(CmdletProvider providerInstance, ProviderInfo provider)
+        internal void Remove(PSSnapInInfo snapinInfo)
         {
-            List<PSDriveInfo> drives = new List<PSDriveInfo>();
-            DriveCmdletProvider driveProvider = providerInstance as DriveCmdletProvider;
-
-            if (driveProvider != null)
-            {
-                Collection<PSDriveInfo> collection = driveProvider.DoInitializeDefaultDrives();
-                if ((collection != null) && (collection.Count > 0))
-                {
-                    drives.AddRange(collection);
-                    //_providersCurrentDrive[provider] = collection[0];
-                }
-            }
-
-            if (drives.Count > 0)
-            {
-                foreach (PSDriveInfo driveInfo in drives)
-                {
-                    if (driveInfo != null)
-                    {
-                        // TODO: need to set driveInfo.Root
-                        // TODO:this should be automatically called when using DriveIntrinsics.New! #providerSupport
-                        driveProvider.DoNewDrive(driveInfo);
-
-                        try
-                        {
-                            //always to global scope
-                            _sessionState.RootSessionState.Drive.New(driveInfo,
-                                SessionStateScope<PSDriveInfo>.ScopeSpecifiers.Global.ToString());
-                        }
-                        catch
-                        {
-                            // TODO: What should we do if the drive name is not unique?
-                            // => I guess overwrite the old one and write a warning (however this works from here)
-                        }
-                    }
-                }
-            }
-        }
-
-        internal void RemoveProviders(PSSnapInInfo snapinInfo)
-        {
-            foreach (var provider in GetProviders(snapinInfo))
+            foreach (var provider in Get(snapinInfo))
             {
                 try
                 {
-                    RemoveProvider(provider.Name);
+                    Remove(provider);
                 }
                 catch (ProviderNotFoundException)
                 {
@@ -217,7 +96,7 @@ namespace System.Management.Automation
             }
         }
 
-        internal void LoadProvidersFromAssembly(Assembly assembly, PSSnapInInfo snapinInfo)
+        internal void Load(Assembly assembly, PSSnapInInfo snapinInfo)
         {
             // first get name and type of all providers in this assembly
             var providers = from Type type in assembly.GetTypes()
@@ -231,19 +110,93 @@ namespace System.Management.Automation
             {
                 ProviderInfo providerInfo = new ProviderInfo(_sessionState.RootSessionState, curPair.Value,
                     curPair.Key, string.Empty, snapinInfo);
-                CmdletProvider provider = AddProvider(providerInfo);
-                InitializeProvider(provider, providerInfo);
-
-                // Cache the provider's instance
-                if (!_providerInstances.ContainsKey(providerInfo.Name))
-                {
-                    _providerInstances.Add(providerInfo.Name, new List<CmdletProvider>());
-                }
-                List<CmdletProvider> instanceList = _providerInstances[providerInfo.Name];
-                instanceList.Add(provider);
+                Add(providerInfo);
             }
         }
 
+        #endregion
+
+        #region private helper functions
+
+        private void Remove(ProviderInfo info)
+        {
+            //remove all drives. TODO: I think _providers[name].Drive
+            foreach (var drive in _sessionState.RootSessionState.Drive.GetAllForProvider(info.FullName))
+            {
+                //remove from all scopes, sub-scopes might created a new drive using this provider
+                _sessionState.RootSessionState.Drive.RemoveAtAllScopes(drive);
+            }
+
+            //now also stop and remove
+            var inst = _providerInstances[info];
+            inst.DoStop();
+            _providerInstances.Remove(info);
+
+            var list = _providers[info.Name];
+            if (list == null) // shouldn't happen, but who knows
+            {
+                return;
+            }
+            list.Remove(info);
+        }
+
+        private CmdletProvider Add(ProviderInfo providerInfo)
+        {
+            CmdletProvider provider = providerInfo.CreateInstance();
+
+            providerInfo = provider.DoStart(providerInfo, new ProviderRuntime(_sessionState._globalExecutionContext));
+            provider.SetProviderInfo(providerInfo);
+
+            // Cache the Provider's Info and instance
+            if (!_providers.ContainsKey(providerInfo.Name))
+            {
+                _providers.Add(providerInfo.Name, new List<ProviderInfo>());
+            }
+            _providers[providerInfo.Name].Add(providerInfo);
+            _providerInstances[providerInfo] = provider;
+
+            // provider is added, default drives can be added
+            InitializeProvider(provider, providerInfo);
+
+            return provider;
+        }
+
+        private void InitializeProvider(CmdletProvider providerInstance, ProviderInfo provider)
+        {
+            DriveCmdletProvider driveProvider = providerInstance as DriveCmdletProvider;
+            if (driveProvider == null)
+            {
+                return;
+            }
+
+            var drives = driveProvider.DoInitializeDefaultDrives();
+            if (drives == null)
+            {
+                throw new PSInvalidOperationException("The default drive collection for this null!");
+            }
+
+            foreach (PSDriveInfo driveInfo in drives)
+            {
+                if (driveInfo == null)
+                {
+                    continue;
+                }
+                try
+                {
+                    // always to global scope
+                    // use DoSkipInit because the dafault drives are inited
+                    _sessionState.RootSessionState.Drive.NewSkipInit(driveInfo,
+                        SessionStateScope<PSDriveInfo>.ScopeSpecifiers.Global.ToString());
+                }
+                catch
+                {
+                    // TODO: What should we do if the drive name is not unique?
+                    // => I guess overwrite the old one and write a warning (however this works from here)
+                }
+            }
+        }
+
+        #endregion
 
     }
 }

--- a/Source/System.Management/Automation/DriveManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/DriveManagementIntrinsics.cs
@@ -151,10 +151,21 @@ namespace System.Management.Automation
             {
                 throw new DriveNotFoundException(driveName, String.Empty, null);
             }
+            Remove(drive, scope, runtime);
+        }
 
+        internal void Remove(PSDriveInfo drive, string scope, ProviderRuntime runtime)
+        {
             // make sure the provider can clean up this drive properly
             GetProvider(drive).RemoveDrive(drive, runtime);
-            _scope.RemoveAtScope(driveName, scope);
+            if (String.IsNullOrEmpty(scope))
+            {
+                _scope.Remove(drive.ItemName, false);
+            }
+            else
+            {
+                _scope.RemoveAtScope(drive.ItemName, scope);
+            }
         }
 
         internal void RemoveAtAllScopes(PSDriveInfo drive, ProviderRuntime runtime)

--- a/Source/System.Management/Automation/DriveManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/DriveManagementIntrinsics.cs
@@ -128,17 +128,15 @@ namespace System.Management.Automation
              * So, we need to find out when a drive is in use and should throw an exception on removal without
              * the "force" parameter being true
              */
-            try
-            {
-                var drive = Get(driveName);
-                // make sure the provider can clean up this drive properly
-                GetProvider(drive).DoRemoveDrive(drive);
-                _scope.RemoveAtScope(driveName, scope);
-            }
-            catch (ItemNotFoundException)
+            var drive = _scope.GetAtScope(driveName, scope);
+            if (drive == null)
             {
                 throw new DriveNotFoundException(driveName, String.Empty, null);
             }
+
+            // make sure the provider can clean up this drive properly
+            GetProvider(drive).DoRemoveDrive(drive);
+            _scope.RemoveAtScope(driveName, scope);
         }
 
         internal void RemoveAtAllScopes(PSDriveInfo drive)

--- a/Source/System.Management/Automation/PSModuleInfo.cs
+++ b/Source/System.Management/Automation/PSModuleInfo.cs
@@ -170,5 +170,19 @@ namespace System.Management.Automation
         }
         #endregion
 
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            var other = obj as PSModuleInfo;
+            if (other == null)
+            {
+                return false;
+            }
+            return Path.Equals(other.Path);
+        }
+
     }
 }

--- a/Source/System.Management/Automation/PSModuleInfo.cs
+++ b/Source/System.Management/Automation/PSModuleInfo.cs
@@ -184,5 +184,10 @@ namespace System.Management.Automation
             return Path.Equals(other.Path);
         }
 
+        public override int GetHashCode()
+        {
+            return Path.GetHashCode();
+        }
+
     }
 }

--- a/Source/System.Management/Automation/Provider/CmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/CmdletProvider.cs
@@ -83,7 +83,7 @@ namespace System.Management.Automation.Provider
             return providerInfo;
         }
 
-        internal ProviderInfo Start(ProviderInfo providerInfo, ProviderRuntime providerRuntime)
+        internal ProviderInfo DoStart(ProviderInfo providerInfo, ProviderRuntime providerRuntime)
         {
             ProviderRuntime = providerRuntime;
             return Start(providerInfo);
@@ -92,7 +92,6 @@ namespace System.Management.Automation.Provider
         protected virtual object StartDynamicParameters() { throw new NotImplementedException(); }
 
 
-        //TODO: simple wrapper to call Stop() from outisde. Should be replaced at any time for something more meaningful
         internal void DoStop()
         {
             Stop();

--- a/Source/System.Management/Automation/Provider/CmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/CmdletProvider.cs
@@ -83,7 +83,7 @@ namespace System.Management.Automation.Provider
             return providerInfo;
         }
 
-        internal ProviderInfo DoStart(ProviderInfo providerInfo, ProviderRuntime providerRuntime)
+        internal ProviderInfo Start(ProviderInfo providerInfo, ProviderRuntime providerRuntime)
         {
             ProviderRuntime = providerRuntime;
             return Start(providerInfo);
@@ -92,14 +92,18 @@ namespace System.Management.Automation.Provider
         protected virtual object StartDynamicParameters() { throw new NotImplementedException(); }
 
 
-        internal void DoStop()
-        {
-            Stop();
-        }
         protected virtual void Stop()
         {
             //TODO: useful default implementation?
         }
+
+        internal void Stop(ProviderRuntime providerRuntime)
+        {
+            ProviderRuntime = providerRuntime;
+            Stop();
+        }
+
+
         protected internal virtual void StopProcessing() { throw new NotImplementedException(); }
         public void ThrowTerminatingError(ErrorRecord errorRecord) { throw new NotImplementedException(); }
         public void WriteDebug(string text) { throw new NotImplementedException(); }

--- a/Source/System.Management/Automation/Provider/DriveCmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/DriveCmdletProvider.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Collections.ObjectModel;
+using Pash.Implementation;
 
 namespace System.Management.Automation.Provider
 {
@@ -32,18 +33,21 @@ namespace System.Management.Automation.Provider
             return drive; //nothing special to do per default
         }
 
-        internal PSDriveInfo DoRemoveDrive(PSDriveInfo drive)
+        internal PSDriveInfo RemoveDrive(PSDriveInfo drive, ProviderRuntime runtime)
         {
+            ProviderRuntime = runtime;
             return RemoveDrive(drive);
         }
 
-        internal Collection<PSDriveInfo> DoInitializeDefaultDrives()
+        internal Collection<PSDriveInfo> InitializeDefaultDrives(ProviderRuntime runtime)
         {
+            ProviderRuntime = runtime;
             return InitializeDefaultDrives();
         }
 
-        internal PSDriveInfo DoNewDrive(PSDriveInfo drive)
+        internal PSDriveInfo NewDrive(PSDriveInfo drive, ProviderRuntime runtime)
         {
+            ProviderRuntime = runtime;
             return NewDrive(drive);
         }
     }

--- a/Source/System.Management/Automation/Provider/DriveCmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/DriveCmdletProvider.cs
@@ -32,11 +32,10 @@ namespace System.Management.Automation.Provider
             return drive; //nothing special to do per default
         }
 
-        // internals
-        //internal System.Collections.ObjectModel.Collection<PSDriveInfo> InitializeDefaultDrives(CmdletProviderContext context);
-        //internal PSDriveInfo NewDrive(PSDriveInfo drive, CmdletProviderContext context);
-        //internal object NewDriveDynamicParameters(CmdletProviderContext context);
-        //internal PSDriveInfo RemoveDrive(PSDriveInfo drive, CmdletProviderContext context);
+        internal PSDriveInfo DoRemoveDrive(PSDriveInfo drive)
+        {
+            return RemoveDrive(drive);
+        }
 
         internal Collection<PSDriveInfo> DoInitializeDefaultDrives()
         {

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -14,6 +14,14 @@ namespace System.Management.Automation
         public ProviderCapabilities Capabilities { get; private set; }
         public string HelpFile { get; private set; }
         private SessionState _sessionState;
+        public PSModuleInfo Module { get; private set; }
+        public string ModuleName
+        {
+            get
+            {
+                return Module == null ? null : Module.Name;
+            }
+        }
 
         public Collection<PSDriveInfo> Drives
         {
@@ -51,6 +59,7 @@ namespace System.Management.Automation
             ImplementingType = providerInfo.ImplementingType;
             Capabilities = providerInfo.Capabilities;
             HelpFile = providerInfo.HelpFile;
+            Module = providerInfo.Module;
         }
 
         public override string ToString()

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -28,7 +28,7 @@ namespace System.Management.Automation
             get
             {
                 //TODO: only get the ones of the global scope to match PS 2.0 behavior
-                return _sessionState.Drive.GetAllForProvider(FullName);
+                return _sessionState.Drive.GetAllForProvider(Name);
             }
         }
 

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -49,7 +49,7 @@ namespace System.Management.Automation
 
         {
             _sessionState = sessionState;
-            Module = Module;
+            Module = module;
             PSSnapIn = psSnapIn;
             Name = name;
             Description = description;

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -93,9 +93,10 @@ namespace System.Management.Automation
         {
             get
             {
-                if (!string.IsNullOrEmpty(PSSnapInName))
+                var moudleOrSnapinName = string.IsNullOrEmpty(PSSnapInName) ? ModuleName : PSSnapInName;
+                if (!string.IsNullOrEmpty(moudleOrSnapinName))
                 {
-                    return string.Format(@"{0}\{1}", PSSnapInName, Name);
+                    return string.Format(@"{0}\{1}", moudleOrSnapinName, Name);
                 }
                 return Name;
             }
@@ -155,6 +156,18 @@ namespace System.Management.Automation
                 return true;
             }
             return string.Equals(Name, providerName, StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        public bool IsAnyNameMatch(string[] providerNames)
+        {
+            foreach (var name in providerNames)
+            {
+                if (IsNameMatch(name))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public override bool Equals(object obj)

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -190,7 +190,7 @@ namespace System.Management.Automation
             {
                 return provider.FullName.CompareTo(provider.FullName); //cannot be 0, otherwise it was a name match
             }
-            return PSSnapIn.CompareTo(provider.PSSnapIn);
+            return 0;
         }
 
         public int CompareTo(object obj)

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -140,7 +140,11 @@ namespace System.Management.Automation
         // internals
         internal bool IsNameMatch(string providerName)
         {
-            return string.Equals(FullName, providerName, StringComparison.CurrentCultureIgnoreCase);
+            if (string.Equals(FullName, providerName, StringComparison.CurrentCultureIgnoreCase))
+            {
+                return true;
+            }
+            return string.Equals(Name, providerName, StringComparison.CurrentCultureIgnoreCase);
         }
 
         public override bool Equals(object obj)

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -37,9 +37,19 @@ namespace System.Management.Automation
         {
         }
 
-        internal ProviderInfo(SessionState sessionState, Type implementingType, string name, string description, string home, string helpFile, PSSnapInInfo psSnapIn)
+        internal ProviderInfo(SessionState sessionState, Type implementingType, string name, string description,
+                              string home, string helpFile, PSSnapInInfo psSnapIn)
+            : this(sessionState, implementingType, name, description, home, helpFile, psSnapIn, null)
+        {
+        }
+
+        // for all fields
+        internal ProviderInfo(SessionState sessionState, Type implementingType, string name, string description, string home,
+                              string helpFile, PSSnapInInfo psSnapIn, PSModuleInfo module)
+
         {
             _sessionState = sessionState;
+            Module = Module;
             PSSnapIn = psSnapIn;
             Name = name;
             Description = description;

--- a/Source/System.Management/Automation/SessionState.cs
+++ b/Source/System.Management/Automation/SessionState.cs
@@ -26,8 +26,15 @@ namespace System.Management.Automation
 
         public DriveManagementIntrinsics Drive { get; private set; }
         public PathIntrinsics Path { get; private set; }
-        public CmdletProviderManagementIntrinsics Provider { get; private set; }
         public PSVariableIntrinsics PSVariable { get; private set; }
+        public CmdletProviderManagementIntrinsics Provider
+        {
+            get
+            {
+                return SessionStateGlobal.Provider;
+            }
+        }
+
 
         // creates a session state with a new (global) scope
         internal SessionState(SessionStateGlobal sessionStateGlobal)
@@ -65,7 +72,6 @@ namespace System.Management.Automation
 
             Drive = new DriveManagementIntrinsics(_driveScope);
             Path = new PathIntrinsics(SessionStateGlobal);
-            Provider = new CmdletProviderManagementIntrinsics(SessionStateGlobal);
             PSVariable = new PSVariableIntrinsics(_variableScope);
             LoadedModules = new ModuleIntrinsics(_moduleScope);
             Cmdlet = new CmdletIntrinsics(_cmdletScope);

--- a/Source/System.Management/Microsoft.PowerShell/Commands/AddPSSnapinCommand.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/AddPSSnapinCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    var snapin = SessionState.SessionStateGlobal.AddPSSnapIn(curName);
+                    var snapin = SessionState.SessionStateGlobal.AddPSSnapIn(curName, ExecutionContext);
                     if (PassThru.IsPresent)
                     {
                         WriteObject(snapin);

--- a/Source/System.Management/Microsoft.PowerShell/Commands/RemoveModuleCommand.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/RemoveModuleCommand.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // TODO: some security checks. E.g. if it's ReadOnly access mode. Then we need to use ShouldContinue
                 // and the Force parameter
-                ExecutionContext.SessionState.LoadedModules.Remove(mod);
+                ExecutionContext.SessionState.LoadedModules.Remove(mod, ExecutionContext);
             }
         }
     }

--- a/Source/System.Management/Microsoft.PowerShell/Commands/RemovePSSnapinCommand.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/RemovePSSnapinCommand.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.Commands
                         //For now we use simply the SessionStateGlobal
                         try
                         {
-                            var snapin = ExecutionContext.SessionStateGlobal.RemovePSSnapIn(curSnapin.Name);
+                            var snapin = ExecutionContext.SessionStateGlobal.RemovePSSnapIn(curSnapin.Name, ExecutionContext);
                             if (PassThru.IsPresent)
                             {
                                 WriteObject(snapin);

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/SettableVariableExpression.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/SettableVariableExpression.cs
@@ -81,7 +81,7 @@ namespace System.Management.Pash.Implementation
             {
                 return null;
             }
-            return ExecutionContext.SessionState.Provider.GetProviderInstance(driveInfo.Provider.Name)
+            return ExecutionContext.SessionState.Provider.GetInstance(driveInfo.Provider.Name)
                 as SessionStateProviderBase;
         }
     }

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/SettableVariableExpression.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitorHelper/SettableVariableExpression.cs
@@ -81,7 +81,7 @@ namespace System.Management.Pash.Implementation
             {
                 return null;
             }
-            return ExecutionContext.SessionStateGlobal.GetProviderInstance(driveInfo.Provider.Name)
+            return ExecutionContext.SessionState.Provider.GetProviderInstance(driveInfo.Provider.Name)
                 as SessionStateProviderBase;
         }
     }

--- a/Source/System.Management/Pash/Implementation/ModuleIntrinsics.cs
+++ b/Source/System.Management/Pash/Implementation/ModuleIntrinsics.cs
@@ -34,9 +34,10 @@ namespace Pash.Implementation
             targetScope.SetLocal(module, false);
         }
 
-        public void Remove(PSModuleInfo module)
+        public void Remove(PSModuleInfo module, ExecutionContext context)
         {
             RemoveMembers(module);
+            Scope.SessionState.Provider.Remove(module, context);
             // remove the module from all scopes upwards the hierarchy
             foreach (var curScope in Scope.HierarchyIterator)
             {

--- a/Source/System.Management/Pash/Implementation/ModuleLoader.cs
+++ b/Source/System.Management/Pash/Implementation/ModuleLoader.cs
@@ -110,7 +110,7 @@ namespace Pash.Implementation
             // load into the local session state of the module
             moduleInfo.SessionState.Cmdlet.LoadCmdletsFromAssembly(assembly, moduleInfo);
             // load providers. they aren't scoped, so the SessionState object used doesn't matter
-            _executionContext.SessionState.Provider.Load(assembly, moduleInfo);
+            _executionContext.SessionState.Provider.Load(assembly, _executionContext, moduleInfo);
             moduleInfo.ValidateExportedMembers(); // make sure cmdlets get exported
         }
 

--- a/Source/System.Management/Pash/Implementation/ModuleLoader.cs
+++ b/Source/System.Management/Pash/Implementation/ModuleLoader.cs
@@ -109,6 +109,8 @@ namespace Pash.Implementation
             Assembly assembly = Assembly.LoadFrom(path);
             // load into the local session state of the module
             moduleInfo.SessionState.Cmdlet.LoadCmdletsFromAssembly(assembly, moduleInfo);
+            // load providers. they aren't scoped, so the SessionState object used doesn't matter
+            _executionContext.SessionState.Provider.Load(assembly, moduleInfo);
             moduleInfo.ValidateExportedMembers(); // make sure cmdlets get exported
         }
 

--- a/Source/System.Management/Pash/Implementation/ProviderRuntime.cs
+++ b/Source/System.Management/Pash/Implementation/ProviderRuntime.cs
@@ -12,6 +12,7 @@ namespace Pash.Implementation
         internal string Filter { get; set; }
         internal SwitchParameter Force { get; set; }
         internal ExecutionContext ExecutionContext { get; private set; }
+        internal PSCredential Credential { get; set; }
 
         private Cmdlet _cmdlet;
         private Collection<PSObject> _outputData;

--- a/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
@@ -31,10 +31,13 @@ namespace Pash.Implementation
         internal SessionState RootSessionState  { get { return _globalExecutionContext.SessionState; } }
         internal PSDriveInfo _currentDrive;
 
+        internal CmdletProviderManagementIntrinsics Provider { get; private set; }
+
         internal SessionStateGlobal(ExecutionContext executionContext)
         {
             _globalExecutionContext = executionContext;
             _snapins = new Dictionary<string, PSSnapInInfo>(StringComparer.CurrentCultureIgnoreCase);
+            Provider = new CmdletProviderManagementIntrinsics(this);
         }
 
 

--- a/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
@@ -26,12 +26,12 @@ namespace Pash.Implementation
             "Microsoft.Commands.Management.PSManagementPSSnapIn, Microsoft.PowerShell.Commands.Management",
         };
         private Dictionary<string, PSSnapInInfo> _snapins;
+        private readonly ExecutionContext _globalExecutionContext;
 
-        internal readonly ExecutionContext _globalExecutionContext;
         internal SessionState RootSessionState  { get { return _globalExecutionContext.SessionState; } }
-        internal PSDriveInfo _currentDrive;
-
         internal CmdletProviderManagementIntrinsics Provider { get; private set; }
+
+        public PSDriveInfo CurrentDrive { get; private set; }
 
         internal SessionStateGlobal(ExecutionContext executionContext)
         {
@@ -145,7 +145,7 @@ namespace Pash.Implementation
             {
                 throw new PSSnapInException(String.Format("The snapin '{0}' is already loaded!", snapinName));
             }
-            RootSessionState.Provider.Load(assembly, snapinInfo);
+            RootSessionState.Provider.Load(assembly, _globalExecutionContext, snapinInfo);
             RootSessionState.Cmdlet.LoadCmdletsFromAssembly(assembly, snapinInfo);
         }
 
@@ -196,18 +196,6 @@ namespace Pash.Implementation
             }
         }
 
-        public PSDriveInfo CurrentDrive
-        {
-            get
-            {
-                return _currentDrive;
-            }
-            private set
-            {
-                _currentDrive = value;
-            }
-        }
-
         internal void SetCurrentDrive()
         {
             ProviderInfo fileSystemProvider = RootSessionState.Provider.GetOne(FileSystemProvider.ProviderName);
@@ -222,7 +210,7 @@ namespace Pash.Implementation
                 if (string.Equals(drive.Name, currentDir.GetDrive(), StringComparison.OrdinalIgnoreCase))
                 {
                     drive.CurrentLocation = currentDir;
-                    _currentDrive = drive;
+                    CurrentDrive = drive;
                     return;
                 }
             }

--- a/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
@@ -87,7 +87,7 @@ namespace Pash.Implementation
                                                           name));
             }
             //unload providers and associated drives
-            RootSessionState.Provider.RemoveProviders(snapinInfo);
+            RootSessionState.Provider.Remove(snapinInfo);
             
             //unload cmdlets
             RootSessionState.Cmdlet.RemoveAll(snapinInfo);
@@ -142,7 +142,7 @@ namespace Pash.Implementation
             {
                 throw new PSSnapInException(String.Format("The snapin '{0}' is already loaded!", snapinName));
             }
-            RootSessionState.Provider.LoadProvidersFromAssembly(assembly, snapinInfo);
+            RootSessionState.Provider.Load(assembly, snapinInfo);
             RootSessionState.Cmdlet.LoadCmdletsFromAssembly(assembly, snapinInfo);
         }
 
@@ -340,7 +340,7 @@ namespace Pash.Implementation
             if (drive == null)
                 return null;
 
-            return RootSessionState.Provider.GetProviderInstance(drive.Provider.Name);
+            return RootSessionState.Provider.GetInstance(drive.Provider.Name);
         }
 
         private PSDriveInfo GetDrive(Path path)

--- a/Source/TestHost/SessionStateScopeTests.cs
+++ b/Source/TestHost/SessionStateScopeTests.cs
@@ -38,7 +38,7 @@ namespace TestHost
             var testModule = new Uri(typeof(TestDriveProvider).Assembly.CodeBase).LocalPath;
 
             globalState = hostRunspace.ExecutionContext.SessionState;
-            globalState.SessionStateGlobal.AddPSSnapIn(testModule);
+            globalState.SessionStateGlobal.AddPSSnapIn(testModule, hostRunspace.ExecutionContext);
             testProvider = globalState.Provider.GetOne(TestDriveProvider.ProviderName);
             globalState.Drive.Remove("testDefault", true, "local"); // so tests can rely on that there are no drives
 

--- a/Source/TestHost/SessionStateScopeTests.cs
+++ b/Source/TestHost/SessionStateScopeTests.cs
@@ -40,6 +40,7 @@ namespace TestHost
             globalState = hostRunspace.ExecutionContext.SessionState;
             globalState.SessionStateGlobal.AddPSSnapIn(testModule);
             testProvider = globalState.Provider.GetOne(TestDriveProvider.ProviderName);
+            globalState.Drive.Remove("testDefault", true, "local"); // so tests can rely on that there are no drives
 
             scriptState = new SessionState(globalState);
             scriptState.IsScriptScope = true;
@@ -244,10 +245,9 @@ namespace TestHost
         public void DriveRemoveNotExistingTest ()
         {
             PSDriveInfo info = createDrive ("test");
-            try {
-                globalState.Drive.Remove (info.Name, true, "local");
-                Assert.True (false);
-            } catch (DriveNotFoundException) { }
+            Assert.Throws<DriveNotFoundException>(delegate {
+                globalState.Drive.Remove(info.Name, true, "local");
+            });
         }
 
         [Test]

--- a/Source/TestPSSnapIn/TestDriveProvider.cs
+++ b/Source/TestPSSnapIn/TestDriveProvider.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Management.Automation;
+using System.Management.Automation.Provider;
+using System.Collections.ObjectModel;
+
+namespace TestPSSnapIn
+{
+    public class TestDrive : PSDriveInfo
+    {
+        public bool IsRemoved { get; internal set; }
+        public TestDrive(PSDriveInfo driveInfo) : base(driveInfo)
+        {
+            IsRemoved = false;
+        }
+    }
+
+    public class TestProviderInfo : ProviderInfo
+    {
+        public bool IsStopped { get; internal set; }
+        public TestProviderInfo(ProviderInfo providerInfo) : base(providerInfo)
+        {
+            IsStopped = false;
+        }
+    }
+
+    [CmdletProvider(TestDriveProvider.ProviderName, ProviderCapabilities.Filter | ProviderCapabilities.ShouldProcess)]
+    public class TestDriveProvider : DriveCmdletProvider
+    {
+        private TestProviderInfo _info;
+
+        public const string ProviderName = "TestDriveProvider";
+        public const string DefaultDriveName = "testDefault";
+
+        protected override PSDriveInfo NewDrive(PSDriveInfo drive)
+        {
+            return new TestDrive(drive);
+        }
+
+        protected override object NewDriveDynamicParameters()
+        {
+            return base.NewDriveDynamicParameters();
+        }
+
+        protected override PSDriveInfo RemoveDrive(PSDriveInfo drive)
+        {
+            var testdrive = drive as TestDrive;
+            if (drive == null)
+            {
+                throw new InvalidOperationException("Drive is not a TestDrive!");
+            }
+            testdrive.IsRemoved = true;
+            return testdrive;
+        }
+
+        protected override Collection<PSDriveInfo> InitializeDefaultDrives()
+        {
+            var defdrive = new TestDrive(new PSDriveInfo(DefaultDriveName, _info, "/", "Test Default Drive", null));
+            return new Collection<PSDriveInfo>(new [] { defdrive });
+        }
+
+        protected override ProviderInfo Start(ProviderInfo providerInfo)
+        {
+            _info = new TestProviderInfo(providerInfo);
+            return _info;
+        }
+
+        protected override object StartDynamicParameters()
+        {
+            return base.StartDynamicParameters();
+        }
+
+        protected override void Stop()
+        {
+            _info.IsStopped = true;
+        }
+
+    }
+}
+

--- a/Source/TestPSSnapIn/TestPSSnapIn.csproj
+++ b/Source/TestPSSnapIn/TestPSSnapIn.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{DC9303A4-3F38-4591-9BD4-67F223F7D204}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -36,6 +36,7 @@
     <Compile Include="PashTestSnapIn.cs" />
     <Compile Include="TestCommands.cs" />
     <Compile Include="TestCreateErrorCommand.cs" />
+    <Compile Include="TestDriveProvider.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
First part of my work on provider support.
What's done:
- CmdletProviderManagementIntrinsics now contains the provider management specific code
- Providers are loaded from modules and removed if the modules are removed
- `New-PSDrive`, `Get-PSDrive`, and `Remove-PSDrive` are baiscally implemented
- The providers `Start`, `Stop`, `NewDrive` and `RemoveDrive` functions are called when the provider/drives are initialized or removed
- Work on ProviderRuntime as a class that is set in a provider to provide different runtime specific information (arguments like `Force` for the execution of a function, the current `SessionState`, ...)

Next stop: ItemCmdletProvider support with related cmdlets.
Note: I won't check/test/fix the currently existing provider implementations like `FileSystemProvider`. This should be done when provider support itself is finished.