### PR TITLE
Support for Read-Host, PSCredential and SecureString

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{0E1D573C-C57D-4A83-A739-3A38E719D87E}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -25,8 +25,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors Condition=" '$(OS)' != 'Windows_NT' ">false</TreatWarningsAsErrors>
-    <TreatWarningsAsErrors Condition=" '$(OS)' == 'Windows_NT' ">true</TreatWarningsAsErrors>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\..\Tools\FxCop\PashRules.Warnings.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -146,6 +144,7 @@
     <Compile Include="CollectForEndProcessingCommandBase.cs" />
     <Compile Include="GenerateCsvCommandBase.cs" />
     <Compile Include="ConvertToCsvCommand.cs" />
+    <Compile Include="ReadHostCommand.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/Microsoft.PowerShell.Commands.Utility/ReadHostCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/ReadHostCommand.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Management.Automation;
 using Pash.Implementation;
+using System.Security;
 
 namespace Microsoft.PowerShell.Commands
 {
+    [OutputType(typeof(string), typeof(SecureString))]
     [Cmdlet(VerbsCommunications.Read, "Host"
             /*, HelpUri="http://go.microsoft.com/fwlink/?LinkID=113371" */)]
     public class ReadHostCommand : PSCmdlet

--- a/Source/Microsoft.PowerShell.Commands.Utility/ReadHostCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/ReadHostCommand.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Management.Automation;
+using Pash.Implementation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommunications.Read, "Host"
+            /*, HelpUri="http://go.microsoft.com/fwlink/?LinkID=113371" */)]
+    public class ReadHostCommand : PSCmdlet
+    {
+        [Parameter(Position=0, ValueFromRemainingArguments=true)]
+        [AllowNull]
+        public Object Prompt { get; set; }
+
+        [Parameter]
+        public SwitchParameter AsSecureString { get; set; }
+
+        protected override void EndProcessing()
+        {
+            var ui = Host.UI;
+            if (Prompt != null)
+            {
+                ui.Write(Prompt.ToString() + ": ");
+            }
+
+            object input;
+            if (AsSecureString.IsPresent)
+            {
+                input = ui.ReadLineAsSecureString();
+            }
+            else
+            {
+                input = ui.ReadLine();
+            }
+            WriteObject(input);
+        }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Security/ConvertFromSecureStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Security/ConvertFromSecureStringCommand.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Management.Automation;
+using System.Security;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [OutputType(typeof(string))]
+    [Cmdlet("ConvertFrom", "SecureString", DefaultParameterSetName="Secure"
+        /*, HelpUri="http://go.microsoft.com/fwlink/?LinkID=113287"*/)] 
+    public sealed class ConvertFromSecureStringCommand : ConvertFromToSecureStringCommandBase
+    {
+        [Parameter(Position=0, ValueFromPipeline=true, Mandatory=true)]
+        public SecureString SecureString { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            throw new NotImplementedException("No support for encryption/decryption of secure strings, yet.");
+        }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Security/ConvertFromToSecureStringCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Security/ConvertFromToSecureStringCommandBase.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Management.Automation;
+using System.Security;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public abstract class ConvertFromToSecureStringCommandBase : SecureStringCommandBase
+    {
+        [Parameter(ParameterSetName="Open")]
+        public byte[] Key { get; set; }
+
+        [Parameter(Position=1, ParameterSetName="Secure")]
+        public SecureString SecureKey { get; set; }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Security/ConvertToSecureStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Security/ConvertToSecureStringCommand.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Management.Automation;
+using System.Security;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [OutputType(typeof(SecureString))]
+    [Cmdlet("ConvertTo", "SecureString", DefaultParameterSetName="Secure"
+        /*, HelpUri="http://go.microsoft.com/fwlink/?LinkID=113291"*/)] 
+    public sealed class ConvertToSecureStringCommand : ConvertFromToSecureStringCommandBase
+    {
+        [Parameter(Position=0, ValueFromPipeline=true, Mandatory=true)]
+        public string String { get; set; }
+
+        [Parameter(Position=1, ParameterSetName="PlainText")]
+        public SwitchParameter AsPlainText { get; set; }
+
+        [Parameter(Position=2, ParameterSetName="PlainText")]
+        public SwitchParameter Force { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            if (!AsPlainText.IsPresent)
+            {
+                throw new NotImplementedException("No support for encryption/decryption of secure strings, yet.");
+            }
+            ConvertFromPlaintext();
+        }
+
+        private void ConvertFromPlaintext()
+        {
+            const string msg = "Converting plain text to a SecureString is not secure as the information can be leaked.";
+            if (!Force && !ShouldContinue("Do you want to proceed?", msg))
+            {
+                return;
+            }
+            var secureStr = new SecureString();
+            foreach (var c in String)
+            {
+                secureStr.AppendChar(c);
+            }
+            WriteObject(secureStr);
+        }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Security/GetCredentialCommand.cs
+++ b/Source/Microsoft.PowerShell.Security/GetCredentialCommand.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [Cmdlet(VerbsCommon.Get, "Credential", DefaultParameterSetName="CredentialSet"
+        /*, HelpUri="http://go.microsoft.com/fwlink/?LinkID=113311"*/)]
+    public class GetCredentialCommand : PSCmdlet
+    {
+        private const string _defaultCaption = "Pash Credential Request";
+
+        [Credential]
+        [Parameter(Position=0, Mandatory=true, ParameterSetName="CredentialSet")]
+        public PSCredential Credential { get; set; }
+
+        [Parameter(Mandatory=true, ParameterSetName="MessageSet")]
+        public string Message { get; set; }
+
+        [Parameter(Position=0, Mandatory=false, ParameterSetName="MessageSet")]
+        public string UserName { get; set; }
+
+        protected override void EndProcessing()
+        {
+            // if the user provided a string as 'Credential' parameter, the parameter binding process has already
+            // prompted the user for the password in order to 'convert' the string to PSCredential
+            if (String.IsNullOrEmpty(Message))
+            {
+                if (Credential != null)
+                {
+                    WriteObject(Credential);
+                }
+                return;
+            }
+            // otherwise we query it with custom message by the host
+            var credential = Host.UI.PromptForCredential(_defaultCaption, Message, UserName, "");
+            WriteObject(credential);
+        }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Security/GetCredentialCommand.cs
+++ b/Source/Microsoft.PowerShell.Security/GetCredentialCommand.cs
@@ -3,6 +3,7 @@ using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands
 {
+    [OutputType(typeof(PSCredential))]
     [Cmdlet(VerbsCommon.Get, "Credential", DefaultParameterSetName="CredentialSet"
         /*, HelpUri="http://go.microsoft.com/fwlink/?LinkID=113311"*/)]
     public class GetCredentialCommand : PSCmdlet

--- a/Source/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
+++ b/Source/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
@@ -9,7 +9,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.Security</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.Security</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,6 +35,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="GetCredentialCommand.cs" />
     <Compile Include="PSSecurityPSSnapIn.cs" />
+    <Compile Include="SecureStringCommandBase.cs" />
+    <Compile Include="ConvertFromToSecureStringCommandBase.cs" />
+    <Compile Include="ConvertToSecureStringCommand.cs" />
+    <Compile Include="ConvertFromSecureStringCommand.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
+++ b/Source/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DF4B0778-BBB9-4A69-AADE-FD4361675644}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.PowerShell.Security</RootNamespace>
+    <AssemblyName>Microsoft.PowerShell.Security</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="GetCredentialCommand.cs" />
+    <Compile Include="PSSecurityPSSnapIn.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\System.Management\System.Management.csproj">
+      <Project>{C5E303EC-5684-4C95-B0EC-2593E6662403}</Project>
+      <Name>System.Management</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/Source/Microsoft.PowerShell.Security/MyClass.cs
+++ b/Source/Microsoft.PowerShell.Security/MyClass.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Microsoft.PowerShell.Security
+{
+    public class MyClass
+    {
+        public MyClass()
+        {
+        }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Security/PSSecurityPSSnapIn.cs
+++ b/Source/Microsoft.PowerShell.Security/PSSecurityPSSnapIn.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.ComponentModel;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell
+{
+    [RunInstaller(true)]
+    public sealed class PSSecurityPSSnapin : PSSnapIn
+    {
+        public override string Description
+        {
+            get
+            {
+                return "This PSSnapIn contains security related cmdlets.";
+            }
+        }
+
+        public override string DescriptionResource { get { throw new NotImplementedException(); } }
+
+        public override string Name
+        {
+            get
+            {
+                return "Microsoft.PowerShell.Security";
+            }
+        }
+
+        public override string Vendor { get { return "Pash"; } }
+
+        public override string VendorResource { get { throw new NotImplementedException(); } }
+    }
+}
+

--- a/Source/Microsoft.PowerShell.Security/Properties/AssemblyInfo.cs
+++ b/Source/Microsoft.PowerShell.Security/Properties/AssemblyInfo.cs
@@ -1,0 +1,38 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+
+[assembly: AssemblyTitle("Microsoft.PowerShell.Security")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Pash Contributors")]
+[assembly: AssemblyProduct("Pash - https://github.com/Pash-Project/Pash/")]
+[assembly: AssemblyCopyright("Copyright © 2008,2012-2015 - License: GPL/BSD")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("eb19fe24-8bec-4ad2-8693-929c6743939b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+

--- a/Source/Microsoft.PowerShell.Security/SecureStringCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Security/SecureStringCommandBase.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Security;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public abstract class SecureStringCommandBase : PSCmdlet
+    {
+        protected SecureString SecureStringData { get; set; }
+    }
+}
+

--- a/Source/Pash.sln
+++ b/Source/Pash.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PashConsole.Tests", "PashCo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceTests", "ReferenceTests\ReferenceTests.csproj", "{A415CC70-7710-49B7-B47D-0C8D93CE20D8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.PowerShell.Security", "Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.csproj", "{DF4B0778-BBB9-4A69-AADE-FD4361675644}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -135,6 +137,14 @@ Global
 		{DC9303A4-3F38-4591-9BD4-67F223F7D204}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DC9303A4-3F38-4591-9BD4-67F223F7D204}.Release|x86.ActiveCfg = Release|Any CPU
 		{DC9303A4-3F38-4591-9BD4-67F223F7D204}.Release|x86.Build.0 = Release|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Debug|x86.Build.0 = Debug|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Release|x86.ActiveCfg = Release|Any CPU
+		{DF4B0778-BBB9-4A69-AADE-FD4361675644}.Release|x86.Build.0 = Release|Any CPU
 		{FF03D73A-2153-41DD-98B9-17632531079B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FF03D73A-2153-41DD-98B9-17632531079B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF03D73A-2153-41DD-98B9-17632531079B}.Debug|x86.ActiveCfg = Debug|x86

--- a/Source/PashConsole/FullHost.cs
+++ b/Source/PashConsole/FullHost.cs
@@ -242,7 +242,10 @@ namespace Pash
 
         private string ReadInput()
         {
-            return LocalHost.UI.ReadLine();
+            // our local user interface has a ReadLine(bool) method that controls whether or not the line should
+            // be appended to history. The default is false, so we look for the explicit function first
+            var localUI = LocalHost.UI as LocalHostUserInterface;
+            return localUI == null ? LocalHost.UI.ReadLine() : localUI.ReadLine(true);
         }
 
         private void ShowPrompt(bool firstRun, string lastCtrlStmtKeyword)

--- a/Source/PashConsole/PashConsole.csproj
+++ b/Source/PashConsole/PashConsole.csproj
@@ -81,6 +81,10 @@
       <Project>{C5E303EC-5684-4C95-B0EC-2593E6662403}</Project>
       <Name>System.Management</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.csproj">
+      <Project>{DF4B0778-BBB9-4A69-AADE-FD4361675644}</Project>
+      <Name>Microsoft.PowerShell.Security</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/ReferenceTests/Commands/ConvertToSecureStringTests.cs
+++ b/Source/ReferenceTests/Commands/ConvertToSecureStringTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NUnit.Framework;
+using System.Security;
+
+namespace ReferenceTests.Commands
+{
+    [TestFixture]
+    public class ConvertToSecureStringTests : ReferenceTestBase
+    {
+        [Test]
+        public void CanConvertPlaintextToSecureString()
+        {
+            var val = "ASuperSecureString";
+            var res = ReferenceHost.RawExecute("ConvertTo-SecureString -AsPlainText -Force '" + val + "'");
+            Assert.That(res.Count, Is.EqualTo(1));
+            var secureStr = res[0].BaseObject as SecureString;
+            Assert.That(secureStr, Is.Not.Null, "Result is not a SecureString");
+            var decoded = TestUtil.DecodeSecureString(secureStr);
+            Assert.That(decoded, Is.EqualTo(val));
+        }
+
+    }
+}
+

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -122,15 +122,13 @@
     <Compile Include="Providers\ProviderLoadingTests.cs" />
     <Compile Include="Providers\DriveCmdletProviderTests.cs" />
     <Compile Include="Providers\NavigationCmdletProviderTests.cs" />
+    <Compile Include="TestUtil.cs" />
+    <Compile Include="Commands\ConvertToSecureStringTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">
       <Project>{C5E303EC-5684-4C95-B0EC-2593E6662403}</Project>
       <Name>System.Management</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\TestHost\TestHost.csproj">
-      <Project>{A5550FB3-553B-441E-8386-AD1EF5C31FAE}</Project>
-      <Name>TestHost</Name>
     </ProjectReference>
     <ProjectReference Include="..\TestPSSnapIn\TestPSSnapIn.csproj">
       <Project>{DC9303A4-3F38-4591-9BD4-67F223F7D204}</Project>

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -148,6 +148,10 @@
       <Project>{BB348EAD-1713-4760-9953-BC721A203885}</Project>
       <Name>PashConsole</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.csproj">
+      <Project>{DF4B0778-BBB9-4A69-AADE-FD4361675644}</Project>
+      <Name>Microsoft.PowerShell.Security</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/ReferenceTests/TestUtil.cs
+++ b/Source/ReferenceTests/TestUtil.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Security;
+using System.Runtime.InteropServices;
 
-namespace TestHost
+namespace ReferenceTests
 {
     public static class TestUtil
     {
@@ -32,6 +34,20 @@ namespace TestHost
             }
             "
         );
+
+        public static string DecodeSecureString(SecureString secureStr)
+        { 
+            IntPtr unmanagedString = IntPtr.Zero;
+            try
+            {
+                unmanagedString = Marshal.SecureStringToGlobalAllocUnicode(secureStr);
+                return Marshal.PtrToStringUni(unmanagedString);
+            }
+            finally
+            {
+                Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
+            }
+        }
     }
 }
 

--- a/Source/System.Management/Automation/CommandParameterInfo.cs
+++ b/Source/System.Management/Automation/CommandParameterInfo.cs
@@ -23,6 +23,7 @@ namespace System.Management.Automation
         public bool ValueFromPipeline { get; private set; }
         public bool ValueFromPipelineByPropertyName { get; private set; }
         public bool ValueFromRemainingArguments { get; private set; }
+        internal ReadOnlyCollection<ArgumentTransformationAttribute> TransformationAttributes { get; private set; }
 
         internal MemberInfo MemberInfo { get; private set; }
 
@@ -42,7 +43,7 @@ namespace System.Management.Automation
             attributes.Add(paramAttr);
 
             // Reflect Aliases from field/property
-            AliasAttribute aliasAttr = (AliasAttribute)info.GetCustomAttributes(false).Where(i => i is AliasAttribute).FirstOrDefault();
+            AliasAttribute aliasAttr = (AliasAttribute)info.GetCustomAttributes(false).FirstOrDefault(i => i is AliasAttribute);
             if (aliasAttr != null)
             {
                 List<string> aliases = new List<string>(aliasAttr.AliasNames);
@@ -53,6 +54,9 @@ namespace System.Management.Automation
             {
                 Aliases = new ReadOnlyCollection<string>(new List<string>());
             }
+
+            var transformationAttrs = info.GetCustomAttributes(true).OfType<ArgumentTransformationAttribute>().ToList();
+            TransformationAttributes = new ReadOnlyCollection<ArgumentTransformationAttribute>(transformationAttrs);
 
             Attributes = new ReadOnlyCollection<Attribute>(attributes);
         }

--- a/Source/System.Management/Automation/EngineIntrinsics.cs
+++ b/Source/System.Management/Automation/EngineIntrinsics.cs
@@ -1,17 +1,51 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
 using System.Management.Automation.Host;
+using Pash.Implementation;
 
 namespace System.Management.Automation
 {
     public class EngineIntrinsics
     {
-        public PSHost Host { get { throw new NotImplementedException(); } }
-        public CommandInvocationIntrinsics InvokeCommand { get { throw new NotImplementedException(); } }
-        public ProviderIntrinsics InvokeProvider { get { throw new NotImplementedException(); } }
-        public SessionState SessionState { get { throw new NotImplementedException(); } }
+        private readonly ExecutionContext _executionContext;
 
-        // internals
-        //internal EngineIntrinsics(ExecutionContext context) { throw new NotImplementedException(); }
+        public PSHost Host
+        {
+            get
+            {
+                return _executionContext.LocalHost;
+            }
+        }
+
+        public CommandInvocationIntrinsics InvokeCommand
+        {
+            get
+            {
+                // maybe we need a cmdlet reference or create a new one?
+                throw new NotImplementedException();
+            }
+        }
+
+        public ProviderIntrinsics InvokeProvider
+        {
+            get
+            {
+                // I guess we need a cmdlet reference
+                throw new NotImplementedException();
+            }
+        }
+
+        public SessionState SessionState
+        {
+            get
+            {
+                return _executionContext.SessionState;
+            }
+        }
+
+        internal EngineIntrinsics(ExecutionContext context)
+        {
+            _executionContext = context;
+        }
     }
 }

--- a/Source/System.Management/Pash/Implementation/CmdletParameterBinder.cs
+++ b/Source/System.Management/Pash/Implementation/CmdletParameterBinder.cs
@@ -23,6 +23,7 @@ namespace System.Management.Automation
         private CommandParameterSetInfo _defaultSet;
         private bool _hasDefaultSet;
         private List<CommandParameterSetInfo> _candidateParameterSets;
+        private EngineIntrinsics _engineIntrinsics;
 
         private CommandParameterSetInfo ActiveOrDefaultParameterSet
         {
@@ -58,6 +59,7 @@ namespace System.Management.Automation
             _hasDefaultSet = true;
             _commonParameters = (from parameter in CommonCmdletParameters.CommonParameterSetInfo.Parameters
                                  select parameter.MemberInfo).ToList();
+            _engineIntrinsics = new EngineIntrinsics(_cmdlet.ExecutionContext);
         }
 
         /// <summary>
@@ -557,6 +559,11 @@ namespace System.Management.Automation
             {
                 var msg = String.Format("Parameter '{0}' has already been bound!", info.Name);
                 throw new ParameterBindingException(msg);
+            }
+
+            foreach (var attr in info.TransformationAttributes)
+            {
+                value = attr.Transform(_engineIntrinsics, value);
             }
 
             // ConvertTo throws an exception if conversion isn't possible. That's just fine.

--- a/Source/System.Management/Pash/Implementation/CredentialMessages.cs
+++ b/Source/System.Management/Pash/Implementation/CredentialMessages.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace System.Management.Automation
+{
+    public static class CredentialMessages
+    {
+        public const string DefaultQueryCaption = "Pash Credential Request";
+        public const string DefaultQueryMessage = "Please enter the requested credential";
+    }
+}
+

--- a/Source/System.Management/Pash/Implementation/LocalHostUserInterface.cs
+++ b/Source/System.Management/Pash/Implementation/LocalHostUserInterface.cs
@@ -164,13 +164,13 @@ namespace Pash.Implementation
         }
 
         // workaround as long as getline.cs might care about history on unix
-        internal virtual string ReadLine(bool addToHistory)
+        internal virtual string ReadLine(bool addToHistory, string intialValue = "")
         {
             if (!InteractiveIO)
             {
                 ThrowNotInteractiveException();
             }
-            return UseUnixLikeInput ? _getlineEditor.Edit("", "", addToHistory) : Console.ReadLine();
+            return UseUnixLikeInput ? _getlineEditor.Edit("", intialValue, addToHistory) : Console.ReadLine();
         }
         #endregion
 
@@ -239,20 +239,28 @@ namespace Pash.Implementation
 
         public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
         {
-            if (!InteractiveIO)
-            {
-                ThrowNotInteractiveException();
-            }
-            throw new NotImplementedException();
+            return PromptForCredential(caption, message, userName, targetName,
+                PSCredentialTypes.Default, PSCredentialUIOptions.Default);
         }
 
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName,
+            PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             if (!InteractiveIO)
             {
                 ThrowNotInteractiveException();
             }
-            throw new NotImplementedException();
+            // TODO: add support for allowedCredentialTypes and options
+            // TODO: what does targetName mean? is it a default password, like userName? If so, implement a default value
+            //       in SecureStringReader and use it like that
+            WriteLine();
+            WriteLine(caption);
+            WriteLine(message);
+            Write("UserName: ");
+            var user = ReadLine(false, userName);
+            Write("Password: ");
+            var pw = ReadLineAsSecureString();
+            return new PSCredential(user, pw);
         }
         #endregion
 

--- a/Source/System.Management/Pash/Implementation/LocalHostUserInterface.cs
+++ b/Source/System.Management/Pash/Implementation/LocalHostUserInterface.cs
@@ -164,7 +164,7 @@ namespace Pash.Implementation
         }
 
         // workaround as long as getline.cs might care about history on unix
-        protected virtual string ReadLine(bool addToHistory)
+        internal virtual string ReadLine(bool addToHistory)
         {
             if (!InteractiveIO)
             {
@@ -219,7 +219,7 @@ namespace Pash.Implementation
                 Write(cd.Label.Replace("&", "") + "  ");
             }
             Write(String.Format("[?] Help (default is \"{0}\"): ", chs[defaultChoice]));
-            string str = ReadLine(false).ToUpper();
+            string str = ReadLine().ToUpper();
             if (str == "?")
             {
                 // TODO: implement help
@@ -271,7 +271,7 @@ namespace Pash.Implementation
         #region ReadXXX methods
         public override string ReadLine()
         {
-            return ReadLine(true);
+            return ReadLine(false);
         }
 
         public override SecureString ReadLineAsSecureString()

--- a/Source/System.Management/Pash/Implementation/LocalHostUserInterface.cs
+++ b/Source/System.Management/Pash/Implementation/LocalHostUserInterface.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using Mono.Terminal;
 using System.IO;
 using Extensions.Reflection;
+using System.Security;
 
 namespace Pash.Implementation
 {
@@ -153,8 +154,8 @@ namespace Pash.Implementation
         {
             var user = PromptValue(label + " (UserName)", typeof(string), new Collection<Attribute>(),
                                    helpMessage) as string;
-            var pw = PromptValue(label + " (UserName)", typeof(System.Security.SecureString),
-                                 new Collection<Attribute>(), helpMessage) as System.Security.SecureString;
+            var pw = PromptValue(label + " (Password)", typeof(SecureString),
+                                 new Collection<Attribute>(), helpMessage) as SecureString;
             if (user == null || pw == null)
             {
                 return null;
@@ -273,9 +274,14 @@ namespace Pash.Implementation
             return ReadLine(true);
         }
 
-        public override System.Security.SecureString ReadLineAsSecureString()
+        public override SecureString ReadLineAsSecureString()
         {
-            throw new NotImplementedException();
+            if (!InteractiveIO)
+            {
+                ThrowNotInteractiveException();
+            }
+            var ssReader = new SecureStringReader();
+            return ssReader.ReadLine();
         }
         #endregion
 

--- a/Source/System.Management/Pash/Implementation/SecureStringReader.cs
+++ b/Source/System.Management/Pash/Implementation/SecureStringReader.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Security;
+using System.Threading;
+
+namespace System.Management.Automation
+{
+    /*
+     * Very simple class to read a secure string (like a password) from console. It uses a SecureString object
+     * as a buffer, prints only asterisks and supports backspace.
+     */
+    internal class SecureStringReader
+    {
+        private Thread _mainThread;
+
+        public SecureString ReadLine()
+        {
+            // make sure Ctrl+C can abort editing
+            _mainThread = Thread.CurrentThread;
+            Console.CancelKeyPress += InterruptEdit;
+
+            SecureString buffer = new SecureString();
+            var finished = false;
+            while (!finished)
+            {
+                try
+                {
+                    finished = ReadKey(buffer);
+                }
+                catch (ThreadAbortException)
+                {
+                    // thrown on Ctrl+C
+                    Thread.ResetAbort();
+                    buffer.Clear();
+                    buffer = null;
+                    break;
+                }
+            }
+
+            Console.WriteLine();
+            // reset Ctrl+C handling
+            Console.CancelKeyPress -= InterruptEdit;
+            return buffer;
+        }
+
+        private bool ReadKey(SecureString buffer)
+        {
+            ConsoleKeyInfo i = Console.ReadKey(true);
+            if (i.Key == ConsoleKey.Enter)
+            {
+                return true;
+            }
+            else if (i.Key == ConsoleKey.Backspace)
+            {
+                if (buffer.Length > 0)
+                {
+                    buffer.RemoveAt(buffer.Length - 1);
+                    Console.Write("\b \b");
+                }
+            }
+            else
+            {
+                buffer.AppendChar(i.KeyChar);
+                Console.Write("*");
+            }
+            return false;
+        }
+
+        void InterruptEdit(object sender, ConsoleCancelEventArgs a)
+        {
+            // Do not abort our program
+            a.Cancel = true;
+            // ThreadAbortException will be thrown
+            _mainThread.Abort();
+        }
+    }
+}
+

--- a/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
@@ -20,11 +20,12 @@ namespace Pash.Implementation
     internal class SessionStateGlobal
     {
         //TODO: This and related stuff should be moved to InitialSessionState.CreateDefault
-        private string[] _defaultSnapins = new string[] {
-            "Microsoft.PowerShell.PSCorePSSnapIn, System.Management.Automation",
-            "Microsoft.PowerShell.PSUtilityPSSnapIn, Microsoft.PowerShell.Commands.Utility",
-            "Microsoft.Commands.Management.PSManagementPSSnapIn, Microsoft.PowerShell.Commands.Management",
-            "Microsoft.PowerShell.PSSecurityPSSnapin, Microsoft.PowerShell.Security",
+        // Key is assembly qualified pssnapin name, value is "required" (true) or optional (false)
+        private Dictionary<string, bool> _defaultSnapins = new Dictionary<string, bool> {
+            { "Microsoft.PowerShell.PSCorePSSnapIn, System.Management.Automation", true },
+            { "Microsoft.PowerShell.PSUtilityPSSnapIn, Microsoft.PowerShell.Commands.Utility", false },
+            { "Microsoft.Commands.Management.PSManagementPSSnapIn, Microsoft.PowerShell.Commands.Management", false },
+            { "Microsoft.PowerShell.PSSecurityPSSnapin, Microsoft.PowerShell.Security", false }
         };
         private Dictionary<string, PSSnapInInfo> _snapins;
         private readonly ExecutionContext _globalExecutionContext;
@@ -45,9 +46,19 @@ namespace Pash.Implementation
         #region PSSnapIn specific stuff
         internal void LoadDefaultPSSnapIns()
         {
-            foreach (var defaultSnapin in _defaultSnapins)
+            foreach (var snapinPair in _defaultSnapins)
             {
-                Type snapinType = Type.GetType(defaultSnapin, true);
+                var defaultSnapin = snapinPair.Key;
+                var required = snapinPair.Value;
+                Type snapinType = Type.GetType(defaultSnapin, false);
+                if (snapinType == null)
+                {
+                    if (!required)
+                    {
+                        continue;
+                    }
+                    throw new TypeLoadException("Couldn't load type for required default snapin '" + defaultSnapin + "'");
+                }
                 PSSnapIn snapin = Activator.CreateInstance(snapinType) as PSSnapIn;
                 Assembly snapinAssembly = snapinType.Assembly;
                 LoadPSSnapIn(new PSSnapInInfo(snapin, snapinAssembly, true), snapinAssembly, _globalExecutionContext);

--- a/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
+++ b/Source/System.Management/Pash/Implementation/SessionStateGlobal.cs
@@ -24,6 +24,7 @@ namespace Pash.Implementation
             "Microsoft.PowerShell.PSCorePSSnapIn, System.Management.Automation",
             "Microsoft.PowerShell.PSUtilityPSSnapIn, Microsoft.PowerShell.Commands.Utility",
             "Microsoft.Commands.Management.PSManagementPSSnapIn, Microsoft.PowerShell.Commands.Management",
+            "Microsoft.PowerShell.PSSecurityPSSnapin, Microsoft.PowerShell.Security",
         };
         private Dictionary<string, PSSnapInInfo> _snapins;
         private readonly ExecutionContext _globalExecutionContext;

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -527,6 +527,7 @@
     <Compile Include="Pash\Implementation\PathGlobber.cs" />
     <Compile Include="Automation\CmdletProviderIntrinsicsBase.cs" />
     <Compile Include="Pash\Implementation\IncludeExcludeFilter.cs" />
+    <Compile Include="Pash\Implementation\SecureStringReader.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -528,6 +528,7 @@
     <Compile Include="Automation\CmdletProviderIntrinsicsBase.cs" />
     <Compile Include="Pash\Implementation\IncludeExcludeFilter.cs" />
     <Compile Include="Pash\Implementation\SecureStringReader.cs" />
+    <Compile Include="Pash\Implementation\CredentialMessages.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/TestHost/CmdletUserInputTests.cs
+++ b/Source/TestHost/CmdletUserInputTests.cs
@@ -67,6 +67,17 @@ namespace TestHost
             var lines = res.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             Assert.AreEqual(TestIntegerArraySumCommand.Transform(intArray), lines[lines.Length - 1]);
         }
+
+        [Test]
+        public void ValueGatheringForPSCredential()
+        {
+            var ui = new TestHostUserInterface();
+            ui.SetInput("TheUser" + Environment.NewLine + "SecretPassword" + Environment.NewLine);
+            var res = TestHost.Execute(true, null, ui, CmdletName(typeof(TestPrintCredentialsCommand)));
+            var lines = res.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(lines[lines.Length - 2], Is.EqualTo("User: TheUser"));
+            Assert.That(lines[lines.Length - 1], Is.EqualTo("Password: SecretPassword"));
+        }
     }
 }
 

--- a/Source/TestHost/CmdletUserInputTests.cs
+++ b/Source/TestHost/CmdletUserInputTests.cs
@@ -78,6 +78,17 @@ namespace TestHost
             Assert.That(lines[lines.Length - 2], Is.EqualTo("User: TheUser"));
             Assert.That(lines[lines.Length - 1], Is.EqualTo("Password: SecretPassword"));
         }
+
+        [Test]
+        public void ValueGatheringForPSCredentialWithStringAsCredential()
+        {
+            var ui = new TestHostUserInterface();
+            ui.SetInput("Bo" + Environment.NewLine + "SecretPassword" + Environment.NewLine);
+            var res = TestHost.Execute(true, null, ui, CmdletName(typeof(TestPrintCredentialsCommand)) + " 'BiBa'");
+            var lines = res.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(lines[lines.Length - 2], Is.EqualTo("User: BiBaBo"));
+            Assert.That(lines[lines.Length - 1], Is.EqualTo("Password: SecretPassword"));
+        }
     }
 }
 

--- a/Source/TestHost/Cmdlets/GetCredentialTests.cs
+++ b/Source/TestHost/Cmdlets/GetCredentialTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using System.Management.Automation;
+using ReferenceTests;
 
 namespace TestHost.Cmdlets
 {

--- a/Source/TestHost/Cmdlets/GetCredentialTests.cs
+++ b/Source/TestHost/Cmdlets/GetCredentialTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using NUnit.Framework;
+using System.Management.Automation;
+
+namespace TestHost.Cmdlets
+{
+    [TestFixture]
+    public class GetCredentialTests
+    {
+        [Test]
+        public void GetCredential()
+        {
+            var ui = new TestHostUserInterface();
+            var val = "testUser" + Environment.NewLine + "testPassword" + Environment.NewLine;
+            ui.SetInput(val);
+
+            var cmd = "$a = Get-Credential; $a.GetType().FullName;"
+                    + "$a.UserName; " + TestUtil.PashDecodeSecureString.Call("$a.Password");
+            var res = TestHost.Execute(true, null, ui, cmd);
+
+            var lines = res.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(lines[lines.Length - 3], Is.EqualTo(typeof(PSCredential).FullName));
+            Assert.That(lines[lines.Length - 2], Is.EqualTo("testUser"));
+            Assert.That(lines[lines.Length - 1], Is.EqualTo("testPassword"));
+        }
+
+        [Test]
+        public void GetCredentialWithPredefinedUsernameAsCredential()
+        {
+            var ui = new TestHostUserInterface();
+            var val = Environment.NewLine + "testPassword" + Environment.NewLine;
+            ui.SetInput(val);
+
+            var cmd = "$a = Get-Credential -Credential 'defUser'; $a.GetType().FullName;"
+                + "$a.UserName; " + TestUtil.PashDecodeSecureString.Call("$a.Password");
+            var res = TestHost.Execute(true, null, ui, cmd);
+
+            var lines = res.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(lines[lines.Length - 3], Is.EqualTo(typeof(PSCredential).FullName));
+            Assert.That(lines[lines.Length - 2], Is.EqualTo("defUser"));
+            Assert.That(lines[lines.Length - 1], Is.EqualTo("testPassword"));
+        }
+
+        [Test]
+        public void GetCredentialWithUsernameAndMessage()
+        {
+            var ui = new TestHostUserInterface();
+            var val = Environment.NewLine + "testPassword" + Environment.NewLine;
+            ui.SetInput(val);
+
+            var cmd = "$a = Get-Credential -Message 'testMessage' 'defUser'; $a.GetType().FullName;"
+                + "$a.UserName; " + TestUtil.PashDecodeSecureString.Call("$a.Password");
+            var res = TestHost.Execute(true, null, ui, cmd);
+
+            var lines = res.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(lines, Contains.Item("testMessage"));
+            Assert.That(lines[lines.Length - 3], Is.EqualTo(typeof(PSCredential).FullName));
+            Assert.That(lines[lines.Length - 2], Is.EqualTo("defUser"));
+            Assert.That(lines[lines.Length - 1], Is.EqualTo("testPassword"));
+        }
+    }
+}
+

--- a/Source/TestHost/Cmdlets/ReadHostTests.cs
+++ b/Source/TestHost/Cmdlets/ReadHostTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using ReferenceTests;
 
 namespace TestHost.Cmdlets
 {

--- a/Source/TestHost/Cmdlets/ReadHostTests.cs
+++ b/Source/TestHost/Cmdlets/ReadHostTests.cs
@@ -56,7 +56,7 @@ namespace TestHost
             var ui = new TestHostUserInterface();
             string val = "foobar" + Environment.NewLine;
             ui.SetInput(val);
-            var res = TestHost.Execute(true, null, ui, "Read-Host 'test'");
+            var res = TestHost.Execute(true, null, ui, "$x = Read-Host 'test' -AsSecureString; secureStr2Str($x)");
             // first nl is after reading the input
             Assert.That(res, Is.EqualTo("test: " + Environment.NewLine + val));
         }

--- a/Source/TestHost/Cmdlets/ReadHostTests.cs
+++ b/Source/TestHost/Cmdlets/ReadHostTests.cs
@@ -1,21 +1,11 @@
 ﻿using System;
 using NUnit.Framework;
 
-namespace TestHost
+namespace TestHost.Cmdlets
 {
     [TestFixture]
     public class ReadHostTests
     {
-        private const string _decodeSecureStrFun =
-@"
-            function secureStr2Str($secureStr) {
-              $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToCoTaskMemUnicode($secureStr)
-              $result = [System.Runtime.InteropServices.Marshal]::PtrToStringUni($ptr)
-              [System.Runtime.InteropServices.Marshal]::ZeroFreeCoTaskMemUnicode($ptr)
-              return $result;
-            }
-";
-
         [Test]
         public void ReadString()
         {
@@ -45,7 +35,7 @@ namespace TestHost
             string val = "foobar" + Environment.NewLine;
             ui.SetInput(val);
             var res = TestHost.Execute(true, null, ui,
-                _decodeSecureStrFun + "$x = Read-Host -AsSecureString; secureStr2Str($x)");
+                "$x = Read-Host -AsSecureString;" + TestUtil.PashDecodeSecureString.Call("$x"));
             // nl is after reading the input
             Assert.That(res, Is.EqualTo(Environment.NewLine + val));
         }
@@ -56,7 +46,8 @@ namespace TestHost
             var ui = new TestHostUserInterface();
             string val = "foobar" + Environment.NewLine;
             ui.SetInput(val);
-            var res = TestHost.Execute(true, null, ui, "$x = Read-Host 'test' -AsSecureString; secureStr2Str($x)");
+            var cmd = "$x = Read-Host 'test' -AsSecureString;" + TestUtil.PashDecodeSecureString.Call("$x");
+            var res = TestHost.Execute(true, null, ui, cmd);
             // first nl is after reading the input
             Assert.That(res, Is.EqualTo("test: " + Environment.NewLine + val));
         }

--- a/Source/TestHost/Cmdlets/ReadHostTests.cs
+++ b/Source/TestHost/Cmdlets/ReadHostTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace TestHost
+{
+    [TestFixture]
+    public class ReadHostTests
+    {
+        private const string _decodeSecureStrFun =
+@"
+            function secureStr2Str($secureStr) {
+              $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToCoTaskMemUnicode($secureStr)
+              $result = [System.Runtime.InteropServices.Marshal]::PtrToStringUni($ptr)
+              [System.Runtime.InteropServices.Marshal]::ZeroFreeCoTaskMemUnicode($ptr)
+              return $result;
+            }
+";
+
+        [Test]
+        public void ReadString()
+        {
+            var ui = new TestHostUserInterface();
+            string val = "foobar" + Environment.NewLine;
+            ui.SetInput(val);
+            var res = TestHost.Execute(true, null, ui, "Read-Host");
+            // nl is after reading the input
+            Assert.That(res, Is.EqualTo(Environment.NewLine + val));
+        }
+
+        [Test]
+        public void ReadStringWithPrompt()
+        {
+            var ui = new TestHostUserInterface();
+            string val = "foobar" + Environment.NewLine;
+            ui.SetInput(val);
+            var res = TestHost.Execute(true, null, ui, "Read-Host 'test'");
+            // nl is after reading the input
+            Assert.That(res, Is.EqualTo("test: " + Environment.NewLine + val));
+        }
+
+        [Test]
+        public void ReadSecureString()
+        {
+            var ui = new TestHostUserInterface();
+            string val = "foobar" + Environment.NewLine;
+            ui.SetInput(val);
+            var res = TestHost.Execute(true, null, ui,
+                _decodeSecureStrFun + "$x = Read-Host -AsSecureString; secureStr2Str($x)");
+            // nl is after reading the input
+            Assert.That(res, Is.EqualTo(Environment.NewLine + val));
+        }
+
+        [Test]
+        public void ReadSecureStringWithPrompt()
+        {
+            var ui = new TestHostUserInterface();
+            string val = "foobar" + Environment.NewLine;
+            ui.SetInput(val);
+            var res = TestHost.Execute(true, null, ui, "Read-Host 'test'");
+            // first nl is after reading the input
+            Assert.That(res, Is.EqualTo("test: " + Environment.NewLine + val));
+        }
+    }
+}
+

--- a/Source/TestHost/LocalHostUserInterfaceTests.cs
+++ b/Source/TestHost/LocalHostUserInterfaceTests.cs
@@ -5,6 +5,8 @@ using System.Text;
 using NUnit.Framework;
 using System.IO;
 using Pash.Implementation;
+using System.Runtime.InteropServices;
+using System.Security;
 
 namespace TestHost
 {
@@ -59,6 +61,5 @@ namespace TestHost
             ui.WriteLine(str);
             Assert.AreEqual(str + Environment.NewLine, GetOutput());
         }
-
     }
 }

--- a/Source/TestHost/LocalHostUserInterfaceTests.cs
+++ b/Source/TestHost/LocalHostUserInterfaceTests.cs
@@ -42,7 +42,7 @@ namespace TestHost
             Console.SetOut(originalOut);
         }
 
-        [Test,Explicit("Currently Nunit ignores the redirection of stdin when running from commandline, so the testing doesn't work")]
+        [Test]
         public void TestReadLine()
         {
             SetInput("foobar" + Environment.NewLine);

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -113,6 +113,7 @@
     <Compile Include="CmdletUserInputTests.cs" />
     <Compile Include="TabExpanderTest.cs" />
     <Compile Include="TabExpansionProviderTests.cs" />
+    <Compile Include="Cmdlets\ReadHostTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Management\Microsoft.Commands.Management.csproj">

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -114,6 +114,8 @@
     <Compile Include="TabExpanderTest.cs" />
     <Compile Include="TabExpansionProviderTests.cs" />
     <Compile Include="Cmdlets\ReadHostTests.cs" />
+    <Compile Include="Cmdlets\GetCredentialTests.cs" />
+    <Compile Include="TestUtil.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Management\Microsoft.Commands.Management.csproj">
@@ -135,6 +137,10 @@
     <ProjectReference Include="..\TestPSSnapIn\TestPSSnapIn.csproj">
       <Project>{DC9303A4-3F38-4591-9BD4-67F223F7D204}</Project>
       <Name>TestPSSnapIn</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.csproj">
+      <Project>{DF4B0778-BBB9-4A69-AADE-FD4361675644}</Project>
+      <Name>Microsoft.PowerShell.Security</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -115,7 +115,6 @@
     <Compile Include="TabExpansionProviderTests.cs" />
     <Compile Include="Cmdlets\ReadHostTests.cs" />
     <Compile Include="Cmdlets\GetCredentialTests.cs" />
-    <Compile Include="TestUtil.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Management\Microsoft.Commands.Management.csproj">
@@ -141,6 +140,10 @@
     <ProjectReference Include="..\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.csproj">
       <Project>{DF4B0778-BBB9-4A69-AADE-FD4361675644}</Project>
       <Name>Microsoft.PowerShell.Security</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ReferenceTests\ReferenceTests.csproj">
+      <Project>{A415CC70-7710-49B7-B47D-0C8D93CE20D8}</Project>
+      <Name>ReferenceTests</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/TestHost/TestHostUserInterface.cs
+++ b/Source/TestHost/TestHostUserInterface.cs
@@ -42,7 +42,8 @@ namespace TestHost
 
         internal override string ReadLine(bool addToHistory, string intialValue = "")
         {
-            return intialValue + ReadLine();
+            var val = ReadLine();
+            return val == null ? null : intialValue + val;
         }
 
         public override string ReadLine()

--- a/Source/TestHost/TestHostUserInterface.cs
+++ b/Source/TestHost/TestHostUserInterface.cs
@@ -7,6 +7,7 @@ using System.Management.Automation.Host;
 using NUnit.Framework;
 using System.IO;
 using Pash.Implementation;
+using System.Security;
 
 namespace TestHost
 {
@@ -54,9 +55,19 @@ namespace TestHost
             return InputStream.ReadLine();
         }
 
-        public override System.Security.SecureString ReadLineAsSecureString()
+        public override SecureString ReadLineAsSecureString()
         {
-            throw new NotImplementedException();
+            var val = ReadLine();
+            if (val == null)
+            {
+                return null;
+            }
+            var secStr = new SecureString();
+            foreach (var c in val)
+            {
+                secStr.AppendChar(c);
+            }
+            return secStr;
         }
 
         public override void Write(string value)

--- a/Source/TestHost/TestHostUserInterface.cs
+++ b/Source/TestHost/TestHostUserInterface.cs
@@ -40,9 +40,9 @@ namespace TestHost
             get { return _rawUI; }
         }
 
-        internal override string ReadLine(bool addToHistory)
+        internal override string ReadLine(bool addToHistory, string intialValue = "")
         {
-            return ReadLine();
+            return intialValue + ReadLine();
         }
 
         public override string ReadLine()

--- a/Source/TestHost/TestHostUserInterface.cs
+++ b/Source/TestHost/TestHostUserInterface.cs
@@ -40,7 +40,7 @@ namespace TestHost
             get { return _rawUI; }
         }
 
-        protected override string ReadLine(bool addToHistory)
+        internal override string ReadLine(bool addToHistory)
         {
             return ReadLine();
         }

--- a/Source/TestHost/TestUtil.cs
+++ b/Source/TestHost/TestUtil.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace TestHost
+{
+    public static class TestUtil
+    {
+        public class PashFunction
+        {
+            public readonly string Name;
+            public readonly string Body;
+
+            public PashFunction(string name, string body)
+            {
+                Name = name;
+                Body = body;
+            }
+
+            public string Call(params string[] args)
+            {
+                return "& { " + Body + "; " + Name + " " + String.Join(" ", args) + " } ";
+            }
+        }
+
+        public static readonly PashFunction PashDecodeSecureString = new PashFunction(
+            "_testSecureStr2Str",
+            @"
+            function _testSecureStr2Str($secureStr) {
+              $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToCoTaskMemUnicode($secureStr)
+              $result = [System.Runtime.InteropServices.Marshal]::PtrToStringUni($ptr)
+              [System.Runtime.InteropServices.Marshal]::ZeroFreeCoTaskMemUnicode($ptr)
+              return $result;
+            }
+            "
+        );
+    }
+}
+

--- a/Source/TestPSSnapIn/TestCommands.cs
+++ b/Source/TestPSSnapIn/TestCommands.cs
@@ -527,7 +527,7 @@ namespace TestPSSnapIn
     [Cmdlet(VerbsDiagnostic.Test, "PrintCredentials")]
     public class TestPrintCredentialsCommand : PSCmdlet
     {
-        [Parameter(Mandatory = true)]
+        [Credential, Parameter(Mandatory = true, Position=0)]
         public PSCredential Credential { get; set; }
 
         protected override void ProcessRecord()

--- a/Source/TestPSSnapIn/TestCommands.cs
+++ b/Source/TestPSSnapIn/TestCommands.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Provider;
 using Microsoft.PowerShell.Commands;
+using System.Runtime.InteropServices;
 
 namespace TestPSSnapIn
 {
@@ -520,6 +521,29 @@ namespace TestPSSnapIn
         protected override void ProcessRecord()
         {
             WriteObject(Message);
+        }
+    }
+
+    [Cmdlet(VerbsDiagnostic.Test, "PrintCredentials")]
+    public class TestPrintCredentialsCommand : PSCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public PSCredential Credential { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            WriteObject("User: " + Credential.UserName);
+            IntPtr unmanagedString = IntPtr.Zero;
+            try
+            {
+                unmanagedString = Marshal.SecureStringToGlobalAllocUnicode(Credential.Password);
+                WriteObject("Password: " + Marshal.PtrToStringUni(unmanagedString));
+            }
+            finally
+            {
+                Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
+            }
+
         }
     }
 


### PR DESCRIPTION
- Implemented Read-Host
- Implemented Get-Credential
- Implemented host ui's PromptForCredential
- Implemented parts of ConvertTo-SecureString
- Implemented `CredentialAttribute` and general usage of `ArgumentTransformationAttribute` when binding parameters to cmdlets.