### PR TITLE
ContentCmdletProvider changes to use PathGlobber and work similar to others

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Management/AddContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/AddContentCommand.cs
@@ -10,10 +10,7 @@ namespace Microsoft.Commands.Management
     {
         protected override void ProcessRecord()
         {
-            foreach (string path in Path)
-            {
-                WriteValues(path, true);
-            }
+            WriteValues(InternalPaths, true);
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/ClearContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/ClearContentCommand.cs
@@ -10,10 +10,7 @@ namespace Microsoft.Commands.Management
     {
         protected override void ProcessRecord()
         {
-            foreach (string path in Path)
-            {
-                InvokeProvider.Content.Clear(path);
-            }
+            InvokeProvider.Content.Clear(InternalPaths, ProviderRuntime);
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/ContentCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/ContentCommandBase.cs
@@ -6,16 +6,13 @@ using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands
 {
-    public abstract class ContentCommandBase : CoreCommandWithCredentialsBase, IDisposable
+    public abstract class ContentCommandBase : CoreCommandWithFilteredPathsBase, IDisposable
     {
         public void Dispose()
         {
         }
 
-        [ParameterAttribute(ParameterSetName = "LiteralPath", ValueFromPipelineByPropertyName = true)]
-        public string[] LiteralPath { get; set; }
-
-        [ParameterAttribute(Position = 0, ParameterSetName = "Path", ValueFromPipelineByPropertyName = true)]
-        public string[] Path { get; set; }
+        [Parameter]
+        public override SwitchParameter Force { get; set; }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/GetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/GetContentCommand.cs
@@ -35,9 +35,10 @@ namespace Microsoft.PowerShell.Commands
 
         protected override void ProcessRecord()
         {
-            foreach (string fileName in Path)
+            var readers = InvokeProvider.Content.GetReader(InternalPaths, ProviderRuntime);
+            foreach (var curContentReader in readers)
             {
-                contentReader = InvokeProvider.Content.GetReader(fileName).Single();
+                contentReader = curContentReader;
                 try
                 {
                     if (Tail > 0)

--- a/Source/Microsoft.PowerShell.Commands.Management/PassThroughContentCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/PassThroughContentCommandBase.cs
@@ -1,8 +1,22 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System.Management.Automation;
+using Pash.Implementation;
 
 namespace Microsoft.PowerShell.Commands
 {
     public class PassThroughContentCommandBase : ContentCommandBase
     {
+        [Parameter]
+        public SwitchParameter PassThru { get; set; }
+
+        internal override ProviderRuntime ProviderRuntime
+        {
+            get
+            {
+                var runtime = base.ProviderRuntime;
+                runtime.PassThru = PassThru.IsPresent;
+                return runtime;
+            }
+        }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
@@ -10,14 +10,8 @@ namespace Microsoft.Commands.Management
     {
         protected override void ProcessRecord()
         {
-            foreach (string path in Path)
-            {
-                if (InvokeProvider.Item.Exists(path))
-                {
-                    InvokeProvider.Content.Clear(path);
-                }
-                WriteValues(path);
-            }
+            InvokeProvider.Content.Clear(InternalPaths, ProviderRuntime);
+            WriteValues(InternalPaths);
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/WriteContentCommandBase .cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/WriteContentCommandBase .cs
@@ -13,21 +13,29 @@ namespace Microsoft.PowerShell.Commands
         [AllowEmptyCollection]
         public object[] Value { get; set; }
 
-        internal void WriteValues(string path, bool seekEnd = false)
+        internal void WriteValues(string[] path, bool seekEnd = false)
         {
-            IContentWriter writer = InvokeProvider.Content.GetWriter(path).Single();
+            var writers = InvokeProvider.Content.GetWriter(path, ProviderRuntime);
 
-            try
+            foreach (var writer in writers)
             {
-                if (seekEnd)
+                try
                 {
-                    writer.Seek(0, SeekOrigin.End);
+                    if (seekEnd)
+                    {
+                        writer.Seek(0, SeekOrigin.End);
+                    }
+                    writer.Write(Value);
+
+                    if (PassThru.IsPresent)
+                    {
+                        WriteObject(Value, true);
+                    }
                 }
-                writer.Write(Value);
-            }
-            finally
-            {
-                writer.Close();
+                finally
+                {
+                    writer.Close();
+                }
             }
         }
     }

--- a/Source/ReferenceTests/Providers/ItemCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ItemCmdletProviderTests.cs
@@ -41,6 +41,16 @@ namespace ReferenceTests.Providers
         }
 
         [Test]
+        public void ItemProviderCanNotGetItemByDrive()
+        {
+            var cmd = "Get-Item -Path '" + TestItemProvider.DefaultDrivePath + TestItemProvider.DefaultItemName + "'";
+            // don't check with .Throws<> for a ParameterBindingException. I'm not planning to adopt that stupid behavior
+            Assert.Catch<RuntimeException>(delegate {
+                ReferenceHost.Execute(cmd);
+            });
+        }
+
+        [Test]
         public void ItemProviderWithoutFilterCapabilitiesFailsOnParameter()
         {
             var cmd = "Get-Item -Filter 'foo' -Path '" + _providerQualification + TestItemProvider.DefaultItemName + "'";

--- a/Source/ReferenceTests/Providers/ItemCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ItemCmdletProviderTests.cs
@@ -41,16 +41,6 @@ namespace ReferenceTests.Providers
         }
 
         [Test]
-        public void ItemProviderCanNotGetItemByDrive()
-        {
-            var cmd = "Get-Item -Path '" + TestItemProvider.DefaultDrivePath + TestItemProvider.DefaultItemName + "'";
-            // don't check with .Throws<> for a ParameterBindingException. I'm not planning to adopt that stupid behavior
-            Assert.Catch<RuntimeException>(delegate {
-                ReferenceHost.Execute(cmd);
-            });
-        }
-
-        [Test]
         public void ItemProviderWithoutFilterCapabilitiesFailsOnParameter()
         {
             var cmd = "Get-Item -Filter 'foo' -Path '" + _providerQualification + TestItemProvider.DefaultItemName + "'";

--- a/Source/ReferenceTests/ReferenceTestBase.cs
+++ b/Source/ReferenceTests/ReferenceTestBase.cs
@@ -146,7 +146,7 @@ namespace ReferenceTests
         public string CreateFile(string script, string extension)
         {
             var tempDir = Path.GetTempPath();
-            var fileName = String.Format("TempFile{0}.{1}", _createdFiles.Count, extension);
+            var fileName = String.Format("TempFile{0}.{1}", _createdFiles.Count, extension.TrimStart('.'));
             var filePath = Path.Combine(tempDir, fileName);
             File.WriteAllText(filePath, script);
             _createdFiles.Add(filePath);

--- a/Source/System.Management/Automation/CmdletProviderIntrinsicsBase.cs
+++ b/Source/System.Management/Automation/CmdletProviderIntrinsicsBase.cs
@@ -3,6 +3,7 @@ using System.Management.Automation.Internal;
 using Pash.Implementation;
 using System.Management.Automation.Provider;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace System.Management.Automation
 {

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -75,6 +75,7 @@ namespace System.Management.Automation
                 CmdletProvider provider;
                 var globbedPaths = Globber.GetGlobbedProviderPaths(curPath, runtime, out provider);
                 var contentProvider = CmdletProvider.As<IContentCmdletProvider>(provider);
+                provider.ProviderRuntime = runtime; // make sure the runtime is set!
                 foreach (var p in globbedPaths)
                 {
                     try
@@ -119,6 +120,7 @@ namespace System.Management.Automation
                 CmdletProvider provider;
                 var globbedPaths = Globber.GetGlobbedProviderPaths(curPath, runtime, out provider);
                 var contentProvider = CmdletProvider.As<IContentCmdletProvider>(provider);
+                provider.ProviderRuntime = runtime; // make sure the runtime is set
                 foreach (var p in globbedPaths)
                 {
                     try

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -18,12 +18,42 @@ namespace System.Management.Automation
             _cmdlet = cmdlet;
         }
 
+        #region public API
+
         public void Clear(string path)
         {
             IContentCmdletProvider provider = GetContentCmdletProvider(path);
             string providerPath = GetProviderPath(path);
             provider.ClearContent(providerPath);
         }
+
+        public Collection<IContentReader> GetReader(string path)
+        {
+            IContentCmdletProvider provider = GetContentCmdletProvider(path);
+            var readers = new Collection<IContentReader>();
+            string providerPath = GetProviderPath(path);
+            readers.Add(provider.GetContentReader(providerPath));
+            return readers;
+       }
+
+        public Collection<IContentWriter> GetWriter(string path)
+        {
+            IContentCmdletProvider provider = GetContentCmdletProvider(path);
+            var writers = new Collection<IContentWriter>();
+            string providerPath = GetProviderPath(path);
+            writers.Add(provider.GetContentWriter(providerPath));
+            return writers;
+        }
+
+        #endregion
+
+        #region internal API
+
+
+
+        #endregion
+
+        #region private helpers
 
         private IContentCmdletProvider GetContentCmdletProvider(string path)
         {
@@ -51,22 +81,6 @@ namespace System.Management.Automation
             return globber.GetProviderSpecificPath(path, new ProviderRuntime(_cmdlet), out providerInfo);
         }
 
-        public Collection<IContentReader> GetReader(string path)
-        {
-            IContentCmdletProvider provider = GetContentCmdletProvider(path);
-            var readers = new Collection<IContentReader>();
-            string providerPath = GetProviderPath(path);
-            readers.Add(provider.GetContentReader(providerPath));
-            return readers;
-       }
-
-        public Collection<IContentWriter> GetWriter(string path)
-        {
-            IContentCmdletProvider provider = GetContentCmdletProvider(path);
-            var writers = new Collection<IContentWriter>();
-            string providerPath = GetProviderPath(path);
-            writers.Add(provider.GetContentWriter(providerPath));
-            return writers;
-        }
+        #endregion
     }
 }

--- a/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
+++ b/Source/System.Management/Automation/ContentCmdletProviderIntrinsics.cs
@@ -22,26 +22,50 @@ namespace System.Management.Automation
 
         public void Clear(string path)
         {
-            IContentCmdletProvider provider = GetContentCmdletProvider(path);
-            string providerPath = GetProviderPath(path);
-            provider.ClearContent(providerPath);
+            Clear(new [] { path }, false, false);
+        }
+
+        public void Clear(string[] path, bool force, bool literalPath)
+        {
+            foreach (var p in path)
+            {
+                IContentCmdletProvider provider = GetContentCmdletProvider(p);
+                string providerPath = GetProviderPath(p);
+                provider.ClearContent(providerPath);
+            }
         }
 
         public Collection<IContentReader> GetReader(string path)
         {
-            IContentCmdletProvider provider = GetContentCmdletProvider(path);
+            return GetReader(new [] { path }, false, false);
+        }
+
+        public Collection<IContentReader> GetReader(string[] path, bool force, bool literalPath)
+        {
             var readers = new Collection<IContentReader>();
-            string providerPath = GetProviderPath(path);
-            readers.Add(provider.GetContentReader(providerPath));
+            foreach (var p in path)
+            {
+                IContentCmdletProvider provider = GetContentCmdletProvider(p);
+                string providerPath = GetProviderPath(p);
+                readers.Add(provider.GetContentReader(providerPath));
+            }
             return readers;
        }
 
         public Collection<IContentWriter> GetWriter(string path)
         {
-            IContentCmdletProvider provider = GetContentCmdletProvider(path);
+            return GetWriter(new [] { path }, false, false);
+        }
+
+        public Collection<IContentWriter> GetWriter(string[] path, bool force, bool literalPath)
+        {
             var writers = new Collection<IContentWriter>();
-            string providerPath = GetProviderPath(path);
-            writers.Add(provider.GetContentWriter(providerPath));
+            foreach (var p in path)
+            {
+                IContentCmdletProvider provider = GetContentCmdletProvider(p);
+                string providerPath = GetProviderPath(p);
+                writers.Add(provider.GetContentWriter(providerPath));
+            }
             return writers;
         }
 

--- a/Source/System.Management/Automation/Provider/CmdletProvider.cs
+++ b/Source/System.Management/Automation/Provider/CmdletProvider.cs
@@ -162,16 +162,15 @@ namespace System.Management.Automation.Provider
             ProviderInfo = providerInfo;
         }
 
-        internal static T As<T>(CmdletProvider provider) where T : CmdletProvider
+        internal static T As<T>(object provider)
         {
             VerifyType<T>(provider);
-            return provider as T;
+            return ((T) provider);
         }
 
-        internal static void VerifyType<T>(CmdletProvider provider) where T : CmdletProvider
+        internal static void VerifyType<T>(object provider)
         {
-            var casted = provider as T;
-            if (casted == null)
+            if (!(provider is T))
             {
                 throw new NotSupportedException("The provider is not a valid provider of type '" + typeof(T).Name + "'");
             }

--- a/Source/System.Management/Automation/ProviderInfo.cs
+++ b/Source/System.Management/Automation/ProviderInfo.cs
@@ -7,7 +7,6 @@ namespace System.Management.Automation
     public class ProviderInfo : IComparable
     {
         internal PSDriveInfo CurrentDrive { get; set; }
-
         public PSSnapInInfo PSSnapIn { get; private set; }
         public string Name { get; private set; }
         public string Description { get; set; }

--- a/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
@@ -111,6 +111,7 @@ namespace Microsoft.PowerShell.Commands
 
         protected override string GetChildName(string path)
         {
+            path = NormalizePath(path);
             if (string.IsNullOrEmpty(path))
             {
                 throw new NullReferenceException("Path can't be null");
@@ -366,6 +367,7 @@ namespace Microsoft.PowerShell.Commands
 
         public void ClearContent(string path)
         {
+            path = NormalizePath(path);
             if (!ItemExists(path))
             {
                 throw new ItemNotFoundException(string.Format("Cannot find path '{0}' because it does not exist.", path));
@@ -383,6 +385,7 @@ namespace Microsoft.PowerShell.Commands
 
         public IContentReader GetContentReader(string path)
         {
+            path = NormalizePath(path);
             return new FileContentReader(path);
         }
 
@@ -393,6 +396,7 @@ namespace Microsoft.PowerShell.Commands
 
         public IContentWriter GetContentWriter(string path)
         {
+            path = NormalizePath(path);
             return new FileContentWriter(path);
         }
 

--- a/Source/System.Management/Pash/Implementation/PathGlobber.cs
+++ b/Source/System.Management/Pash/Implementation/PathGlobber.cs
@@ -70,7 +70,8 @@ namespace Pash.Implementation
             if (IsProviderQualifiedPath(path))
             {
                 path = GetProviderPathFromProviderQualifiedPath(path, out providerInfo);
-                drive = providerInfo.CurrentDrive;
+                // in case there is no CurrentDrive, set a dummy drive to keep track of the used provider
+                drive = providerInfo.CurrentDrive ?? new PSDriveInfo(providerInfo.Name, providerInfo, "", "", null);
             }
             else if (IsDriveQualifiedPath(path))
             {

--- a/Source/TestPSSnapIn/TestContainerProvider.cs
+++ b/Source/TestPSSnapIn/TestContainerProvider.cs
@@ -219,7 +219,9 @@ namespace TestPSSnapIn
         {
             if (path.StartsWith(PSDriveInfo.Root))
             {
-                path = path.Substring(PSDriveInfo.Root.Length);
+                // for tests: throw an exception here to make sure all paths contain
+                // the drive's root
+                throw new ArgumentException("The path includes the drive's root. But shouldn't by default");
             }
             path = path.Trim('\\', '/');
             return path;

--- a/Source/TestPSSnapIn/TestItemProvider.cs
+++ b/Source/TestPSSnapIn/TestItemProvider.cs
@@ -14,6 +14,8 @@ namespace TestPSSnapIn
         public const string ProviderName = "TestItemProvider";
         public const string DefaultItemName = "defItem";
         public const string DefaultItemValue = "defItemValue";
+        public const string DefaultDriveName = "itemDefaultDrive";
+        public const string DefaultDrivePath = DefaultDriveName + ":\\";
 
         public class ItemTestDrive : PSDriveInfo
         {
@@ -34,7 +36,7 @@ namespace TestPSSnapIn
 
         protected override Collection<PSDriveInfo> InitializeDefaultDrives()
         {
-            var defDrive = new ItemTestDrive(new PSDriveInfo("testItemDrive", ProviderInfo, "/", "Test Item Drive", null));
+            var defDrive = new ItemTestDrive(new PSDriveInfo(DefaultDriveName, ProviderInfo, "", "Test Item Drive", null));
             return new Collection<PSDriveInfo>(new[] { defDrive });
         }
 


### PR DESCRIPTION
As the title says, some small changes so the ContentCmdletProvider works the same way as the other `*CmdletProvider`s, i.e. using PathGlobber (and therefore regarding `-Include`, `-Exclude`, `-Filter`).

All old tests run fine with these changes. I didn't introduce more tests because `NavigationCmdletProvider` is not yet fully supported. When this is done we can add tests to the `ReferenceTests.Command.*` tests to verify all cmdlets work as expected, with globbing and filtering.