### PR TITLE
Get-Content, Set-Content, Add-Content and Clear-Content commands

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Management/AddContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/AddContentCommand.cs
@@ -5,14 +5,14 @@ using Microsoft.PowerShell.Commands;
 
 namespace Microsoft.Commands.Management
 {
-    [Cmdlet(VerbsCommon.Clear, "Content", DefaultParameterSetName="Path" /*HelpUri="http://go.microsoft.com/fwlink/?LinkID=113282" */)]
-    public class ClearContentCommand : ContentCommandBase
+    [CmdletAttribute(VerbsCommon.Add, "Content", DefaultParameterSetName = "Path" /* HelpUri = "http://go.microsoft.com/fwlink/?LinkID=113278"*/)]
+    public class AddContentCommand : WriteContentCommandBase
     {
         protected override void ProcessRecord()
         {
             foreach (string path in Path)
             {
-                InvokeProvider.Content.Clear(path);
+                WriteValues(path, true);
             }
         }
     }

--- a/Source/Microsoft.PowerShell.Commands.Management/ClearContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/ClearContentCommand.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Management.Automation;
+using Microsoft.PowerShell.Commands;
+
+namespace Microsoft.Commands.Management
+{
+    [Cmdlet("Clear", "Content", DefaultParameterSetName="Path" /*HelpUri="http://go.microsoft.com/fwlink/?LinkID=113282" */)]
+    public class ClearContentCommand : ContentCommandBase
+    {
+        protected override void ProcessRecord()
+        {
+            foreach (string path in Path)
+            {
+                InvokeProvider.Content.Clear(path);
+            }
+        }
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Management/ContentCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/ContentCommandBase.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public abstract class ContentCommandBase : CoreCommandWithCredentialsBase, IDisposable
+    {
+        public void Dispose()
+        {
+        }
+
+        [ParameterAttribute(ParameterSetName = "LiteralPath", ValueFromPipelineByPropertyName = true)]
+        public string[] LiteralPath { get; set; }
+
+        [ParameterAttribute(Position = 0, ParameterSetName = "Path", ValueFromPipelineByPropertyName = true)]
+        public string[] Path { get; set; }
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Management/GetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/GetContentCommand.cs
@@ -37,7 +37,8 @@ namespace Microsoft.PowerShell.Commands
         {
             foreach (string fileName in Path)
             {
-                using (contentReader = InvokeProvider.Content.GetReader(fileName).Single())
+                contentReader = InvokeProvider.Content.GetReader(fileName).Single();
+                try
                 {
                     if (Tail > 0)
                     {
@@ -49,6 +50,10 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     WritePendingItems();
+                }
+                finally
+                {
+                    contentReader.Close();
                 }
             }
         }

--- a/Source/Microsoft.PowerShell.Commands.Management/GetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/GetContentCommand.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.IO;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [CmdletAttribute(VerbsCommon.Get, "Content", DefaultParameterSetName="Path" /*HelpUri="http://go.microsoft.com/fwlink/?LinkID=113310"*/)] 
+    public class GetContentCommand : ContentCommandBase
+    {
+        [ParameterAttribute(ValueFromPipelineByPropertyName = true)]
+        public long ReadCount { get; set; }
+
+        [Alias("Last")]
+        [ParameterAttribute(ValueFromPipelineByPropertyName = true)]
+        public int Tail { get; set; }
+
+        [Alias("First", "Head")]
+        [ParameterAttribute(ValueFromPipelineByPropertyName = true)]
+        public long TotalCount { get; set; }
+
+        public GetContentCommand()
+        {
+            ReadCount = 1;
+            TotalCount = -1;
+        }
+
+        List<object> pendingLines = new List<object>();
+
+        protected override void ProcessRecord()
+        {
+            foreach (string fileName in Path)
+            {
+                CheckPathHasSupportedProvider(fileName);
+
+                if (Tail > 0)
+                {
+                    WriteLastLinesToPipeline(fileName);
+                }
+                else
+                {
+                    WriteLinesToPipeline(fileName);
+                }
+
+                WritePendingLines();
+            }
+        }
+
+        private void CheckPathHasSupportedProvider(string fileName)
+        {
+            PSDriveInfo drive;
+            var provider = SessionState.SessionStateGlobal.GetProviderByPath(fileName, out drive) as FileSystemProvider;
+            if (provider == null)
+            {
+                throw new NotImplementedException("Not supported by FileSystemProvider");
+            }
+        }
+
+        private void WriteLastLinesToPipeline(string fileName)
+        {
+            foreach (string line in File.ReadLines(fileName).Reverse().Take(Tail).Reverse())
+            {
+                WriteLine(line);
+            }
+        }
+
+        private void WriteLine(string line)
+        {
+            if (ReadCount > 1)
+            {
+                pendingLines.Add(line);
+
+                if (pendingLines.Count >= ReadCount)
+                {
+                    WritePendingLines();
+                }
+            }
+            else
+            {
+                WriteObject(line);
+            }
+        }
+
+        private void WritePendingLines()
+        {
+            if ((pendingLines != null) && (pendingLines.Count > 0))
+            {
+                WriteObject(pendingLines.ToArray());
+                pendingLines.Clear();
+            }
+        }
+
+        private void WriteLinesToPipeline(string fileName)
+        {
+            int currentLineNumber = 1;
+            if (!ReadMoreLines(currentLineNumber))
+            {
+                return;
+            }
+
+            foreach (string line in File.ReadLines(fileName))
+            {
+                WriteLine(line);
+
+                currentLineNumber++;
+                if (!ReadMoreLines(currentLineNumber))
+                {
+                    return;
+                }
+            }
+        }
+
+        private bool ReadMoreLines(int currentLineNumber)
+        {
+            return (TotalCount == -1) || (currentLineNumber <= TotalCount);
+        }
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClearContentCommand.cs" />
     <Compile Include="ContentCommandBase.cs" />
     <Compile Include="ConvertPathCommand.cs" />
     <Compile Include="CopyItemCommand.cs" />

--- a/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
@@ -77,6 +77,7 @@
     <Compile Include="JoinPathCommand.cs" />
     <Compile Include="MoveItemCommand.cs" />
     <Compile Include="NewItemCommand.cs" />
+    <Compile Include="PassThroughContentCommandBase.cs" />
     <Compile Include="ProcessBaseCommand.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProviderCommandBase.cs" />
@@ -85,6 +86,7 @@
     <Compile Include="RenameItemCommand.cs" />
     <Compile Include="RestartServiceCommand.cs" />
     <Compile Include="ResumeServiceCommand.cs" />
+    <Compile Include="SetContentCommand.cs" />
     <Compile Include="SetLocationCommand.cs" />
     <Compile Include="SplitPathCommand.cs" />
     <Compile Include="StartServiceCommand.cs" />
@@ -101,6 +103,7 @@
     <Compile Include="TestPathCommand.cs" />
     <Compile Include="TestPathType.cs" />
     <Compile Include="CoreCommandWithPathsBase.cs" />
+    <Compile Include="WriteContentCommandBase .cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
@@ -61,11 +61,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContentCommandBase.cs" />
     <Compile Include="ConvertPathCommand.cs" />
     <Compile Include="CopyItemCommand.cs" />
     <Compile Include="CoreCommandBase.cs" />
     <Compile Include="DriveMatchingCoreCommandBase.cs" />
     <Compile Include="GetChildItemCommand.cs" />
+    <Compile Include="GetContentCommand.cs" />
     <Compile Include="GetLocationCommand.cs" />
     <Compile Include="GetProcessCommand.cs" />
     <Compile Include="GetPSDriveCommand.cs" />

--- a/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddContentCommand.cs" />
     <Compile Include="ClearContentCommand.cs" />
     <Compile Include="ContentCommandBase.cs" />
     <Compile Include="ConvertPathCommand.cs" />

--- a/Source/Microsoft.PowerShell.Commands.Management/PassThroughContentCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/PassThroughContentCommandBase.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+
+namespace Microsoft.PowerShell.Commands
+{
+    public class PassThroughContentCommandBase : ContentCommandBase
+    {
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Commands.Management
         {
             foreach (string path in Path)
             {
-                InvokeProvider.Content.Clear(path);
+                if (InvokeProvider.Item.Exists(path))
+                {
+                    InvokeProvider.Content.Clear(path);
+                }
                 WriteValues(path);
             }
         }

--- a/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Provider;
 using System.Text;
 using Microsoft.PowerShell.Commands;
 

--- a/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation;
+using System.Text;
+using Microsoft.PowerShell.Commands;
+
+namespace Microsoft.Commands.Management
+{
+    [CmdletAttribute(VerbsCommon.Set, "Content", DefaultParameterSetName = "Path" /* HelpUri = "http://go.microsoft.com/fwlink/?LinkID=113392"*/)]
+    public class SetContentCommand : WriteContentCommandBase
+    {
+        protected override void ProcessRecord()
+        {
+            foreach (string path in Path)
+            {
+                WriteValues(path);
+            }
+        }
+
+        private void WriteValues(string path)
+        {
+            // Default file encoding is ASCII.
+            using (var writer = new StreamWriter(path, false, Encoding.ASCII))
+            {
+                foreach (object obj in Value)
+                {
+                    writer.WriteLine(obj);
+                }
+            }
+        }
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Provider;
-using System.Text;
 using Microsoft.PowerShell.Commands;
 
 namespace Microsoft.Commands.Management
@@ -19,20 +14,6 @@ namespace Microsoft.Commands.Management
             {
                 InvokeProvider.Content.Clear(path);
                 WriteValues(path);
-            }
-        }
-
-        private void WriteValues(string path)
-        {
-            IContentWriter writer = InvokeProvider.Content.GetWriter(path).Single();
-
-            try
-            {
-                writer.Write(Value);
-            }
-            finally
-            {
-                writer.Close();
             }
         }
     }

--- a/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
@@ -17,19 +17,22 @@ namespace Microsoft.Commands.Management
         {
             foreach (string path in Path)
             {
+                InvokeProvider.Content.Clear(path);
                 WriteValues(path);
             }
         }
 
         private void WriteValues(string path)
         {
-            // Default file encoding is ASCII.
-            using (var writer = new StreamWriter(path, false, Encoding.ASCII))
+            IContentWriter writer = InvokeProvider.Content.GetWriter(path).Single();
+
+            try
             {
-                foreach (object obj in Value)
-                {
-                    writer.WriteLine(obj);
-                }
+                writer.Write(Value);
+            }
+            finally
+            {
+                writer.Close();
             }
         }
     }

--- a/Source/Microsoft.PowerShell.Commands.Management/WriteContentCommandBase .cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/WriteContentCommandBase .cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System.IO;
+using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Provider;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -9,5 +12,23 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, Position = 1, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [AllowEmptyCollection]
         public object[] Value { get; set; }
+
+        internal void WriteValues(string path, bool seekEnd = false)
+        {
+            IContentWriter writer = InvokeProvider.Content.GetWriter(path).Single();
+
+            try
+            {
+                if (seekEnd)
+                {
+                    writer.Seek(0, SeekOrigin.End);
+                }
+                writer.Write(Value);
+            }
+            finally
+            {
+                writer.Close();
+            }
+        }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/WriteContentCommandBase .cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/WriteContentCommandBase .cs
@@ -1,0 +1,13 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public class WriteContentCommandBase : PassThroughContentCommandBase
+    {
+        [AllowNull]
+        [Parameter(Mandatory = true, Position = 1, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [AllowEmptyCollection]
+        public object[] Value { get; set; }
+    }
+}

--- a/Source/ReferenceTests/Commands/AddContentTests.cs
+++ b/Source/ReferenceTests/Commands/AddContentTests.cs
@@ -60,7 +60,7 @@ namespace ReferenceTests.Commands
             string fileName1 = GenerateTempFile("1" + Environment.NewLine);
             string fileName2 = GenerateTempFile("2" + Environment.NewLine);
 
-            string result = ReferenceHost.Execute("'abc' | Add-Content " + fileName1 + "," + fileName2);
+            ReferenceHost.Execute("'abc' | Add-Content " + fileName1 + "," + fileName2);
 
             string input1Text = File.ReadAllText(fileName1);
             string input2Text = File.ReadAllText(fileName2);

--- a/Source/ReferenceTests/Commands/AddContentTests.cs
+++ b/Source/ReferenceTests/Commands/AddContentTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Commands
+{
+    [TestFixture]
+    public class AddContentTests : ReferenceTestBase
+    {
+        private string GenerateTempFile(string content)
+        {
+            return CreateFile(content, ".txt");
+        }
+
+        [Test]
+        public void StringValueDoesNotOverwriteExistingFile()
+        {
+            string fileName = GenerateTempFile("test" + Environment.NewLine);
+
+            string result = ReferenceHost.Execute(new string[] {
+                "Add-Content -value 'abc' -path " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(NewlineJoin("test", "abc"), result);
+        }
+
+        [Test]
+        public void NoNamedParameters()
+        {
+            string fileName = GenerateTempFile("test" + Environment.NewLine);
+
+            string result = ReferenceHost.Execute(new string[] {
+                "Add-Content " + fileName + " 'abc'",
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(NewlineJoin("test", "abc"), result);
+        }
+
+        [Test]
+        public void ValueTakenFromPipeline()
+        {
+            string fileName = GenerateTempFile("test" + Environment.NewLine);
+
+            string result = ReferenceHost.Execute(new string[] {
+                "'abc' | Add-Content " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(NewlineJoin("test", "abc"), result);
+        }
+
+        [Test]
+        public void TwoFiles()
+        {
+            string fileName1 = GenerateTempFile("1" + Environment.NewLine);
+            string fileName2 = GenerateTempFile("2" + Environment.NewLine);
+
+            string result = ReferenceHost.Execute("'abc' | Add-Content " + fileName1 + "," + fileName2);
+
+            string input1Text = File.ReadAllText(fileName1);
+            string input2Text = File.ReadAllText(fileName2);
+            Assert.AreEqual(NewlineJoin("1", "abc"), input1Text);
+            Assert.AreEqual(NewlineJoin("2", "abc"), input2Text);
+        }
+
+        [Test]
+        public void ArrayOfValues()
+        {
+            string fileName = GenerateTempFile("test" + Environment.NewLine);
+
+            string result = ReferenceHost.Execute(new string[] {
+                "$a = 'abc','def'",
+                "Add-Content -value $a -path " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(NewlineJoin("test", "abc", "def"), result);
+        }
+    }
+}

--- a/Source/ReferenceTests/Commands/ClearContentTests.cs
+++ b/Source/ReferenceTests/Commands/ClearContentTests.cs
@@ -41,7 +41,7 @@ namespace ReferenceTests.Commands
             string fileName1 = CreateFile("1", ".txt");
             string fileName2 = CreateFile("2", ".txt");
 
-            string result = ReferenceHost.Execute("Clear-Content " + fileName1 + "," + fileName2);
+            ReferenceHost.Execute("Clear-Content " + fileName1 + "," + fileName2);
 
             string input1Text = File.ReadAllText(fileName1);
             string input2Text = File.ReadAllText(fileName2);

--- a/Source/ReferenceTests/Commands/ClearContentTests.cs
+++ b/Source/ReferenceTests/Commands/ClearContentTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using System.Management.Automation;
+
+namespace ReferenceTests.Commands
+{
+    [TestFixture]
+    public class ClearContentTests : ReferenceTestBase
+    {
+        [Test]
+        public void StringValueOverwritesExistingFile()
+        {
+            string fileName = CreateFile("test", ".txt");
+
+            ReferenceHost.Execute("Clear-Content -path " + fileName);
+
+            string result = File.ReadAllText(fileName);
+            Assert.AreEqual(String.Empty, result);
+        }
+
+        [Test]
+        public void NoNamedParameters()
+        {
+            string fileName = CreateFile("test", ".txt");
+
+            string result = ReferenceHost.Execute(new string[] {
+                "Clear-Content " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(String.Empty, result);
+        }
+
+        [Test]
+        public void TwoFiles()
+        {
+            string fileName1 = CreateFile("1", ".txt");
+            string fileName2 = CreateFile("2", ".txt");
+
+            string result = ReferenceHost.Execute("Clear-Content " + fileName1 + "," + fileName2);
+
+            string input1Text = File.ReadAllText(fileName1);
+            string input2Text = File.ReadAllText(fileName2);
+            Assert.AreEqual(String.Empty, input1Text);
+            Assert.AreEqual(String.Empty, input2Text);
+        }
+
+        [Test, Explicit("Pash throws a CmdletInvocationException")]
+        public void FileDoesNotExistThrowsItemNotFoundException()
+        {
+            var ex = Assert.Throws<ExecutionWithErrorsException>(delegate {
+                ReferenceHost.Execute("Clear-Content FileDoesNotExistItemNotFoundExceptionThrown.txt");
+            });
+
+            ErrorRecord error = ex.Errors[0];
+            Assert.IsInstanceOf<ItemNotFoundException>(error.Exception);
+            Assert.AreEqual(ErrorCategory.ObjectNotFound, error.CategoryInfo.Category);
+            Assert.AreEqual("PathNotFound,Microsoft.PowerShell.Commands.ClearContentCommand", error.FullyQualifiedErrorId);
+        }
+
+        [Test]
+        public void FileDoesNotExistThrowsException()
+        {
+            try
+            {
+                ReferenceHost.Execute("Clear-Content FileDoesNotExistItemNotFoundExceptionThrown.txt");
+                Assert.Fail("Exception should be thrown.");
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+}

--- a/Source/ReferenceTests/Commands/GetContentTests.cs
+++ b/Source/ReferenceTests/Commands/GetContentTests.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Commands
+{
+    [TestFixture]
+    public class GetContentTests : ReferenceTestBase
+    {
+        private string _tempFileName;
+
+        private string GenerateTempFile(string content, string fileName = "input.txt")
+        {
+            _tempFileName = Path.Combine(Path.GetTempPath(), fileName);
+            File.WriteAllText(_tempFileName, content);
+            AddCleanupFile(_tempFileName);
+            return _tempFileName;
+        }
+
+        [Test]
+        public void TextFileWithTwoLines()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2"));
+
+            string result = ReferenceHost.Execute("Get-Content " + fileName);
+
+            Assert.AreEqual(NewlineJoin("1", "2"), result);
+        }
+
+        [Test]
+        public void TextFileIsIntoObjectArrayContainingStrings()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2", "3"));
+
+            string result = ReferenceHost.Execute(new string[] {
+                "$c = Get-Content -path " + fileName,
+                "$array = $c.GetType().Name",
+                "$item = $c[0].GetType().Name",
+                "\"$array - $item\""
+            });
+
+            Assert.AreEqual("Object[] - String" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ReadTwoFiles()
+        {
+            string fileName1 = GenerateTempFile(NewlineJoin("1", "2"), "input1.txt");
+            string fileName2 = GenerateTempFile(NewlineJoin("3", "4"), "input2.txt");
+
+            string result = ReferenceHost.Execute("Get-Content " + fileName1 + "," + fileName2);
+
+            Assert.AreEqual(NewlineJoin("1", "2", "3", "4"), result);
+        }
+
+        [Test]
+        public void ReadFirstTwoLinesOfThreeLineTextFile()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2", "3"));
+
+            string result = ReferenceHost.Execute("Get-Content -totalcount 2 " + fileName);
+
+            Assert.AreEqual(NewlineJoin("1", "2"), result);
+        }
+
+        [Test]
+        public void ReadFirstTwoLinesOfThreeLineTextFileUsingFirstParameterAlias()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2", "3"));
+
+            string result = ReferenceHost.Execute("Get-Content -first 2 " + fileName);
+
+            Assert.AreEqual(NewlineJoin("1", "2"), result);
+        }
+
+        [Test]
+        public void ReadFirstTwoLinesOfThreeLineTextFileUsingHeadParameterAlias()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2", "3"));
+
+            string result = ReferenceHost.Execute("Get-Content -head 2 " + fileName);
+
+            Assert.AreEqual(NewlineJoin("1", "2"), result);
+        }
+
+        [Test]
+        public void ReadNoLinesOfFileThatDoesNotExist()
+        {
+            string result = ReferenceHost.Execute("Get-Content -first 0 unknownfile.txt");
+
+            Assert.AreEqual(String.Empty, result);
+        }
+
+        [Test]
+        public void ReadLastTwoLinesOfThreeLineTextFile()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2", "3"));
+
+            string result = ReferenceHost.Execute("Get-Content -tail 2 " + fileName);
+
+            Assert.AreEqual(NewlineJoin("2", "3"), result);
+        }
+
+        [Test]
+        public void ReadLastTwoLinesOfThreeLineTextFileUsingLastParameterAlias()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2", "3"));
+
+            string result = ReferenceHost.Execute("Get-Content -last 2 " + fileName);
+
+            Assert.AreEqual(NewlineJoin("2", "3"), result);
+        }
+
+        [Test]
+        public void ReadTwoLinesInOneGoUsingReadCount()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("A1", "B2", "C3", "D4"));
+
+            string result = ReferenceHost.Execute(new string[] {
+                "$items = Get-Content -ReadCount 2 -path " + fileName,
+                "$a = $items[0][0]",
+                "$b = $items[0][1]",
+                "$c = $items[1][0]",
+                "$d = $items[1][1]",
+                "\"$a $b $c $d\""
+            });
+
+            Assert.AreEqual("A1 B2 C3 D4" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void TypesUsedWhenReadTwoLinesInOneGoUsingReadCount()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("1", "2", "3", "4"));
+
+            string result = ReferenceHost.Execute(new string[] {
+                "$c = Get-Content -ReadCount 2 -path " + fileName,
+                "$array = $c.GetType().Name",
+                "$item = $c[0].GetType().Name",
+                "$item2 = $c[0][0].GetType().Name",
+                "\"$array - $item - $item2\""
+            });
+
+            Assert.AreEqual("Object[] - Object[] - String" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ReadTwoLinesInOneGoUsingReadCountButOnlyThreeLinesInTotal()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("A1", "B2", "C3"));
+
+            string result = ReferenceHost.Execute(new string[] {
+                "$items = Get-Content -ReadCount 2 -path " + fileName,
+                "$a = $items[0][0]",
+                "$b = $items[0][1]",
+                "$c = $items[1][0]",
+                "\"$a $b $c\""
+            });
+
+            Assert.AreEqual("A1 B2 C3" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ReadTwoLinesInOneGoUsingReadCountButReadTheLastThreeLines()
+        {
+            string fileName = GenerateTempFile(NewlineJoin("A1", "B2", "C3", "D4"));
+
+            string result = ReferenceHost.Execute(new string[] {
+                "$items = Get-Content -ReadCount 2 -Tail 3 -path " + fileName,
+                "$a = $items[0][0]",
+                "$b = $items[0][1]",
+                "$c = $items[1][0]",
+                "\"$a $b $c\""
+            });
+
+            Assert.AreEqual("B2 C3 D4" + Environment.NewLine, result);
+        }
+    }
+}

--- a/Source/ReferenceTests/Commands/SetContentTests.cs
+++ b/Source/ReferenceTests/Commands/SetContentTests.cs
@@ -65,7 +65,7 @@ namespace ReferenceTests.Commands
             string fileName1 = GenerateTempFile("1", "input1.txt");
             string fileName2 = GenerateTempFile("2", "input2.txt");
 
-            string result = ReferenceHost.Execute("'abc' | Set-Content " + fileName1 + "," + fileName2);
+            ReferenceHost.Execute("'abc' | Set-Content " + fileName1 + "," + fileName2);
 
             string input1Text = File.ReadAllText(fileName1);
             string input2Text = File.ReadAllText(fileName2);

--- a/Source/ReferenceTests/Commands/SetContentTests.cs
+++ b/Source/ReferenceTests/Commands/SetContentTests.cs
@@ -99,5 +99,19 @@ namespace ReferenceTests.Commands
 
             Assert.AreEqual(NewlineJoin("abc", "def"), result);
         }
+
+        [Test]
+        public void FileDoesNotExist()
+        {
+            string fileName = GenerateTempFile("test");
+            File.Delete(fileName);
+
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Content -value 'abc' -path " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
     }
 }

--- a/Source/ReferenceTests/Commands/SetContentTests.cs
+++ b/Source/ReferenceTests/Commands/SetContentTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Commands
+{
+    [TestFixture]
+    public class SetContentTests : ReferenceTestBase
+    {
+        private string _tempFileName;
+
+        private string GenerateTempFile(string content, string fileName = "content.txt")
+        {
+            _tempFileName = Path.Combine(Path.GetTempPath(), fileName);
+            File.WriteAllText(_tempFileName, content);
+            AddCleanupFile(_tempFileName);
+            return _tempFileName;
+        }
+
+        [Test]
+        public void StringValueOverwritesExistingFile()
+        {
+            string fileName = GenerateTempFile("test");
+
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Content -value 'abc' -path " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void NoNamedParameters()
+        {
+            string fileName = GenerateTempFile("test");
+
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Content " + fileName + " 'abc'",
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ValueTakenFromPipeline()
+        {
+            string fileName = GenerateTempFile("test");
+
+            string result = ReferenceHost.Execute(new string[] {
+                "'abc' | Set-Content " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void TwoFiles()
+        {
+            string fileName1 = GenerateTempFile("1", "input1.txt");
+            string fileName2 = GenerateTempFile("2", "input2.txt");
+
+            string result = ReferenceHost.Execute("'abc' | Set-Content " + fileName1 + "," + fileName2);
+
+            string input1Text = File.ReadAllText(fileName1);
+            string input2Text = File.ReadAllText(fileName2);
+            Assert.AreEqual("abc" + Environment.NewLine, input1Text);
+            Assert.AreEqual("abc" + Environment.NewLine, input2Text);
+        }
+
+        [Test, Explicit("Array values passed one at a time to Set-Content and not as an array")]
+        public void ValueArrayTakenFromPipeline()
+        {
+            string fileName = GenerateTempFile("test");
+
+            string result = ReferenceHost.Execute(new string[] {
+                "'abc','def' | Set-Content " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(NewlineJoin("abc", "def"), result);
+        }
+
+        [Test]
+        public void ArrayOfValues()
+        {
+            string fileName = GenerateTempFile("test");
+
+            string result = ReferenceHost.Execute(new string[] {
+                "$a = 'abc','def'",
+                "Set-Content -value $a -path " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(NewlineJoin("abc", "def"), result);
+        }
+    }
+}

--- a/Source/ReferenceTests/Providers/AliasProviderTests.cs
+++ b/Source/ReferenceTests/Providers/AliasProviderTests.cs
@@ -64,5 +64,40 @@ namespace ReferenceTests.Providers
 
             Assert.AreEqual("Get-ChildItem" + Environment.NewLine, result);
         }
+
+        [Test]
+        public void SetAlias()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$alias:AliasProviderTest = 'abc'",
+                "$alias:AliasProviderTest"
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void SetContentForAlias()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$alias:AliasProviderTest = 'abc'",
+                "Set-Content alias:AliasProviderTest 'test'",
+                "$alias:AliasProviderTest"
+            });
+
+            Assert.AreEqual("test" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void SetContentForAliasUsingTwoItems()
+        {
+            Assert.Throws(Is.InstanceOf(typeof(Exception)), delegate
+            {
+                ReferenceHost.Execute(new string[] {
+                    "$alias:AliasProviderTest = 'abc'",
+                    "Set-Content alias:AliasProviderTest 'test1','test2'",
+                });
+            });
+        }
     }
 }

--- a/Source/ReferenceTests/Providers/AliasProviderTests.cs
+++ b/Source/ReferenceTests/Providers/AliasProviderTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Providers
+{
+    [TestFixture]
+    class AliasProviderTests : ReferenceTestBase
+    {
+        [Test]
+        public void ListAllAliases()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Alias testalias Get-ChildItem",
+                "Get-ChildItem alias: | ? { $_.Name -eq 'testalias' } | % { $_.Name }"
+            });
+
+            Assert.AreEqual("testalias" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListAllAliasesUsingBackslashInDriveName()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Alias testalias Get-ChildItem",
+                String.Format(@"Get-ChildItem alias:{0} | ? {{ $_.Name -eq 'testalias' }} | % {{ $_.Name }}", Path.DirectorySeparatorChar)
+            });
+
+            Assert.AreEqual("testalias" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListSingleAlias()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Alias testalias Get-ChildItem",
+                @"Get-ChildItem alias:testalias | % { $_.Name }"
+            });
+
+            Assert.AreEqual("testalias" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListSingleAliasWithBackslashInDriveName()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Alias testalias Get-ChildItem",
+                String.Format(@"Get-ChildItem alias:{0}testalias | % {{ $_.Name }}", Path.DirectorySeparatorChar)
+            });
+
+            Assert.AreEqual("testalias" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void GetContentForAlias()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Alias testalias Get-ChildItem",
+                @"Get-Content alias:testalias"
+            });
+
+            Assert.AreEqual("Get-ChildItem" + Environment.NewLine, result);
+        }
+    }
+}

--- a/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
@@ -62,5 +62,29 @@ namespace ReferenceTests.Providers
 
             AssertMessagesAreEqual("ClearContent foo");
         }
+
+        [Test]
+        public void AddContent()
+        {
+            string result = ReferenceHost.Execute("Add-Content -value 'abc' -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual(
+                "GetContentWriter foo",
+                "ContentWriter.Seek(0, End)",
+                "ContentWriter.Write(abc)",
+                "ContentWriter.Close()");
+        }
+
+        [Test]
+        public void AddContentWithTwoItems()
+        {
+            string result = ReferenceHost.Execute("Add-Content -value '1','2' -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual(
+                "GetContentWriter foo",
+                "ContentWriter.Seek(0, End)",
+                "ContentWriter.Write(1,2)",
+                "ContentWriter.Close()");
+        }
     }
 }

--- a/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
@@ -32,7 +32,7 @@ namespace ReferenceTests.Providers
                 "ContentWriter.Close()");
         }
 
-        [Test, Explicit("Not implemented")]
+        [Test]
         public void GetContent()
         {
             string result = ReferenceHost.Execute("Get-Content -path TestContentCmdletProvider::foo");

--- a/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using TestPSSnapIn;
+
+namespace ReferenceTests.Providers
+{
+    [TestFixture]
+    public class ContentCmdletProviderTests : ReferenceTestBaseWithTestModule
+    {
+        [SetUp]
+        public void Init()
+        {
+            TestContentCmdletProvider.Messages.Clear();
+        }
+
+        void AssertMessagesAreEqual(params string[] expected)
+        {
+            CollectionAssert.AreEqual(expected, TestContentCmdletProvider.Messages);
+        }
+
+        [Test, Explicit("Not implemented")]
+        public void SetContent()
+        {
+            string result = ReferenceHost.Execute("Set-Content -value 'abc' -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual(
+                "ClearContent foo",
+                "GetContentWriter foo",
+                "ContentWriter.Write(abc)",
+                "ContentWriter.Close()");
+        }
+
+        [Test, Explicit("Not implemented")]
+        public void GetContent()
+        {
+            string result = ReferenceHost.Execute("Get-Content -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual(
+                "GetContentReader foo",
+                "ContentReader.Read(1)",
+                "ContentReader.Close()");
+        }
+
+        [Test, Explicit("Not implemented")]
+        public void ClearContent()
+        {
+            string result = ReferenceHost.Execute("Clear-Content -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual("ClearContent foo");
+        }
+    }
+}

--- a/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
@@ -43,7 +43,7 @@ namespace ReferenceTests.Providers
                 "ContentReader.Close()");
         }
 
-        [Test, Explicit("Not implemented")]
+        [Test]
         public void ClearContent()
         {
             string result = ReferenceHost.Execute("Clear-Content -path TestContentCmdletProvider::foo");

--- a/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
@@ -23,7 +23,7 @@ namespace ReferenceTests.Providers
         [Test]
         public void SetContent()
         {
-            string result = ReferenceHost.Execute("Set-Content -value 'abc' -path TestContentCmdletProvider::foo");
+            ReferenceHost.Execute("Set-Content -value 'abc' -path TestContentCmdletProvider::foo");
 
             AssertMessagesAreEqual(
                 "ClearContent foo",
@@ -35,7 +35,7 @@ namespace ReferenceTests.Providers
         [Test]
         public void SetContentWithTwoItems()
         {
-            string result = ReferenceHost.Execute("Set-Content -value '1','2' -path TestContentCmdletProvider::foo");
+            ReferenceHost.Execute("Set-Content -value '1','2' -path TestContentCmdletProvider::foo");
 
             AssertMessagesAreEqual(
                 "ClearContent foo",
@@ -47,7 +47,7 @@ namespace ReferenceTests.Providers
         [Test]
         public void GetContent()
         {
-            string result = ReferenceHost.Execute("Get-Content -path TestContentCmdletProvider::foo");
+            ReferenceHost.Execute("Get-Content -path TestContentCmdletProvider::foo");
 
             AssertMessagesAreEqual(
                 "GetContentReader foo",
@@ -58,7 +58,7 @@ namespace ReferenceTests.Providers
         [Test]
         public void ClearContent()
         {
-            string result = ReferenceHost.Execute("Clear-Content -path TestContentCmdletProvider::foo");
+            ReferenceHost.Execute("Clear-Content -path TestContentCmdletProvider::foo");
 
             AssertMessagesAreEqual("ClearContent foo");
         }
@@ -66,7 +66,7 @@ namespace ReferenceTests.Providers
         [Test]
         public void AddContent()
         {
-            string result = ReferenceHost.Execute("Add-Content -value 'abc' -path TestContentCmdletProvider::foo");
+            ReferenceHost.Execute("Add-Content -value 'abc' -path TestContentCmdletProvider::foo");
 
             AssertMessagesAreEqual(
                 "GetContentWriter foo",
@@ -78,7 +78,7 @@ namespace ReferenceTests.Providers
         [Test]
         public void AddContentWithTwoItems()
         {
-            string result = ReferenceHost.Execute("Add-Content -value '1','2' -path TestContentCmdletProvider::foo");
+            ReferenceHost.Execute("Add-Content -value '1','2' -path TestContentCmdletProvider::foo");
 
             AssertMessagesAreEqual(
                 "GetContentWriter foo",

--- a/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
@@ -20,7 +20,7 @@ namespace ReferenceTests.Providers
             CollectionAssert.AreEqual(expected, TestContentCmdletProvider.Messages);
         }
 
-        [Test, Explicit("Not implemented")]
+        [Test]
         public void SetContent()
         {
             string result = ReferenceHost.Execute("Set-Content -value 'abc' -path TestContentCmdletProvider::foo");
@@ -29,6 +29,18 @@ namespace ReferenceTests.Providers
                 "ClearContent foo",
                 "GetContentWriter foo",
                 "ContentWriter.Write(abc)",
+                "ContentWriter.Close()");
+        }
+
+        [Test]
+        public void SetContentWithTwoItems()
+        {
+            string result = ReferenceHost.Execute("Set-Content -value '1','2' -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual(
+                "ClearContent foo",
+                "GetContentWriter foo",
+                "ContentWriter.Write(1,2)",
                 "ContentWriter.Close()");
         }
 

--- a/Source/ReferenceTests/Providers/ContentReaderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentReaderTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Providers
+{
+    [TestFixture]
+    public class ContentReaderTests : ReferenceTestBaseWithTestModule
+    {
+        [Test]
+        public void ReadFileWithTwoLines()
+        {
+            string fileName = CreateFile(NewlineJoin("first", "second"), ".txt");
+            string result = ReferenceHost.Execute("Test-ContentReader -path " + fileName);
+
+            Assert.AreEqual(NewlineJoin("first", "second"), result);
+        }
+    }
+}

--- a/Source/ReferenceTests/Providers/ContentWriterTests.cs
+++ b/Source/ReferenceTests/Providers/ContentWriterTests.cs
@@ -10,7 +10,7 @@ namespace ReferenceTests.Providers
     [TestFixture]
     public class ContentWriterTests : ReferenceTestBaseWithTestModule
     {
-        [Test, Explicit("Not implemented")]
+        [Test]
         public void WriteStringArrayToFileByDefaultAppendsText()
         {
             string fileName = CreateFile(NewlineJoin("first", "second"), ".txt");

--- a/Source/ReferenceTests/Providers/ContentWriterTests.cs
+++ b/Source/ReferenceTests/Providers/ContentWriterTests.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Providers
+{
+    [TestFixture]
+    public class ContentWriterTests : ReferenceTestBaseWithTestModule
+    {
+        [Test, Explicit("Not implemented")]
+        public void WriteStringArrayToFileByDefaultAppendsText()
+        {
+            string fileName = CreateFile(NewlineJoin("first", "second"), ".txt");
+            ReferenceHost.Execute("Test-ContentWriter -value 'abc','def' -path " + fileName);
+
+            string text = File.ReadAllText(fileName);
+            Assert.AreEqual(NewlineJoin("first", "second", "abc", "def"), text);
+        }
+    }
+}

--- a/Source/ReferenceTests/Providers/EnvironmentProviderTests.cs
+++ b/Source/ReferenceTests/Providers/EnvironmentProviderTests.cs
@@ -102,5 +102,40 @@ namespace ReferenceTests.Providers
 
             StringAssert.Contains("TestValue" + Environment.NewLine, result);
         }
+
+        [Test]
+        public void SetEnvironmentVariableToIntegerArray()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$env:SetEnvironmentVariableToIntegerArrayTest = 1,2",
+                "$env:SetEnvironmentVariableToIntegerArrayTest"
+            });
+
+            Assert.AreEqual("1 2" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void SetContentForEnvironmentVariable()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$env:EnvironmentProviderTestVariable = 'abc'",
+                "Set-Content env:EnvironmentProviderTestVariable 'test'",
+                "$env:EnvironmentProviderTestVariable"
+            });
+
+            Assert.AreEqual("test" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void SetContentForEnvironmentVariableUsingTwoItems()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$env:EnvironmentProviderTestVariable = 'abc'",
+                "Set-Content env:EnvironmentProviderTestVariable 'test1','test2'",
+                "$env:EnvironmentProviderTestVariable"
+            });
+
+            Assert.AreEqual("test1 test2" + Environment.NewLine, result);
+        }
     }
 }

--- a/Source/ReferenceTests/Providers/EnvironmentProviderTests.cs
+++ b/Source/ReferenceTests/Providers/EnvironmentProviderTests.cs
@@ -92,5 +92,15 @@ namespace ReferenceTests.Providers
 
             StringAssert.Contains("TestValue" + Environment.NewLine, result);
         }
+
+        [Test]
+        public void GetContentForEnviromentVariable()
+        {
+            Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, "TestValue");
+            string command = string.Format("Get-Content env:{0}{1}", Path.DirectorySeparatorChar, PashTestEnvironmentVariableName);
+            string result = ReferenceHost.Execute(command);
+
+            StringAssert.Contains("TestValue" + Environment.NewLine, result);
+        }
     }
 }

--- a/Source/ReferenceTests/Providers/EnvironmentProviderTests.cs
+++ b/Source/ReferenceTests/Providers/EnvironmentProviderTests.cs
@@ -3,16 +3,16 @@ using System;
 using System.IO;
 using NUnit.Framework;
 
-namespace TestHost.ProviderTests
+namespace ReferenceTests.Providers
 {
     [TestFixture]
-    class EnvironmentProviderTests
+    class EnvironmentProviderTests : ReferenceTestBase
     {
         const string PashTestEnvironmentVariableName = "PashEnvironmentProviderTest";
         const string PashTestEnvironmentVariableName2 = "PashEnvironmentProviderTest2";
 
         [TearDown]
-        public void TearDown()
+        public override void TearDown()
         {
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, null);
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName2, null);
@@ -23,7 +23,7 @@ namespace TestHost.ProviderTests
         {
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, "TestValue");
             string command = string.Format("$env:{0}", PashTestEnvironmentVariableName);
-            string result = TestHost.Execute(true, command);
+            string result = ReferenceHost.Execute(command);
 
             Assert.AreEqual("TestValue" + Environment.NewLine, result);
         }
@@ -32,7 +32,7 @@ namespace TestHost.ProviderTests
         public void EnvironmentVariableValueCanBeSet()
         {
             string command = string.Format("$env:{0} = 'AnotherValue'", PashTestEnvironmentVariableName);
-            TestHost.Execute(true, command);
+            ReferenceHost.Execute(command);
             string result = Environment.GetEnvironmentVariable(PashTestEnvironmentVariableName);
 
             Assert.AreEqual("AnotherValue", result);
@@ -43,7 +43,7 @@ namespace TestHost.ProviderTests
         {
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, "TestValue");
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName2, "TestValue2");
-            string result = TestHost.Execute(true, "get-childitem env: | foreach-object { $_.value }");
+            string result = ReferenceHost.Execute("get-childitem env: | foreach-object { $_.value }");
 
             StringAssert.Contains("TestValue" + Environment.NewLine, result);
             StringAssert.Contains("TestValue2" + Environment.NewLine, result);
@@ -55,7 +55,7 @@ namespace TestHost.ProviderTests
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, "TestValue");
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName2, "TestValue2");
             string command = string.Format("get-childitem env:{0} | foreach-object {{ $_.value }}", Path.DirectorySeparatorChar);
-            string result = TestHost.Execute(true, command);
+            string result = ReferenceHost.Execute(command);
 
             StringAssert.Contains("TestValue" + Environment.NewLine, result);
             StringAssert.Contains("TestValue2" + Environment.NewLine, result);
@@ -66,7 +66,7 @@ namespace TestHost.ProviderTests
         {
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, "TestValue");
             string command = string.Format("get-childitem env:{0} | foreach-object {{ $_.value }}", PashTestEnvironmentVariableName);
-            string result = TestHost.Execute(true, command);
+            string result = ReferenceHost.Execute(command);
 
             StringAssert.Contains("TestValue" + Environment.NewLine, result);
         }
@@ -76,7 +76,7 @@ namespace TestHost.ProviderTests
         {
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, "TestValue");
             string command = string.Format("get-childitem env:{0}{1} | foreach-object {{ $_.value }}", Path.DirectorySeparatorChar, PashTestEnvironmentVariableName);
-            string result = TestHost.Execute(true, command);
+            string result = ReferenceHost.Execute(command);
 
             StringAssert.Contains("TestValue" + Environment.NewLine, result);
         }
@@ -86,7 +86,9 @@ namespace TestHost.ProviderTests
         {
             Environment.SetEnvironmentVariable(PashTestEnvironmentVariableName, "TestValue");
             string command = string.Format("get-childitem {0} | foreach-object {{ $_.value }}", PashTestEnvironmentVariableName);
-            string result = TestHost.Execute("Set-Location env:", command);
+            string result = ReferenceHost.Execute(new string[] {
+                "Set-Location env:",
+                command});
 
             StringAssert.Contains("TestValue" + Environment.NewLine, result);
         }

--- a/Source/ReferenceTests/Providers/FunctionProviderTests.cs
+++ b/Source/ReferenceTests/Providers/FunctionProviderTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Providers
+{
+    [TestFixture]
+    class FunctionProviderTests : ReferenceTestBase
+    {
+        [Test]
+        public void ListAllFunctions()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "function testfunc {}",
+                "Get-ChildItem function: | ? { $_.Name -eq 'testfunc' } | % { $_.Name }"
+            });
+
+            Assert.AreEqual("testfunc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListAllFunctionsUsingBackslashInDriveName()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "function testfunc {}",
+                String.Format(@"Get-ChildItem function:{0} | ? {{ $_.Name -eq 'testfunc' }} | % {{ $_.Name }}", Path.DirectorySeparatorChar)
+            });
+
+            Assert.AreEqual("testfunc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListSingleFunction()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "function testfunc {}",
+                @"Get-ChildItem function:testfunc | % { $_.Name }"
+            });
+
+            Assert.AreEqual("testfunc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListSingleFunctionWithBackslashInDriveName()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "function testfunc {}",
+                String.Format(@"Get-ChildItem function:{0}testfunc | % {{ $_.Name }}", Path.DirectorySeparatorChar)
+            });
+
+            Assert.AreEqual("testfunc" + Environment.NewLine, result);
+        }
+
+        [Test, Explicit("ScriptBlock.ToString() should return the function body text")]
+        public void GetContentForFunction()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "function testfunc { Write-Host 'test' }",
+                @"(Get-Content function:testfunc).ToString()"
+            });
+
+            Assert.AreEqual(" Write-Host 'test' " + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void GetContentForFunctionIsScriptBlock()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "function testfunc {}",
+                @"(Get-Content function:testfunc).GetType().FullName"
+            });
+
+            Assert.AreEqual("System.Management.Automation.ScriptBlock" + Environment.NewLine, result);
+        }
+    }
+}

