### PR TITLE
Travis CI: test against Mono latest, 3.2.8 and 2.10.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
-language: c
+language: csharp
+
+sudo: false   # use the new container-based Travis infrastructure
+
+mono:
+  - latest
+  - 3.2.8
+  - 2.10.8
 
 notifications:
   email:
     on_success: always
-
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq mono-devel mono-utils gtk-sharp2
 
 script: "xbuild /target:test"


### PR DESCRIPTION
Switches .travis.yml to use C# support on Travis and allows testing against multiple Mono versions.

See #334