### PR TITLE
Support for conversion to void

### DIFF
--- a/Source/ReferenceTests/API/LanguagePrimitivesTests.cs
+++ b/Source/ReferenceTests/API/LanguagePrimitivesTests.cs
@@ -247,6 +247,20 @@ namespace ReferenceTests.API
             var result = LanguagePrimitives.ConvertTo(input, typeof(Version));
             Assert.That(result, Is.EqualTo(new Version(input)));
         }
+
+        [Test]
+        public void ConvertToVoidReturnsAutomationNull()
+        {
+            var result = LanguagePrimitives.ConvertTo("foo", typeof(void));
+            Assert.That(result, Is.SameAs(System.Management.Automation.Internal.AutomationNull.Value));
+        }
+
+        [Test]
+        public void ConvertNullToPSObjectReturnsNull()
+        {
+            var result = LanguagePrimitives.ConvertTo(null, typeof(PSObject));
+            Assert.That(result, Is.Null);
+        }
     }
 }
 

--- a/Source/ReferenceTests/Language/ExpressionTests.cs
+++ b/Source/ReferenceTests/Language/ExpressionTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ReferenceTests.Language
+{
+    [TestFixture]
+    public class ExpressionTests : ReferenceTestBase
+    {
+
+        // a void value is not written to pipeline (see GeneralConversionTest.ConvertToVoidNotWrittenToPipeline)
+        // but it can be used in an expression as null. Here are just some examples
+        [TestCase("[string]::IsNullOrEmpty([void]0)")]
+        [TestCase("[void]'foo' -eq $null")]
+        [TestCase("$a = [void]'foo'; $var = Get-Variable a; ($var.name -eq 'a') -and ($var.value -eq $null)")]
+        public void EmptyPipeExpressionIsHandledAsNull(string cmd)
+        {
+            ExecuteAndCompareTypedResult(cmd, true);
+        }
+    }
+}
+

--- a/Source/ReferenceTests/Language/InvocationTests.cs
+++ b/Source/ReferenceTests/Language/InvocationTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using System.Management.Automation;
 
 namespace ReferenceTests.Language
 {
@@ -19,6 +20,14 @@ $type.GetMethods(20) | Foreach-Object { $_.name }"
 );
 
             StringAssert.Contains("GetHashCode" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void ErrorInInvocationIsMethodInvocationException()
+        {
+            Assert.Throws<MethodInvocationException>(delegate {
+                ReferenceHost.Execute("[System.Management.Automation.LanguagePrimitives]::ConvertTo('a', [DateTime])");
+            });
         }
     }
 }

--- a/Source/ReferenceTests/Language/Operators/Conversion_Tests_6.cs
+++ b/Source/ReferenceTests/Language/Operators/Conversion_Tests_6.cs
@@ -519,15 +519,6 @@ namespace ReferenceTests.Language.Operators
         {
             ExecuteAndCompareTypedResult("[version]'1.0'", new Version("1.0"));
         }
-
-        [TestCase("[void]'a'")]
-        [TestCase("[void]1")]
-        [TestCase("[void][version]'1.0'")]
-        [TestCase("[void][version]$null")]
-        public void ConvertToVoid(string cmd)
-        {
-            ExecuteAndCompareTypedResult(cmd, new object[0]);
-        }
     }
 }
 

--- a/Source/ReferenceTests/Language/Operators/Conversion_Tests_6.cs
+++ b/Source/ReferenceTests/Language/Operators/Conversion_Tests_6.cs
@@ -519,6 +519,15 @@ namespace ReferenceTests.Language.Operators
         {
             ExecuteAndCompareTypedResult("[version]'1.0'", new Version("1.0"));
         }
+
+        [TestCase("[void]'a'")]
+        [TestCase("[void]1")]
+        [TestCase("[void][version]'1.0'")]
+        [TestCase("[void][version]$null")]
+        public void ConvertToVoid(string cmd)
+        {
+            ExecuteAndCompareTypedResult(cmd, new object[0]);
+        }
     }
 }
 

--- a/Source/ReferenceTests/Language/Operators/GeneralConversionTests.cs
+++ b/Source/ReferenceTests/Language/Operators/GeneralConversionTests.cs
@@ -15,6 +15,7 @@ namespace ReferenceTests.Language.Operators
         [TestCase("[bool]$null", false)]
         [TestCase("[float]$notExisting", 0.0f)]
         [TestCase("[float]$null", 0.0f)]
+        [TestCase("[PSObject]$null", null)]
         public void NullIsCorrectlyConverted(string cmd, object expected)
         {
             ExecuteAndCompareTypedResult(cmd, expected);
@@ -60,6 +61,14 @@ namespace ReferenceTests.Language.Operators
             ExecuteAndCompareTypedResult("([int[]]4.7).GetType()", typeof(int[]));
         }
 