--- a/Source/ReferenceTests/Providers/VariableProviderTests.cs
+++ b/Source/ReferenceTests/Providers/VariableProviderTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ReferenceTests.Providers
+{
+    [TestFixture]
+    class VariableProviderTests : ReferenceTestBase
+    {
+        [Test]
+        public void ListAllVariables()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$VariableProviderTestsVariable = 'abc'",
+                "Get-ChildItem variable: | ? { $_.Name -eq 'VariableProviderTestsVariable' } | % { $_.Value }"
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListAllVariablesUsingBackslashInDriveName()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$VariableProviderTestsVariable = 'abc'",
+                String.Format(@"Get-ChildItem variable:{0} | ? {{ $_.Name -eq 'VariableProviderTestsVariable' }} | % {{ $_.Value }}", Path.DirectorySeparatorChar)
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListSingleVariable()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$VariableProviderTestsVariable = 'abc'",
+                @"Get-ChildItem variable:VariableProviderTestsVariable | % { $_.Value }"
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ListSingleVariableWithBackslashInDriveName()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$VariableProviderTestsVariable = 'abc'",
+                String.Format(@"Get-ChildItem variable:{0}VariableProviderTestsVariable | % {{ $_.Value }}", Path.DirectorySeparatorChar)
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void GetContentForVariable()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$VariableProviderTestsVariable = 'abc'",
+                @"Get-Content variable:VariableProviderTestsVariable"
+            });
+
+            Assert.AreEqual("abc" + Environment.NewLine, result);
+        }
+    }
+}

--- a/Source/ReferenceTests/Providers/VariableProviderTests.cs
+++ b/Source/ReferenceTests/Providers/VariableProviderTests.cs
@@ -64,5 +64,32 @@ namespace ReferenceTests.Providers
 
             Assert.AreEqual("abc" + Environment.NewLine, result);
         }
+
+        [Test]
+        public void SetContentForVariable()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$VariableProviderTestsVariable = 'abc'",
+                @"Set-Content variable:VariableProviderTestsVariable 'test'",
+                "$VariableProviderTestsVariable"
+            });
+
+            Assert.AreEqual("test" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void SetContentForVariableUsingTwoItems()
+        {
+            string result = ReferenceHost.Execute(new string[] {
+                "$VariableProviderTestsVariable = 'abc'",
+                @"Set-Content variable:VariableProviderTestsVariable 'test1','test2'",
+                "$type = $VariableProviderTestsVariable.GetType().Name",
+                "$first = $VariableProviderTestsVariable[0]",
+                "$second = $VariableProviderTestsVariable[1]",
+                "\"$type - $first - $second\""
+            });
+
+            Assert.AreEqual("Object[] - test1 - test2" + Environment.NewLine, result);
+        }
     }
 }

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Language\ScopeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\ItemCmdletProviderTests.cs" />
+    <Compile Include="Providers\EnvironmentProviderTests.cs" />
     <Compile Include="ReferenceHost.cs" />
     <Compile Include="Language\PipelineExecutionTests.cs" />
     <Compile Include="ReferenceTestBase.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\ItemCmdletProviderTests.cs" />
     <Compile Include="Providers\EnvironmentProviderTests.cs" />