+        [TestCase("[void]'a'")]
+        [TestCase("[void]1")]
+        [TestCase("[void][version]'1.0'")]
+        [TestCase("[void]$null")]
+        public void ConvertToVoidNotWrittenToPipeline(string cmd)
+        {
+            ExecuteAndCompareTypedResult(cmd, new object[0]);
+        }
     }
 }
 

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Providers\ProviderLoadingTests.cs" />
     <Compile Include="Providers\DriveCmdletProviderTests.cs" />
     <Compile Include="Providers\NavigationCmdletProviderTests.cs" />
+    <Compile Include="Language\ExpressionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/System.Management/Automation/LanguagePrimitives.cs
+++ b/Source/System.Management/Automation/LanguagePrimitives.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using System.Text;
 using System.Management.Automation.Language;
 using System.Xml;
+using System.Management.Automation.Internal;
 
 namespace System.Management.Automation
 {
@@ -181,6 +182,12 @@ namespace System.Management.Automation
             if (resultType == null)
             {
                 throw new ArgumentException("Result type can not be null.");
+            }
+
+            // if it's a cast to void, we want to "mute" the output. That's done by converting to null
+            if (resultType == typeof(void))
+            {
+                return AutomationNull.Value;
             }
 
             // result is no PSObject, so unpack the value if we deal with one

--- a/Source/System.Management/Automation/MethodInvocationException.cs
+++ b/Source/System.Management/Automation/MethodInvocationException.cs
@@ -11,19 +11,36 @@ namespace System.Management.Automation
     [Serializable]
     public class MethodInvocationException : MethodException
     {
+        public override ErrorRecord ErrorRecord { get; set; }
+
         public MethodInvocationException()
-            : base(typeof(MethodInvocationException).FullName)
+            : this(typeof(MethodInvocationException).FullName)
         {
         }
 
         public MethodInvocationException(string message)
-            : base(message)
+            : this(message, null)
         {
         }
 
         public MethodInvocationException(string message, Exception innerException)
+            : this(message, innerException, null, ErrorCategory.NotSpecified)
+        {
+        }
+
+        public MethodInvocationException(string message, Exception innerException, string errorId, ErrorCategory errorCategory)
             : base(message, innerException)
         {
+            var runtimeException = innerException as IContainsErrorRecord;
+            if (errorId == null)
+            {
+                errorId = runtimeException == null ? "MethodInvocation" : runtimeException.ErrorRecord.ErrorId;
+            }
+            if (errorCategory == ErrorCategory.NotSpecified && runtimeException != null)
+            {
+                errorCategory = runtimeException.ErrorRecord.CategoryInfo.Category;
+            }
+            ErrorRecord = new ErrorRecord(this, errorId, errorCategory, null);
         }
 
         protected MethodInvocationException(SerializationInfo info, StreamingContext context)

--- a/Source/System.Management/Automation/PSMethod.cs
+++ b/Source/System.Management/Automation/PSMethod.cs
@@ -50,7 +50,16 @@ namespace System.Management.Automation
         {
             object[] newArgs;
             var methodInfo = FindBestMethod(arguments, out newArgs);
-            return methodInfo.Invoke(_instance, newArgs);
+            try
+            {
+                return methodInfo.Invoke(_instance, newArgs);
+            }
+            catch (TargetInvocationException e)
+            {
+                var msg = e.InnerException == null ? "Error invoking method '" + methodInfo.ToString() + "'"
+                                                   : e.InnerException.Message;
+                throw new MethodInvocationException(msg, e.InnerException);
+            }
         }
 
         public override PSMemberInfo Copy()

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -875,7 +875,7 @@ namespace System.Management.Pash.Implementation
             Type type = convertExpressionAst.Type.TypeName.GetReflectionType();
 
             var value = EvaluateAst(convertExpressionAst.Child);
-
+            var converted = LanguagePrimitives.ConvertTo(value, type);
             _pipelineCommandRuntime.WriteObject(LanguagePrimitives.ConvertTo(value, type));
             return AstVisitAction.SkipChildren;
         }

--- a/Source/System.Management/Pash/Implementation/PipelineCommandRuntime.cs
+++ b/Source/System.Management/Pash/Implementation/PipelineCommandRuntime.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Pash.Implementation;
+using System.Management.Automation.Internal;
 
 namespace System.Management.Automation
 {
@@ -103,6 +104,11 @@ namespace System.Management.Automation
 
         public void WriteObject(object sendToPipeline)
         {
+            // AutomationNull.Value is never written to stream, it's like "void"
+            if (sendToPipeline == AutomationNull.Value)
+            {
+                return;
+            }
             OutputStream.Write(PSObject.WrapOrNull(sendToPipeline));
         }
 


### PR DESCRIPTION
`[void]'foo'` and similar expressions are now supported and correctly handled inside other expressions.

Also Exceptions thrown when invoking a PSObject's method invocation are nicer now.