+    <Compile Include="Providers\VariableProviderTests.cs" />
     <Compile Include="ReferenceHost.cs" />
     <Compile Include="Language\PipelineExecutionTests.cs" />
     <Compile Include="ReferenceTestBase.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -66,6 +66,9 @@
     <Compile Include="Language\ScopeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\AliasProviderTests.cs" />
+    <Compile Include="Providers\ContentCmdletProviderTests.cs" />
+    <Compile Include="Providers\ContentReaderTests.cs" />
+    <Compile Include="Providers\ContentWriterTests.cs" />
     <Compile Include="Providers\FunctionProviderTests.cs" />
     <Compile Include="Providers\ItemCmdletProviderTests.cs" />
     <Compile Include="Providers\EnvironmentProviderTests.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="Commands\AddMemberTests.cs" />
     <Compile Include="Commands\AddTypeTests.cs" />
+    <Compile Include="Commands\GetContentTests.cs" />
     <Compile Include="Commands\ImportModuleTests.cs" />
     <Compile Include="Commands\RemoveModuleTests.cs" />
     <Compile Include="Commands\WhereObjectTests.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Commands\GetContentTests.cs" />
     <Compile Include="Commands\ImportModuleTests.cs" />
     <Compile Include="Commands\RemoveModuleTests.cs" />
+    <Compile Include="Commands\SetContentTests.cs" />
     <Compile Include="Commands\WhereObjectTests.cs" />
     <Compile Include="Integration\RosettaCode.cs" />
     <Compile Include="Language\FileRedirectionTests.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Language\Operators\RangeOperatorTests_7_4.cs" />
     <Compile Include="Language\ScopeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Providers\AliasProviderTests.cs" />
     <Compile Include="Providers\ItemCmdletProviderTests.cs" />
     <Compile Include="Providers\EnvironmentProviderTests.cs" />
     <Compile Include="Providers\VariableProviderTests.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="Commands\AddMemberTests.cs" />
     <Compile Include="Commands\AddTypeTests.cs" />
+    <Compile Include="Commands\ClearContentTests.cs" />
     <Compile Include="Commands\GetContentTests.cs" />
     <Compile Include="Commands\ImportModuleTests.cs" />
     <Compile Include="Commands\RemoveModuleTests.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -44,6 +44,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\AddContentTests.cs" />
     <Compile Include="Commands\AddMemberTests.cs" />
     <Compile Include="Commands\AddTypeTests.cs" />
     <Compile Include="Commands\ClearContentTests.cs" />

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Language\ScopeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\AliasProviderTests.cs" />
+    <Compile Include="Providers\FunctionProviderTests.cs" />
     <Compile Include="Providers\ItemCmdletProviderTests.cs" />
     <Compile Include="Providers\EnvironmentProviderTests.cs" />
     <Compile Include="Providers\VariableProviderTests.cs" />

--- a/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
+++ b/Source/System.Management/Automation/CmdletProviderManagementIntrinsics.cs
@@ -214,6 +214,11 @@ namespace System.Management.Automation
                 throw new PSInvalidOperationException("The default drive collection for this null!");
             }
 
+            if (drives.Count == 0)
+            {
+                drives = providerInstance.GetDriveFromProviderInfo();
+            }
+
             foreach (PSDriveInfo driveInfo in drives)
             {
                 if (driveInfo == null)

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -18,7 +18,21 @@ namespace System.Management.Automation
         }
 
         public void Clear(string path) { throw new NotImplementedException(); }
-        public Collection<IContentReader> GetReader(string path) { throw new NotImplementedException(); }
+
+        public Collection<IContentReader> GetReader(string path)
+        {
+            PSDriveInfo drive;
+            var provider = _cmdlet.State.SessionStateGlobal.GetProviderByPath(path, out drive) as IContentCmdletProvider;
+            if (provider != null)
+            {
+                var readers = new Collection<IContentReader>();
+                readers.Add(provider.GetContentReader(path));
+                return readers;
+            }
+
+            throw new PSInvalidOperationException(String.Format("The provider for path '{0}' is not a IContentCmdletProvider", path));
+        }
+
         public Collection<IContentWriter> GetWriter(string path) { throw new NotImplementedException(); }
     }
 }

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -39,6 +39,11 @@ namespace System.Management.Automation
 
         private string GetProviderPath(string path)
         {
+            if (path.IndexOf("::") == -1)
+            {
+                return path;
+            }
+
             PSDriveInfo drive;
             ProviderInfo providerInfo;
             var globber = new PathGlobber(_cmdlet.ExecutionContext.SessionState);
@@ -49,7 +54,8 @@ namespace System.Management.Automation
         {
             IContentCmdletProvider provider = GetContentCmdletProvider(path);
             var readers = new Collection<IContentReader>();
-            readers.Add(provider.GetContentReader(path));
+            string providerPath = GetProviderPath(path);
+            readers.Add(provider.GetContentReader(providerPath));
             return readers;
        }
 

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -17,21 +17,31 @@ namespace System.Management.Automation
             _cmdlet = cmdlet;
         }
 
-        public void Clear(string path) { throw new NotImplementedException(); }
+        public void Clear(string path)
+        {
+            IContentCmdletProvider provider = GetContentCmdletProvider(path);
+            provider.ClearContent(path);
+        }
 
-        public Collection<IContentReader> GetReader(string path)
+        private IContentCmdletProvider GetContentCmdletProvider(string path)
         {
             PSDriveInfo drive;
             var provider = _cmdlet.State.SessionStateGlobal.GetProviderByPath(path, out drive) as IContentCmdletProvider;
             if (provider != null)
             {
-                var readers = new Collection<IContentReader>();
-                readers.Add(provider.GetContentReader(path));
-                return readers;
+                return provider;
             }
 
             throw new PSInvalidOperationException(String.Format("The provider for path '{0}' is not a IContentCmdletProvider", path));
         }
+
+        public Collection<IContentReader> GetReader(string path)
+        {
+            IContentCmdletProvider provider = GetContentCmdletProvider(path);
+            var readers = new Collection<IContentReader>();
+            readers.Add(provider.GetContentReader(path));
+            return readers;
+       }
 
         public Collection<IContentWriter> GetWriter(string path) { throw new NotImplementedException(); }
     }

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -59,6 +59,13 @@ namespace System.Management.Automation
             return readers;
        }
 
-        public Collection<IContentWriter> GetWriter(string path) { throw new NotImplementedException(); }
+        public Collection<IContentWriter> GetWriter(string path)
+        {
+            IContentCmdletProvider provider = GetContentCmdletProvider(path);
+            var writers = new Collection<IContentWriter>();
+            string providerPath = GetProviderPath(path);
+            writers.Add(provider.GetContentWriter(providerPath));
+            return writers;
+        }
     }
 }

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Provider;
+using Pash.Implementation;
 
 namespace System.Management.Automation
 {
@@ -20,7 +21,8 @@ namespace System.Management.Automation
         public void Clear(string path)
         {
             IContentCmdletProvider provider = GetContentCmdletProvider(path);
-            provider.ClearContent(path);
+            string providerPath = GetProviderPath(path);
+            provider.ClearContent(providerPath);
         }
 
         private IContentCmdletProvider GetContentCmdletProvider(string path)
@@ -33,6 +35,14 @@ namespace System.Management.Automation
             }
 
             throw new PSInvalidOperationException(String.Format("The provider for path '{0}' is not a IContentCmdletProvider", path));
+        }
+
+        private string GetProviderPath(string path)
+        {
+            PSDriveInfo drive;
+            ProviderInfo providerInfo;
+            var globber = new PathGlobber(_cmdlet.ExecutionContext.SessionState);
+            return globber.GetProviderSpecificPath(path, out providerInfo, out drive);
         }
 
         public Collection<IContentReader> GetReader(string path)

--- a/Source/System.Management/Automation/ItemCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ItemCmdletProviderIntrinsics.cs
@@ -187,7 +187,13 @@ namespace System.Management.Automation
 
         internal bool Exists(string path, ProviderRuntime runtime)
         {
-            throw new NotImplementedException();
+            PSDriveInfo drive;
+            var itemProvider = _cmdlet.State.SessionStateGlobal.GetProviderByPath(path, out drive) as ItemCmdletProvider;
+            if (itemProvider != null)
+            {
+                return itemProvider.ItemExists(path, runtime);
+            }
+            return true;
         }
 
         internal void Get(string[] path, ProviderRuntime runtime)

--- a/Source/System.Management/Automation/Provider/CmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/CmdletProvider.cs
@@ -216,5 +216,13 @@ namespace System.Management.Automation.Provider
             psObject.Properties.Add(new PSNoteProperty("PSProvider", ProviderInfo));
             return psObject;
         }
+
+        internal Collection<PSDriveInfo> GetDriveFromProviderInfo()
+        {
+            var drives = new Collection<PSDriveInfo>();
+            var drive = new PSDriveInfo(ProviderInfo.Name, ProviderInfo, string.Empty, string.Empty, null);
+            drives.Add(drive);
+            return drives;
+        }
     }
 }

--- a/Source/System.Management/Automation/Provider/CmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/CmdletProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Management.Automation.Host;
 using System.Collections.ObjectModel;
@@ -220,8 +221,17 @@ namespace System.Management.Automation.Provider
         internal Collection<PSDriveInfo> GetDriveFromProviderInfo()
         {
             var drives = new Collection<PSDriveInfo>();
-            var drive = new PSDriveInfo(ProviderInfo.Name, ProviderInfo, string.Empty, string.Empty, null);
-            drives.Add(drive);
+
+            string providerName = GetType().GetCustomAttributes(typeof(CmdletProviderAttribute), true)
+                .OfType<CmdletProviderAttribute>()
+                .Select(attribute => attribute.ProviderName)
+                .FirstOrDefault();
+
+            if (!String.IsNullOrEmpty(providerName))
+            {
+                var drive = new PSDriveInfo(ProviderInfo.Name, ProviderInfo, string.Empty, string.Empty, null);
+                drives.Add(drive);
+            }
             return drives;
         }
     }

--- a/Source/System.Management/Microsoft.PowerShell/Commands/AliasProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/AliasProvider.cs
@@ -67,7 +67,24 @@ namespace Microsoft.PowerShell.Commands
 
         internal override void SetSessionStateItem(string name, object value, bool writeItem)
         {
-            throw new NotImplementedException();
+            Path path = PathIntrinsics.RemoveDriveName(name);
+            path = path.TrimStartSlash();
+
+            if (value is Array)
+            {
+                var array = (Array)value;
+                if (array.Length > 1)
+                {
+                    throw new PSArgumentException("value");
+                }
+                value = array.GetValue(0);
+            }
+            
+            var aliasInfo = new AliasInfo(path, value.ToString(), null);
+            SessionState.Alias.Set(aliasInfo, "global");
+
+            var a = SessionState.Alias.Get(path);
+            Console.WriteLine(a.Definition);
         }
 
         protected override void GetItem(string path)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/AliasProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/AliasProvider.cs
@@ -40,7 +40,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal override object GetSessionStateItem(string name)
         {
-            throw new NotImplementedException();
+            Path path = PathIntrinsics.RemoveDriveName(name);
+            path = path.TrimStartSlash();
+            return SessionState.Alias.Get(path);
         }
 
         internal override System.Collections.IDictionary GetSessionStateTable()
@@ -50,7 +52,12 @@ namespace Microsoft.PowerShell.Commands
 
         internal override object GetValueOfItem(object item)
         {
-            throw new NotImplementedException();
+            var aliasInfo = item as AliasInfo;
+            if (aliasInfo != null)
+            {
+                return aliasInfo.Definition;
+            }
+            return base.GetValueOfItem(item);
         }
 
         internal override void RemoveSessionStateItem(string name)
@@ -61,6 +68,12 @@ namespace Microsoft.PowerShell.Commands
         internal override void SetSessionStateItem(string name, object value, bool writeItem)
         {
             throw new NotImplementedException();
+        }
+
+        protected override void GetItem(string path)
+        {
+            path = PathIntrinsics.RemoveDriveName(new Path(path).TrimEndSlash());
+            GetChildItems(path, false);
         }
     }
 }

--- a/Source/System.Management/Microsoft.PowerShell/Commands/EnvironmentProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/EnvironmentProvider.cs
@@ -52,6 +52,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal override void SetSessionStateItem(string path, object value, bool writeItem)
         {
+            Path name = PathIntrinsics.RemoveDriveName(path);
+            path = name.TrimStartSlash();
+
             if (value == null)
             {
                 Environment.SetEnvironmentVariable(path, null);

--- a/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
@@ -8,6 +8,7 @@ using System.Security;
 using System.Security.AccessControl;
 using System.Management;
 using System.Management.Pash.Implementation;
+using System.Text;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -365,7 +366,14 @@ namespace Microsoft.PowerShell.Commands
 
         public void ClearContent(string path)
         {
-            throw new NotImplementedException();
+            if (!ItemExists(path))
+            {
+                throw new ItemNotFoundException(string.Format("Cannot find path '{0}' because it does not exist.", path));
+            }
+
+            using (var writer = new System.IO.StreamWriter(path, false, Encoding.ASCII))
+            {
+            }
         }
 
         public object ClearContentDynamicParameters(string path)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
@@ -7,6 +7,7 @@ using System.Management.Automation.Provider;
 using System.Security;
 using System.Security.AccessControl;
 using System.Management;
+using System.Management.Pash.Implementation;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -374,7 +375,7 @@ namespace Microsoft.PowerShell.Commands
 
         public IContentReader GetContentReader(string path)
         {
-            throw new NotImplementedException();
+            return new FileContentReader(path);
         }
 
         public object GetContentReaderDynamicParameters(string path)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.Commands
 
         public IContentWriter GetContentWriter(string path)
         {
-            throw new NotImplementedException();
+            return new FileContentWriter(path);
         }
 
         public object GetContentWriterDynamicParameters(string path)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/FunctionProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FunctionProvider.cs
@@ -38,7 +38,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal override object GetSessionStateItem(string name)
         {
-            throw new NotImplementedException();
+            Path path = PathIntrinsics.RemoveDriveName(name);
+            path = path.TrimStartSlash();
+            return SessionState.Function.Get(path);
         }
 
         internal override IDictionary GetSessionStateTable()
@@ -70,6 +72,12 @@ namespace Microsoft.PowerShell.Commands
         internal override void SetSessionStateItem(string name, object value, bool writeItem)
         {
             throw new NotImplementedException();
+        }
+
+        protected override void GetItem(string name)
+        {
+            name = PathIntrinsics.RemoveDriveName(new Path(name).TrimEndSlash());
+            GetChildItems(name, false);
         }
     }
 }

--- a/Source/System.Management/Microsoft.PowerShell/Commands/SessionStateProviderBase.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/SessionStateProviderBase.cs
@@ -88,7 +88,6 @@ namespace Microsoft.PowerShell.Commands
 
         public void ClearContent(string path)
         {
-            throw new NotImplementedException();
         }
 
         public object ClearContentDynamicParameters(string path)
@@ -108,7 +107,7 @@ namespace Microsoft.PowerShell.Commands
 
         public IContentWriter GetContentWriter(string path)
         {
-            throw new NotImplementedException();
+            return new SessionStateContentWriter(this, path);
         }
 
         public object GetContentWriterDynamicParameters(string path)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/SessionStateProviderBase.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/SessionStateProviderBase.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Management.Automation.Provider;
 using System.Management.Automation;
 using System.Management;
+using System.Management.Pash.Implementation;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -97,7 +98,7 @@ namespace Microsoft.PowerShell.Commands
 
         public IContentReader GetContentReader(string path)
         {
-            throw new NotImplementedException();
+            return new SessionStateContentReader(this, path);
         }
 
         public object GetContentReaderDynamicParameters(string path)

--- a/Source/System.Management/Microsoft.PowerShell/Commands/VariableProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/VariableProvider.cs
@@ -25,11 +25,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal override object GetSessionStateItem(string name)
         {
-            // TODO: deal with empty path
-            if (string.Equals("variable:" + new Path(name).CorrectSlash, name, StringComparison.CurrentCultureIgnoreCase))
-                return true;
-
-            return SessionState.PSVariable.Get(name);
+            Path path = PathIntrinsics.RemoveDriveName(name);
+            path = path.TrimStartSlash();
+            return SessionState.PSVariable.Get(path);
         }
 
         internal override bool CanRenameItem(object item)
@@ -90,17 +88,18 @@ namespace Microsoft.PowerShell.Commands
 
         protected override void GetItem(string name)
         {
-            // HACK: should it be this way?
+            name = PathIntrinsics.RemoveDriveName(new Path(name).TrimEndSlash());
+            GetChildItems(name, false);
+        }
 
-            if (string.Equals("variable:\\", name, StringComparison.CurrentCultureIgnoreCase))
+        internal override object GetValueOfItem(object item)
+        {
+            var variable = item as PSVariable;
+            if (variable != null)
             {
-                name = PathIntrinsics.RemoveDriveName(name);
-                GetChildItems(name, false);
+                return variable.Value;
             }
-            else
-            {
-                GetItem(PathIntrinsics.RemoveDriveName(name));
-            }
+            return base.GetValueOfItem(item);
         }
     }
 }

--- a/Source/System.Management/Microsoft.PowerShell/Commands/VariableProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/VariableProvider.cs
@@ -52,6 +52,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal override void SetSessionStateItem(string name, object value, bool writeItem)
         {
+            Path path = PathIntrinsics.RemoveDriveName(name);
+            name = path.TrimStartSlash();
+
             PSVariable variable = null;
             if (value != null)
             {

--- a/Source/System.Management/Pash/Implementation/Commands/FileContentReader.cs
+++ b/Source/System.Management/Pash/Implementation/Commands/FileContentReader.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Provider;
+
+namespace System.Management.Pash.Implementation
+{
+    class FileContentReader : IContentReader
+    {
+        string _fileName;
+        List<string> lines;
+        int currentLine;
+
+        internal FileContentReader(string fileName)
+        {
+            this._fileName = fileName;
+        }
+
+        public void Close()
+        {
+        }
+
+        public IList Read(long readCount)
+        {
+            if (lines == null)
+            {
+                lines = File.ReadLines(_fileName).ToList();
+            }
+
+            int start = currentLine;
+            currentLine += (int)readCount;
+            return lines.Skip(start).Take((int)readCount).ToList();
+        }
+
+        public void Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+    }
+}

--- a/Source/System.Management/Pash/Implementation/Commands/FileContentWriter.cs
+++ b/Source/System.Management/Pash/Implementation/Commands/FileContentWriter.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Provider;
+using System.Text;
+
+namespace System.Management.Pash.Implementation
+{
+    class FileContentWriter : IContentWriter
+    {
+        string _fileName;
+        StreamWriter _writer;
+
+        internal FileContentWriter(string fileName)
+        {
+            // Default file encoding is ASCII.
+            this._fileName = fileName;
+            _writer = new StreamWriter(fileName, true, Encoding.ASCII);
+        }
+
+        public void Close()
+        {
+            _writer.Close();
+        }
+
+        public void Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IList Write(IList content)
+        {
+            foreach (object item in content)
+            {
+                _writer.WriteLine(item);
+            }
+            return content;
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+    }
+}

--- a/Source/System.Management/Pash/Implementation/Commands/FileContentWriter.cs
+++ b/Source/System.Management/Pash/Implementation/Commands/FileContentWriter.cs
@@ -28,7 +28,10 @@ namespace System.Management.Pash.Implementation
 
         public void Seek(long offset, SeekOrigin origin)
         {
-            throw new NotImplementedException();
+            if ((offset != 0) || (origin != SeekOrigin.End))
+            {
+                throw new NotImplementedException();
+            }
         }
 
         public IList Write(IList content)

--- a/Source/System.Management/Pash/Implementation/Commands/SessionStateContentReader.cs
+++ b/Source/System.Management/Pash/Implementation/Commands/SessionStateContentReader.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (C) Pash Contributors. License GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Provider;
+using Microsoft.PowerShell.Commands;
+
+namespace System.Management.Pash.Implementation
+{
+    class SessionStateContentReader : IContentReader
+    {
+        SessionStateProviderBase _provider;
+        Path _path;
+        bool readItem;
+
+        internal SessionStateContentReader(SessionStateProviderBase provider, Path path)
+        {
+            _provider = provider;
+            _path = path;
+        }
+
+        public void Close()
+        {
+        }
+
+        public IList Read(long readCount)
+        {
+            var items = new List<object>();
+
+            if (!readItem)
+            {
+               readItem = true;
+                object item = _provider.GetSessionStateItem(_path);
+                items.Add(_provider.GetValueOfItem(item));
+            }
+
+            return items;
+        }
+
+        public void Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+    }
+}

--- a/Source/System.Management/Pash/Implementation/Commands/SessionStateContentWriter.cs
+++ b/Source/System.Management/Pash/Implementation/Commands/SessionStateContentWriter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (C) Pash Contributors. License GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Provider;
+using Microsoft.PowerShell.Commands;
+
+namespace System.Management.Pash.Implementation
+{
+    class SessionStateContentWriter : IContentWriter
+    {
+        SessionStateProviderBase _provider;
+        Path _path;
+
+        internal SessionStateContentWriter(SessionStateProviderBase provider, Path path)
+        {
+            _provider = provider;
+            _path = path;
+        }
+
+        public void Close()
+        {
+        }
+
+        public void Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IList Write(IList content)
+        {
+            _provider.SetSessionStateItem(_path, content, false);
+            return content;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -422,6 +422,7 @@
     <Compile Include="Microsoft.PowerShell\PSCorePSSnapIn.cs" />
     <Compile Include="Pash\BitwiseOperation.cs" />
     <Compile Include="Pash\Implementation\Commands\FileContentReader.cs" />
+    <Compile Include="Pash\Implementation\Commands\FileContentWriter.cs" />
     <Compile Include="Pash\Implementation\Commands\SessionStateContentReader.cs" />
     <Compile Include="Pash\Implementation\CommonCmdlet.cs" />
     <Compile Include="Pash\Implementation\CommonCmdletParameters.cs" />

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -422,6 +422,7 @@
     <Compile Include="Microsoft.PowerShell\PSCorePSSnapIn.cs" />
     <Compile Include="Pash\BitwiseOperation.cs" />
     <Compile Include="Pash\Implementation\Commands\FileContentReader.cs" />
+    <Compile Include="Pash\Implementation\Commands\SessionStateContentReader.cs" />
     <Compile Include="Pash\Implementation\CommonCmdlet.cs" />
     <Compile Include="Pash\Implementation\CommonCmdletParameters.cs" />
     <Compile Include="Pash\Implementation\ExecutionVisitorHelper\FileRedirectionOperator.cs" />

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -424,6 +424,7 @@
     <Compile Include="Pash\Implementation\Commands\FileContentReader.cs" />
     <Compile Include="Pash\Implementation\Commands\FileContentWriter.cs" />
     <Compile Include="Pash\Implementation\Commands\SessionStateContentReader.cs" />
+    <Compile Include="Pash\Implementation\Commands\SessionStateContentWriter.cs" />
     <Compile Include="Pash\Implementation\CommonCmdlet.cs" />
     <Compile Include="Pash\Implementation\CommonCmdletParameters.cs" />
     <Compile Include="Pash\Implementation\ExecutionVisitorHelper\FileRedirectionOperator.cs" />

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -421,6 +421,7 @@
     </Compile>
     <Compile Include="Microsoft.PowerShell\PSCorePSSnapIn.cs" />
     <Compile Include="Pash\BitwiseOperation.cs" />
+    <Compile Include="Pash\Implementation\Commands\FileContentReader.cs" />
     <Compile Include="Pash\Implementation\CommonCmdlet.cs" />
     <Compile Include="Pash\Implementation\CommonCmdletParameters.cs" />
     <Compile Include="Pash\Implementation\ExecutionVisitorHelper\FileRedirectionOperator.cs" />

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -91,7 +91,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="FileSystemTests\ProcessBlockingTests.cs" />
     <Compile Include="2.3.5.1.2 Real literals.cs" />
-    <Compile Include="ProviderTests\EnvironmentProviderTests.cs" />
     <Compile Include="ScriptParameterTests.cs" />
     <Compile Include="7.1.6 - SubexpressionOperator.cs" />
     <Compile Include="TestHelpers\TestCommand.cs" />

--- a/Source/TestPSSnapIn/TestContentCmdletProvider.cs
+++ b/Source/TestPSSnapIn/TestContentCmdletProvider.cs
@@ -64,7 +64,7 @@ namespace TestPSSnapIn
 
             public void Seek(long offset, SeekOrigin origin)
             {
-                _provider.AddMessage(string.Format("ContentWriter.Seek({0}, {1}", offset, origin));
+                _provider.AddMessage(string.Format("ContentWriter.Seek({0}, {1})", offset, origin));
             }
 
             public IList Write(IList content)

--- a/Source/TestPSSnapIn/TestContentCmdletProvider.cs
+++ b/Source/TestPSSnapIn/TestContentCmdletProvider.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Provider;
+
+namespace TestPSSnapIn
+{
+    [CmdletProvider(TestContentCmdletProvider.ProviderName, ProviderCapabilities.None)]
+    public class TestContentCmdletProvider : DriveCmdletProvider, IContentCmdletProvider
+    {
+        public const string ProviderName = "TestContentCmdletProvider";
+        public static List<string> Messages = new List<string>();
+
+        public void ClearContent(string path)
+        {
+            Messages.Add(string.Format("ClearContent {0}", path));
+        }
+
+        public object ClearContentDynamicParameters(string path)
+        {
+            //Messages.Add(string.Format("ClearContentDynamicParameters {0}", path));
+            return null;
+        }
+
+        public IContentReader GetContentReader(string path)
+        {
+            Messages.Add(string.Format("GetContentReader {0}", path));
+            return new ContentReader(this);
+        }
+
+        public object GetContentReaderDynamicParameters(string path)
+        {
+            //Messages.Add(string.Format("GetContentReaderDynamicParameters {0}", path));
+            return null;
+        }
+
+        public IContentWriter GetContentWriter(string path)
+        {
+            Messages.Add(string.Format("GetContentWriter {0}", path));
+            return new ContentWriter(this);
+        }
+
+        public object GetContentWriterDynamicParameters(string path)
+        {
+            //Messages.Add(string.Format("GetContentWriterDynamicParameters {0}", path));
+            return null;
+        }
+
+        class ContentWriter : IContentWriter
+        {
+            TestContentCmdletProvider _provider;
+
+            public ContentWriter(TestContentCmdletProvider provider)
+            {
+                _provider = provider;
+            }
+
+            public void Close()
+            {
+                _provider.AddMessage("ContentWriter.Close()");
+            }
+
+            public void Seek(long offset, SeekOrigin origin)
+            {
+                _provider.AddMessage(string.Format("ContentWriter.Seek({0}, {1}", offset, origin));
+            }
+
+            public IList Write(IList content)
+            {
+                var items = new List<object>();
+                foreach (object item in content)
+                {
+                    items.Add(item);
+                }
+                string text = String.Join(",", items.ToArray());
+                _provider.AddMessage(String.Format("ContentWriter.Write({0})", text));
+
+                return content;
+            }
+
+            public void Dispose()
+            {
+                _provider.AddMessage("ContentWriter.Dispose()");
+            }
+        }
+
+        class ContentReader : IContentReader
+        {
+            TestContentCmdletProvider _provider;
+
+            public ContentReader(TestContentCmdletProvider provider)
+            {
+                _provider = provider;
+            }
+
+            public void Close()
+            {
+                _provider.AddMessage("ContentReader.Close()");
+            }
+
+            public IList Read(long readCount)
+            {
+                _provider.AddMessage(String.Format("ContentReader.Read({0})", readCount));
+                return new string[0];
+            }
+
+            public void Seek(long offset, SeekOrigin origin)
+            {
+                _provider.AddMessage(String.Format("ContentReader.Seek({0}, {1})", offset, origin));
+            }
+
+            public void Dispose()
+            {
+                _provider.AddMessage("ContentReader.Dispose()");
+            }
+        }
+
+        internal void AddMessage(string message)
+        {
+            Messages.Add(message);
+        }
+    }
+}

--- a/Source/TestPSSnapIn/TestPSSnapIn.csproj
+++ b/Source/TestPSSnapIn/TestPSSnapIn.csproj
@@ -35,12 +35,17 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PashTestSnapIn.cs" />
     <Compile Include="TestCommands.cs" />
+    <Compile Include="TestContentCmdletProvider.cs" />
     <Compile Include="TestCreateErrorCommand.cs" />
     <Compile Include="TestDriveProvider.cs" />
     <Compile Include="TestItemProvider.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.PowerShell.Commands.Management\Microsoft.Commands.Management.csproj">
+      <Project>{91225A72-A021-4B7D-BA56-5E1B7AC02F03}</Project>
+      <Name>Microsoft.Commands.Management</Name>
+    </ProjectReference>
     <ProjectReference Include="..\System.Management\System.Management.csproj">
       <Project>{C5E303EC-5684-4C95-B0EC-2593E6662403}</Project>
       <Name>System.Management</Name>

--- a/WindowsPowershellReferenceTests/TestModule/TestModule.csproj
+++ b/WindowsPowershellReferenceTests/TestModule/TestModule.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Management.Automation" />
+    <Reference Include="Microsoft.PowerShell.Commands.Management" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
These commands work for text files. Also there is some support for using these commands against other providers that implement the IContentCmdletProvider interface.

  - No wildcard support.
  - No support for dynamic parameters added by providers.