### PR TITLE
Implement Select-String

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Management/AddContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/AddContentCommand.cs
@@ -2,15 +2,22 @@
 using System;
 using System.Management.Automation;
 using Microsoft.PowerShell.Commands;
+using System.Management.Automation.Provider;
+using System.IO;
 
 namespace Microsoft.Commands.Management
 {
     [CmdletAttribute(VerbsCommon.Add, "Content", DefaultParameterSetName = "Path" /* HelpUri = "http://go.microsoft.com/fwlink/?LinkID=113278"*/)]
     public class AddContentCommand : WriteContentCommandBase
     {
-        protected override void ProcessRecord()
+        protected override void BeginProcessing()
         {
-            WriteValues(InternalPaths, true);
+            Writers = InvokeProvider.Content.GetWriter(InternalPaths, ProviderRuntime);
+
+            foreach (IContentWriter writer in Writers)
+            {
+                writer.Seek(0, SeekOrigin.End);
+            }
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Management/SetContentCommand.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Commands.Management
     [CmdletAttribute(VerbsCommon.Set, "Content", DefaultParameterSetName = "Path" /* HelpUri = "http://go.microsoft.com/fwlink/?LinkID=113392"*/)]
     public class SetContentCommand : WriteContentCommandBase
     {
-        protected override void ProcessRecord()
+        protected override void BeginProcessing()
         {
             InvokeProvider.Content.Clear(InternalPaths, ProviderRuntime);
-            WriteValues(InternalPaths);
+            Writers = InvokeProvider.Content.GetWriter(InternalPaths, ProviderRuntime);
         }
     }
 }

--- a/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.PowerShell.Commands
@@ -30,13 +32,13 @@ namespace Microsoft.PowerShell.Commands
         {
         }
 
-        internal MatchInfo(string path, string pattern, Match match, string line, int lineNumber, bool ignoreCase)
+        internal MatchInfo(string path, string pattern, IEnumerable<Match> matches, string line, int lineNumber, bool ignoreCase)
         {
             IgnoreCase = ignoreCase;
             Line = line;
             LineNumber = lineNumber;
             Filename = System.IO.Path.GetFileName(path);
-            Matches = new[] { match };
+            Matches = matches.ToArray();
             Path = path;
             Pattern = pattern;
         }

--- a/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
@@ -28,9 +28,9 @@ namespace Microsoft.PowerShell.Commands
         {
         }
 
-        internal MatchInfo(string path, string pattern, Match match, string line, int lineNumber)
+        internal MatchInfo(string path, string pattern, Match match, string line, int lineNumber, bool ignoreCase)
         {
-            IgnoreCase = true;
+            IgnoreCase = ignoreCase;
             Line = line;
             LineNumber = lineNumber;
             Filename = System.IO.Path.GetFileName(path);

--- a/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
@@ -17,6 +17,10 @@ namespace Microsoft.PowerShell.Commands
 
         public override string ToString()
         {
+            if (Filename == "InputStream")
+            {
+                return Line;
+            }
             return String.Format("{0}:{1}:{2}", Path, LineNumber, Line);
         }
 

--- a/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
@@ -8,8 +8,6 @@ namespace Microsoft.PowerShell.Commands
 {
     public class MatchInfo
     {
-        private int _lineNumber;
-
         public MatchInfoContext Context { get; set; }
         public string Filename { get; internal set; }
         public bool IgnoreCase { get; set; }

--- a/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
@@ -6,6 +6,8 @@ namespace Microsoft.PowerShell.Commands
 {
     public class MatchInfo
     {
+        private int _lineNumber;
+
         public MatchInfoContext Context { get; set; }
         public string Filename { get; internal set; }
         public bool IgnoreCase { get; set; }
@@ -35,6 +37,17 @@ namespace Microsoft.PowerShell.Commands
             LineNumber = lineNumber;
             Filename = System.IO.Path.GetFileName(path);
             Matches = new[] { match };
+            Path = path;
+            Pattern = pattern;
+        }
+
+        internal MatchInfo(string path, string pattern, string line, int lineNumber, bool ignoreCase)
+        {
+            Filename = System.IO.Path.GetFileName(path);
+            IgnoreCase = ignoreCase;
+            Line = line;
+            LineNumber = lineNumber;
+            Matches = new Match[0];
             Path = path;
             Pattern = pattern;
         }

--- a/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/MatchInfo.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public class MatchInfo
+    {
+        public MatchInfoContext Context { get; set; }
+        public string Filename { get; internal set; }
+        public bool IgnoreCase { get; set; }
+        public string Line { get; set; }
+        public int LineNumber { get; set; }
+        public Match[] Matches { get; set; }
+        public string Path { get; set; }
+        public string Pattern { get; set; }
+
+        public override string ToString()
+        {
+            return String.Format("{0}:{1}:{2}", Path, LineNumber, Line);
+        }
+
+        public MatchInfo()
+        {
+        }
+
+        internal MatchInfo(string path, string pattern, Match match, string line, int lineNumber)
+        {
+            IgnoreCase = true;
+            Line = line;
+            LineNumber = lineNumber;
+            Filename = System.IO.Path.GetFileName(path);
+            Matches = new[] { match };
+            Path = path;
+            Pattern = pattern;
+        }
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Utility/MatchInfoContext.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/MatchInfoContext.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+
+namespace Microsoft.PowerShell.Commands
+{
+    public sealed class MatchInfoContext : ICloneable
+    {
+        public string[] DisplayPostContext { get; set; }
+        public string[] DisplayPreContext { get; set; }
+        public string[] PostContext { get; set; }
+        public string[] PreContext { get; set; }
+
+        public object Clone()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -83,6 +83,8 @@
     <Compile Include="GetVariableCommand.cs" />
     <Compile Include="ImportCsvCommand.cs" />
     <Compile Include="Language.cs" />
+    <Compile Include="MatchInfo.cs" />
+    <Compile Include="MatchInfoContext.cs" />
     <Compile Include="MemberDefinition.cs" />
     <Compile Include="NewObjectCommand.cs" />
     <Compile Include="NewAliasCommand.cs" />
@@ -96,6 +98,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PSUtilityPSSnapIn.cs" />
     <Compile Include="RemoveVariableCommand.cs" />
+    <Compile Include="SelectStringCommand.cs" />
     <Compile Include="SetAliasCommand.cs" />
     <Compile Include="SetVariableCommand.cs" />
     <Compile Include="SortObjectCommand.cs" />

--- a/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Provider;
+using System.Management.Pash.Implementation;
 using System.Text.RegularExpressions;
 using Pash.Implementation;
 
@@ -124,8 +125,13 @@ namespace Microsoft.PowerShell.Commands
         {
             foreach (string path in ResolvePaths())
             {
-                MatchInLines(path, File.ReadLines(path));
+                MatchInLines(path, ReadLines(path));
             }
+        }
+
+        private IEnumerable<string> ReadLines(string path)
+        {
+            return File.ReadAllLines(path, EncodingMapping.GetEncoding(Encoding));
         }
 
         private IEnumerable<string> ResolvePaths()

--- a/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
@@ -64,7 +64,17 @@ namespace Microsoft.PowerShell.Commands
             ValueFromPipelineByPropertyName = true,
             ParameterSetName = "LiteralFile")]
         [Alias("PSPath")]
-        public string[] LiteralPath { get; set; }
+        public string[] LiteralPath {
+            get { return InternalPaths; }
+            set
+            {
+                AvoidWildcardExpansion = true;
+                InternalPaths = value;
+            }
+        }
+
+        bool AvoidWildcardExpansion;
+        string[] InternalPaths { get; set; }
 
         [Parameter]
         public SwitchParameter NotMatch { get; set; }
@@ -74,7 +84,10 @@ namespace Microsoft.PowerShell.Commands
             Mandatory = true,
             ValueFromPipelineByPropertyName = true,
             ParameterSetName = "File")]
-        public string[] Path { get; set; }
+        public string[] Path {
+            get { return InternalPaths; }
+            set { InternalPaths = value; }
+        }
 
         [Parameter(
             Mandatory = true,
@@ -126,7 +139,7 @@ namespace Microsoft.PowerShell.Commands
 
         private IEnumerable<string> ResolvePaths()
         {
-            foreach (string path in Path)
+            foreach (string path in InternalPaths)
             {
                 CmdletProvider provider;
                 ProviderRuntime runtime = CreateProviderRuntime();
@@ -142,7 +155,7 @@ namespace Microsoft.PowerShell.Commands
             var runtime = new ProviderRuntime(this);
             runtime.Include = Include == null ? new Collection<string>() : new Collection<string>(Include.ToList());
             runtime.Exclude = Exclude == null ? new Collection<string>() : new Collection<string>(Exclude.ToList());
-            //runtime.AvoidGlobbing = AvoidWildcardExpansion;
+            runtime.AvoidGlobbing = AvoidWildcardExpansion;
             return runtime;
         }
 
@@ -264,7 +277,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-            if (Path != null && Quiet.IsPresent && !_matchedAtLeastOneItem)
+            if (InternalPaths != null && Quiet.IsPresent && !_matchedAtLeastOneItem)
             {
                 WriteObject(false);
             }

--- a/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
@@ -196,15 +196,14 @@ namespace Microsoft.PowerShell.Commands
                     if (matchInfo != null)
                     {
                         WriteMatch(matchInfo);
+                        if (Quiet.IsPresent || List.IsPresent)
+                        {
+                            return;
+                        }
                         break;
                     }
                 }
                 _lineNumber++;
-
-                if (!ContinueProcessing())
-                {
-                    return;
-                }
             }
         }
 

--- a/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.PowerShell.Commands
+{
+    [CmdletAttribute(VerbsCommon.Select, "String", DefaultParameterSetName = "File" /*HelpUri="http://go.microsoft.com/fwlink/?LinkID=113388"*/)] 
+    [OutputType(typeof(MatchInfo), typeof(bool))]
+    public sealed class SelectStringCommand : PSCmdlet
+    {
+        [Parameter]
+        public SwitchParameter AllMatches { get; set; }
+
+        [Parameter]
+        public SwitchParameter CaseSensitive { get; set; }
+
+        [Parameter]
+        [ValidateCount(1, 2)]
+        [ValidateNotNullOrEmpty]
+        [ValidateRange(0, 2147483647)]
+        public int[] Context { get; set; }
+
+        [Parameter]
+        [ValidateSet(
+            "unicode",
+            "utf7",
+            "utf8",
+            "utf32",
+            "ascii",
+            "bigendianunicode",
+            "default",
+            "oem")]
+        [ValidateNotNullOrEmpty]
+        public string Encoding { get; set; }
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string[] Exclude { get; set; }
+
+        [ParameterAttribute]
+        [ValidateNotNullOrEmpty]
+        public string[] Include { get; set; }
+
+        [Parameter(
+            ValueFromPipeline = true,
+            Mandatory = true,
+            ParameterSetName = "Object")]
+        [AllowNull]
+        [AllowEmptyString]
+        public PSObject InputObject { get; set; }
+
+        [Parameter]
+        public SwitchParameter List { get; set; }
+
+        [ParameterAttribute(
+            Mandatory = true,
+            ValueFromPipelineByPropertyName = true,
+            ParameterSetName = "LiteralFile")]
+        [Alias("PSPath")]
+        public string[] LiteralPath { get; set; }
+
+        [Parameter]
+        public SwitchParameter NotMatch { get; set; }
+
+        [Parameter(
+            Position = 1,
+            Mandatory = true,
+            ValueFromPipelineByPropertyName = true,
+            ParameterSetName = "File")]
+        public string[] Path { get; set; }
+
+        [Parameter(
+            Mandatory = true,
+            Position = 0)]
+        public string[] Pattern { get; set; }
+
+        [Parameter]
+        public SwitchParameter Quiet { get; set; }
+
+        [Parameter]
+        public SwitchParameter SimpleMatch { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            foreach (string path in Path)
+            {
+                MatchInFile(path);
+            }
+        }
+
+        private void MatchInFile(string path)
+        {
+            int lineNumber = 1;
+            foreach (string line in File.ReadLines(path))
+            {
+                foreach (string pattern in Pattern)
+                {
+                    Match match = Regex.Match(line, pattern);
+                    if (match.Success)
+                    {
+                        var matchInfo = new MatchInfo(path, pattern, match, line, lineNumber);
+                        WriteObject(matchInfo);
+                        break;
+                    }
+                }
+                lineNumber++;
+            }
+        }
+    }
+}

--- a/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
@@ -218,10 +218,23 @@ namespace Microsoft.PowerShell.Commands
 
         private MatchInfo FindRegexMatch(string line, string pattern, string path)
         {
-            Match match = Regex.Match(line, pattern, GetRegexOptions());
-            if (match.Success)
+            var matches = new List<Match>();
+            if (AllMatches.IsPresent)
             {
-                return new MatchInfo(path, pattern, match, line, _lineNumber, !CaseSensitive);
+                matches = Regex.Matches(line, pattern, GetRegexOptions()).OfType<Match>().ToList();
+            }
+            else
+            {
+                Match match = Regex.Match(line, pattern, GetRegexOptions());
+                if (match.Success)
+                {
+                    matches.Add(match);
+                }
+            }
+
+            if (matches.Count > 0)
+            {
+                return new MatchInfo(path, pattern, matches, line, _lineNumber, !CaseSensitive);
             }
             return null;
         }

--- a/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/SelectStringCommand.cs
@@ -145,16 +145,25 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (string pattern in Pattern)
                 {
-                    Match match = Regex.Match(line, pattern, RegexOptions.IgnoreCase);
+                    Match match = Regex.Match(line, pattern, GetRegexOptions());
                     if (match.Success)
                     {
-                        var matchInfo = new MatchInfo(path, pattern, match, line, _lineNumber);
+                        var matchInfo = new MatchInfo(path, pattern, match, line, _lineNumber, !CaseSensitive);
                         WriteObject(matchInfo);
                         break;
                     }
                 }
                 _lineNumber++;
             }
+        }
+
+        private RegexOptions GetRegexOptions()
+        {
+            if (CaseSensitive)
+            {
+                return RegexOptions.None;
+            }
+            return RegexOptions.IgnoreCase;
         }
     }
 }

--- a/Source/ReferenceTests/Commands/AddContentTests.cs
+++ b/Source/ReferenceTests/Commands/AddContentTests.cs
@@ -55,6 +55,19 @@ namespace ReferenceTests.Commands
         }
 
         [Test]
+        public void MultipleItemsTakenFromPipeline()
+        {
+            string fileName = GenerateTempFile("test" + Environment.NewLine);
+
+            string result = ReferenceHost.Execute(new string[] {
+                "'a','b','c' | Add-Content " + fileName,
+                "Get-Content " + fileName
+            });
+
+            Assert.AreEqual(NewlineJoin("test", "a", "b", "c"), result);
+        }
+
+        [Test]
         public void TwoFiles()
         {
             string fileName1 = GenerateTempFile("1" + Environment.NewLine);

--- a/Source/ReferenceTests/Commands/GetCommandTests.cs
+++ b/Source/ReferenceTests/Commands/GetCommandTests.cs
@@ -76,6 +76,7 @@ namespace ReferenceTests.Commands
         [TestCase("Stop-Service", new[] { typeof(ServiceController) })]
         [TestCase("Suspend-Service", new[] { typeof(ServiceController) })]
         [TestCase("Test-Path", new[] { typeof(bool) })]
+        [TestCase("Select-String", new[] { typeof(MatchInfo), typeof(bool) })]
         public void OutputTypesForCommand(string commandName, Type[] expectedOutputTypes)
         {
             string command = string.Format("(Get-Command {0}).OutputType", commandName);

--- a/Source/ReferenceTests/Commands/SelectStringTests.cs
+++ b/Source/ReferenceTests/Commands/SelectStringTests.cs
@@ -252,5 +252,22 @@ namespace ReferenceTests.Commands
             Assert.AreEqual("-HELLO-", firstMatch.ToString());
             Assert.AreEqual("hello", secondMatch.ToString());
         }
+
+        [Test]
+        public void CaseSensitiveMatch()
+        {
+            MatchInfo match = RawExecuteSingleMatch("\"Hello\",\"HELLO\" | select-string -pattern \"HELLO\" -casesensitive");
+            Match regexMatch = match.Matches.Single();
+
+            Assert.AreEqual("InputStream", match.Filename);
+            Assert.AreEqual("InputStream", match.Path);
+            Assert.AreEqual("HELLO", match.Line);
+            Assert.AreEqual(2, match.LineNumber);
+            Assert.IsFalse(match.IgnoreCase);
+            Assert.AreEqual("HELLO", match.Pattern);
+            Assert.AreEqual(0, regexMatch.Index);
+            Assert.AreEqual(5, regexMatch.Length);
+            Assert.AreEqual("HELLO", regexMatch.Value);
+        }
     }
 }

--- a/Source/ReferenceTests/Commands/SelectStringTests.cs
+++ b/Source/ReferenceTests/Commands/SelectStringTests.cs
@@ -175,7 +175,7 @@ namespace ReferenceTests.Commands
             Assert.AreEqual("-HELLO-", match.ToString());
         }
 
-        [Test, Explicit("Array values passed one at a time to select-string and not as an array")]
+        [Test]
         public void MatchUsingStringArrayFromPipeline()
         {
             MatchInfo match = ReferenceHost.RawExecute("\"-12345-\",\"-HELLO-\" | select-string -pattern \"HELLO\"")
@@ -226,6 +226,35 @@ namespace ReferenceTests.Commands
             string result = ReferenceHost.Execute(command);
 
             Assert.AreEqual(string.Empty, result);
+        }
+
+        [Test]
+        public void MultipleMatchesUsingStringArrayFromPipeline()
+        {
+            MatchInfo[] matches = ReferenceHost.RawExecute("\"-12345-\",\"-HELLO-\",\"hello\" | select-string -pattern \"HELLO\"")
+                 .Select(psObject => (MatchInfo)psObject.ImmediateBaseObject)
+                 .ToArray();
+            MatchInfo firstMatch = matches[0];
+            MatchInfo secondMatch = matches[1];
+
+            Assert.AreEqual("InputStream", firstMatch.Filename);
+            Assert.AreEqual("InputStream", secondMatch.Filename);
+            Assert.AreEqual("InputStream", firstMatch.Path);
+            Assert.AreEqual("InputStream", secondMatch.Path);
+            Assert.AreEqual("-HELLO-", firstMatch.Line);
+            Assert.AreEqual("hello", secondMatch.Line);
+            Assert.AreEqual(2, firstMatch.LineNumber);
+            Assert.AreEqual(3, secondMatch.LineNumber);
+            Assert.AreEqual("HELLO", firstMatch.Pattern);
+            Assert.AreEqual("HELLO", secondMatch.Pattern);
+            Assert.AreEqual(1, firstMatch.Matches.Single().Index);
+            Assert.AreEqual(5, firstMatch.Matches.Single().Length);
+            Assert.AreEqual(0, secondMatch.Matches.Single().Index);
+            Assert.AreEqual(5, secondMatch.Matches.Single().Length);
+            Assert.AreEqual("HELLO", firstMatch.Matches.Single().Value);
+            Assert.AreEqual("hello", secondMatch.Matches.Single().Value);
+            Assert.AreEqual("-HELLO-", firstMatch.ToString());
+            Assert.AreEqual("hello", secondMatch.ToString());
         }
     }
 }

--- a/Source/ReferenceTests/Commands/SelectStringTests.cs
+++ b/Source/ReferenceTests/Commands/SelectStringTests.cs
@@ -552,5 +552,34 @@ namespace ReferenceTests.Commands
             Assert.AreEqual("a", matches[0].Line);
             Assert.AreEqual("aa", matches[1].Line);
         }
+
+        [Test]
+        public void AllMatchesFromPipeline()
+        {
+            MatchInfo[] matches = RawExecuteMultipleMatches("'aa','aaa' | select-string -pattern a -AllMatches");
+            MatchInfo firstMatch = matches[0];
+            MatchInfo secondMatch = matches[1];
+
+            Assert.AreEqual(2, matches.Length);
+            Assert.AreEqual("aa", firstMatch.Line);
+            Assert.AreEqual(2, firstMatch.Matches.Length);
+            Assert.AreEqual(0, firstMatch.Matches[0].Index);
+            Assert.AreEqual("a", firstMatch.Matches[0].Value);
+            Assert.AreEqual(1, firstMatch.Matches[0].Length);
+            Assert.AreEqual(1, firstMatch.Matches[1].Index);
+            Assert.AreEqual("a", firstMatch.Matches[1].Value);
+            Assert.AreEqual(1, firstMatch.Matches[1].Length);
+            Assert.AreEqual("aaa", secondMatch.Line);
+            Assert.AreEqual(3, secondMatch.Matches.Length);
+            Assert.AreEqual(0, secondMatch.Matches[0].Index);
+            Assert.AreEqual("a", secondMatch.Matches[0].Value);
+            Assert.AreEqual(1, secondMatch.Matches[0].Length);
+            Assert.AreEqual(1, secondMatch.Matches[1].Index);
+            Assert.AreEqual("a", secondMatch.Matches[1].Value);
+            Assert.AreEqual(1, secondMatch.Matches[1].Length);
+            Assert.AreEqual(2, secondMatch.Matches[2].Index);
+            Assert.AreEqual("a", secondMatch.Matches[2].Value);
+            Assert.AreEqual(1, secondMatch.Matches[2].Length);
+        }
     }
 }

--- a/Source/ReferenceTests/Commands/SelectStringTests.cs
+++ b/Source/ReferenceTests/Commands/SelectStringTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Microsoft.PowerShell.Commands;
+using System.Text.RegularExpressions;
+
+namespace ReferenceTests.Commands
+{
+    [TestFixture]
+    public class SelectStringTests : ReferenceTestBase
+    {
+        [Test]
+        public void FileWithSingleLineAndPatternMatchesTextInLine()
+        {
+            string fileName = CreateFile("first line", ".txt");
+
+            string command = string.Format("Select-String -Path '{0}' -Pattern 'first'", fileName);
+            MatchInfo match = ReferenceHost.RawExecute(command)
+                .Select(psObject => (MatchInfo)psObject.ImmediateBaseObject)
+                .Single();
+            Match regexMatch = match.Matches.FirstOrDefault();
+
+            Assert.IsNull(match.Context);
+            Assert.AreEqual(1, match.LineNumber);
+            Assert.AreEqual("first line", match.Line);
+            Assert.AreEqual(Path.GetFileName(fileName), match.Filename);
+            Assert.IsTrue(match.IgnoreCase);
+            Assert.AreEqual("first", match.Pattern);
+            Assert.AreEqual(fileName, match.Path);
+            Assert.AreEqual(1, match.Matches.Length);
+            Assert.IsTrue(regexMatch.Success);
+            Assert.AreEqual(0, regexMatch.Index);
+            Assert.AreEqual(5, regexMatch.Length);
+            Assert.AreEqual("first", regexMatch.Value);
+        }
+
+        [Test]
+        public void MatchInfoToStringShowsFileNameLineNumberAndLineText()
+        {
+            string fileName = CreateFile("first line", ".txt");
+
+            string command = string.Format("(sls -Path '{0}' -Pattern 'first').ToString()", fileName);
+            string result = ReferenceHost.Execute(command);
+
+            Assert.AreEqual(fileName + ":1:first line" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void NoMatchesInFile()
+        {
+            string fileName = CreateFile("first line", ".txt");
+
+            string command = string.Format("(Select-string -Path '{0}' -Pattern 'notfound') -eq $null", fileName);
+            string result = ReferenceHost.Execute(command);
+
+            Assert.AreEqual("True" + Environment.NewLine, result);
+        }
+
+        [Test]
+        [Ignore("Get a ParameterBindingException : Parameter 'Pattern' has already been bound!")]
+        public void SimpleMatchWhenPathFirstParameterAndPatternSecondAsNamedParameter()
+        {
+            string fileName = CreateFile("first line", ".txt");
+
+            string command = string.Format("(Select-String '{0}' -Pattern 'first').ToString()", fileName);
+            string result = ReferenceHost.Execute(command);
+
+            Assert.AreEqual(fileName + ":1:first line" + Environment.NewLine, result);
+        }
+
+        [Test]
+        public void FileWithPatternMatchesTextOnTwoLines()
+        {
+            string fileName = CreateFile(NewlineJoin("first line", "second line"), ".txt");
+
+            string command = string.Format("Select-String 'line' '{0}'", fileName);
+            MatchInfo[] matches = ReferenceHost.RawExecute(command)
+                .Select(psObject => (MatchInfo)psObject.ImmediateBaseObject)
+                .ToArray();
+            MatchInfo firstMatch = matches[0];
+            MatchInfo secondMatch = matches[1];
+
+            Assert.AreEqual(2, matches.Length);
+            Assert.AreEqual(1, firstMatch.LineNumber);
+            Assert.AreEqual(2, secondMatch.LineNumber);
+            Assert.AreEqual("first line", firstMatch.Line);
+            Assert.AreEqual("second line", secondMatch.Line);
+            Assert.AreEqual(Path.GetFileName(fileName), secondMatch.Filename);
+            Assert.AreEqual("line", secondMatch.Pattern);
+            Assert.AreEqual(fileName, secondMatch.Path);
+            Assert.AreEqual(6, firstMatch.Matches.Single().Index);
+            Assert.AreEqual(4, firstMatch.Matches.Single().Length);
+            Assert.AreEqual(7, secondMatch.Matches.Single().Index);
+            Assert.AreEqual(4, secondMatch.Matches.Single().Length);
+        }
+
+        [Test]
+        public void TwoPatternsPassedAsParameterFirstPatternMatchesFirstLineSecondPatternMatchesSecondLine()
+        {
+            string fileName = CreateFile(NewlineJoin("first line", "second line"), ".txt");
+
+            string command = string.Format("Select-String -Path '{0}' -Pattern 'first','line'", fileName);
+            MatchInfo[] matches = ReferenceHost.RawExecute(command)
+                .Select(psObject => (MatchInfo)psObject.ImmediateBaseObject)
+                .ToArray();
+            MatchInfo firstMatch = matches[0];
+            MatchInfo secondMatch = matches[1];
+
+            Assert.AreEqual(2, matches.Length);
+            Assert.AreEqual(1, firstMatch.LineNumber);
+            Assert.AreEqual(2, secondMatch.LineNumber);
+            Assert.AreEqual("first line", firstMatch.Line);
+            Assert.AreEqual("second line", secondMatch.Line);
+            Assert.AreEqual("first", firstMatch.Pattern);
+            Assert.AreEqual("line", secondMatch.Pattern);
+            Assert.AreEqual(0, firstMatch.Matches.Single().Index);
+            Assert.AreEqual(5, firstMatch.Matches.Single().Length);
+            Assert.AreEqual(7, secondMatch.Matches.Single().Index);
+            Assert.AreEqual(4, secondMatch.Matches.Single().Length);
+        }
+
+        [Test]
+        public void TwoPatternsPassedSecondPattermMatchesFirstLine()
+        {
+            string fileName = CreateFile("first line", ".txt");
+
+            string command = string.Format("Select-String -Path '{0}' -Pattern 'nomatch','line'", fileName);
+            MatchInfo match = ReferenceHost.RawExecute(command)
+                 .Select(psObject => (MatchInfo)psObject.ImmediateBaseObject)
+                 .Single();
+            Match regexMatch = match.Matches.Single();
+
+            Assert.AreEqual(1, match.LineNumber);
+            Assert.AreEqual("first line", match.Line);
+            Assert.AreEqual("line", match.Pattern);
+            Assert.IsTrue(regexMatch.Success);
+            Assert.AreEqual(6, regexMatch.Index);
+            Assert.AreEqual(4, regexMatch.Length);
+        }
+
+        [Test]
+        public void TwoFilesPassedMatchInBothFiles()
+        {
+            string fileName1 = CreateFile("first line", ".txt");
+            string fileName2 = CreateFile("first line", ".txt");
+
+            string command = string.Format("Select-String -Path '{0}','{1}' -Pattern 'first'", fileName1, fileName2);
+            MatchInfo[] matches = ReferenceHost.RawExecute(command)
+                .Select(psObject => (MatchInfo)psObject.ImmediateBaseObject)
+                .ToArray();
+            MatchInfo firstMatch = matches[0];
+            MatchInfo secondMatch = matches[1];
+
+            Assert.AreEqual(fileName1, firstMatch.Path);
+            Assert.AreEqual(fileName2, secondMatch.Path);
+        }
+    }
+}

--- a/Source/ReferenceTests/Commands/SelectStringTests.cs
+++ b/Source/ReferenceTests/Commands/SelectStringTests.cs
@@ -59,7 +59,6 @@ namespace ReferenceTests.Commands
         }
 
         [Test]
-        [Ignore("Get a ParameterBindingException : Parameter 'Pattern' has already been bound!")]
         public void SimpleMatchWhenPathFirstParameterAndPatternSecondAsNamedParameter()
         {
             string fileName = CreateFile("first line", ".txt");

--- a/Source/ReferenceTests/Commands/SelectStringTests.cs
+++ b/Source/ReferenceTests/Commands/SelectStringTests.cs
@@ -71,7 +71,7 @@ namespace ReferenceTests.Commands
         }
 
         [Test]
-        public void SimpleMatchWhenPathFirstParameterAndPatternSecondAsNamedParameter()
+        public void MatchWhenPathFirstParameterAndPatternSecondAsNamedParameter()
         {
             string fileName = CreateFile("first line", ".txt");
 
@@ -268,6 +268,57 @@ namespace ReferenceTests.Commands
             Assert.AreEqual(0, regexMatch.Index);
             Assert.AreEqual(5, regexMatch.Length);
             Assert.AreEqual("HELLO", regexMatch.Value);
+        }
+
+        [Test]
+        public void RegularExpressionPattern()
+        {
+            MatchInfo[] matches = RawExecuteMultipleMatches("\"app\",\"app..\",\"apple\" | select-string -pattern \"app..\"");
+
+            Assert.AreEqual(2, matches.Length);
+            Assert.AreEqual("app..", matches[0].Line);
+            Assert.AreEqual("apple", matches[1].Line);
+        }
+
+        [Test]
+        public void SimpleMatch()
+        {
+            MatchInfo match = RawExecuteSingleMatch("\"app\",\"app..\",\"apple\" | select-string -SimpleMatch \"app..\"");
+
+            Assert.AreEqual("InputStream", match.Filename);
+            Assert.AreEqual("InputStream", match.Path);
+            Assert.AreEqual("app..", match.Line);
+            Assert.AreEqual(2, match.LineNumber);
+            Assert.IsTrue(match.IgnoreCase);
+            Assert.AreEqual("app..", match.Pattern);
+            Assert.AreEqual(0, match.Matches.Length);
+            Assert.AreEqual("app..", match.ToString());
+        }
+
+        [Test]
+        public void SimpleMatchInDifferentPartsOfText()
+        {
+            MatchInfo[] matches = RawExecuteMultipleMatches("\"app.a\",\"aapp..\",\"dapp.\",\"appp\" | select-string -SimpleMatch \"app.\"");
+
+            Assert.AreEqual(3, matches.Length);
+        }
+
+        [Test]
+        public void SimpleMatchIsCaseInsensitiveByDefault()
+        {
+            MatchInfo[] matches = RawExecuteMultipleMatches("\"App.\",\"aPp.\",\"APP.\",\"appp\" | select-string -SimpleMatch \"app.\"");
+
+            Assert.AreEqual(3, matches.Length);
+        }
+
+        [Test]
+        public void CaseSensitiveSimpleMatch()
+        {
+            MatchInfo[] matches = RawExecuteMultipleMatches("\"App.a\",\"app.\",\"dApp.\",\"appp\" | select-string -CaseSensitive -SimpleMatch \"app.\"");
+
+            Assert.AreEqual(1, matches.Length);
+            Assert.AreEqual("app.", matches[0].Line);
+            Assert.IsFalse(matches[0].IgnoreCase);
         }
     }
 }

--- a/Source/ReferenceTests/Commands/SelectStringTests.cs
+++ b/Source/ReferenceTests/Commands/SelectStringTests.cs
@@ -475,5 +475,38 @@ namespace ReferenceTests.Commands
             Assert.AreEqual("bar2.txt", matches[1].Filename);
             Assert.AreEqual("baa", matches[1].Line);
         }
+
+        [Test]
+        public void LiteralPaths()
+        {
+            string fileName = CreateTextFile("a", "File[1].txt");
+            string directory = Path.GetDirectoryName(fileName);
+            CreateTextFile("ba", "File[2].txt");
+            AddCleanupDir(directory);
+
+            MatchInfo[] matches = RawExecuteMultipleMatches(new[] {
+                string.Format("cd '{0}'", directory),
+                "select-string -Pattern a -LiteralPath File[1].txt,File[2].txt"
+            });
+
+            Assert.AreEqual(2, matches.Length);
+            Assert.AreEqual("File[1].txt", matches[0].Filename);
+            Assert.AreEqual("File[2].txt", matches[1].Filename);
+            Assert.AreEqual("a", matches[0].Line);
+            Assert.AreEqual("ba", matches[1].Line);
+        }
+
+        [Test]
+        [TestCase("a,b", "select-string -quiet -pattern \"a\"", "True")]
+        [TestCase("b,b", "select-string -quiet -simplematch \"B\"", "True")]
+        public void QuietMatchesInLiteralFilePath(string fileContent, string command, string expectedResult)
+        {
+            string[] lines = fileContent.Split(',');
+            string fileName = CreateFile(NewlineJoin(lines), ".txt");
+            string fullCommand = string.Format("{0} -LiteralPath '{1}'", command, fileName);
+            string result = ReferenceHost.Execute(fullCommand);
+
+            Assert.AreEqual(expectedResult + Environment.NewLine, result);
+        }
     }
 }

--- a/Source/ReferenceTests/Commands/SetContentTests.cs
+++ b/Source/ReferenceTests/Commands/SetContentTests.cs
@@ -73,7 +73,7 @@ namespace ReferenceTests.Commands
             Assert.AreEqual("abc" + Environment.NewLine, input2Text);
         }
 
-        [Test, Explicit("Array values passed one at a time to Set-Content and not as an array")]
+        [Test]
         public void ValueArrayTakenFromPipeline()
         {
             string fileName = GenerateTempFile("test");

--- a/Source/ReferenceTests/Language/CmdletParameterTests.cs
+++ b/Source/ReferenceTests/Language/CmdletParameterTests.cs
@@ -391,6 +391,22 @@ namespace ReferenceTests.Language
             Assert.IsNotNull(verboseParameter);
             Assert.IsTrue(verboseParameter.Aliases.Contains("vb"));
         }
+
+        [Test]
+        [TestCase("'B' -First 'A' -Third 'C' -Fourth 'D'")]
+        [TestCase("'B' 'C' -First 'A' -Fourth 'D'")]
+        [TestCase("'B' 'C' 'D' -First 'A'")]
+        [TestCase("'A' 'C' 'D' -Second 'B'")]
+        [TestCase("'A' 'D' -Second 'B' -Third 'C'")]
+        public void CmdletParameterBoundInPositionTwoWhenFirstPositionalParameterBoundByName(string parameters)
+        {
+            string cmdletName = CmdletName(typeof(TestParametersByPositionWhenOneBoundByName));
+            string cmd = cmdletName + " " + parameters;
+
+            string result = ReferenceHost.Execute(cmd);
+
+            Assert.AreEqual("'A', 'B', 'C', 'D'" + Environment.NewLine, result);
+        }
     }
 }
 

--- a/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
+++ b/Source/ReferenceTests/Providers/ContentCmdletProviderTests.cs
@@ -45,6 +45,20 @@ namespace ReferenceTests.Providers
         }
 
         [Test]
+        public void SetContentFromPipeline()
+        {
+            ReferenceHost.Execute("'a','b','c' | Set-Content -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual(
+                "ClearContent foo",
+                "GetContentWriter foo",
+                "ContentWriter.Write(a)",
+                "ContentWriter.Write(b)",
+                "ContentWriter.Write(c)",
+                "ContentWriter.Close()");
+        }
+
+        [Test]
         public void GetContent()
         {
             ReferenceHost.Execute("Get-Content -path TestContentCmdletProvider::foo");
@@ -84,6 +98,20 @@ namespace ReferenceTests.Providers
                 "GetContentWriter foo",
                 "ContentWriter.Seek(0, End)",
                 "ContentWriter.Write(1,2)",
+                "ContentWriter.Close()");
+        }
+
+        [Test]
+        public void AddContentFromPipeline()
+        {
+            ReferenceHost.Execute("'a','b','c' | Add-Content -path TestContentCmdletProvider::foo");
+
+            AssertMessagesAreEqual(
+                "GetContentWriter foo",
+                "ContentWriter.Seek(0, End)",
+                "ContentWriter.Write(a)",
+                "ContentWriter.Write(b)",
+                "ContentWriter.Write(c)",
                 "ContentWriter.Close()");
         }
     }

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Commands\GetContentTests.cs" />
     <Compile Include="Commands\ImportModuleTests.cs" />
     <Compile Include="Commands\RemoveModuleTests.cs" />
+    <Compile Include="Commands\SelectStringTests.cs" />
     <Compile Include="Commands\SetContentTests.cs" />
     <Compile Include="Commands\SplitPathTests.cs" />
     <Compile Include="Commands\WhereObjectTests.cs" />

--- a/Source/System.Management/Automation/Runspaces/InitialSessionState.cs
+++ b/Source/System.Management/Automation/Runspaces/InitialSessionState.cs
@@ -389,6 +389,7 @@ namespace System.Management.Automation.Runspaces
             initialSessionState.Commands.Add(new SessionStateAliasEntry("set", "Set-Variable", "", ScopedItemOptions.AllScope));
             initialSessionState.Commands.Add(new SessionStateAliasEntry("si", "Set-Item", "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope));
             initialSessionState.Commands.Add(new SessionStateAliasEntry("sl", "Set-Location", "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope));
+            initialSessionState.Commands.Add(new SessionStateAliasEntry("sls", "Select-String", "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope));
             initialSessionState.Commands.Add(new SessionStateAliasEntry("swmi", "Set-WMIInstance", "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope));
             initialSessionState.Commands.Add(new SessionStateAliasEntry("sleep", "Start-Sleep", "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope));
             initialSessionState.Commands.Add(new SessionStateAliasEntry("sort", "Sort-Object", "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope));

--- a/Source/System.Management/Pash/Implementation/CmdletParameterBinder.cs
+++ b/Source/System.Management/Pash/Implementation/CmdletParameterBinder.cs
@@ -284,16 +284,24 @@ namespace System.Management.Automation
             int i = 0;
             foreach (var curParam in parametersWithoutName)
             {
-                if (i < positionals.Count)
+                bool bound = false;
+                while (!bound)
                 {
-                    var affectedParam = positionals[i];
-                    BindParameter(affectedParam, curParam.Value, true);
-                    i++;
-                }
-                else
-                {
-                    var msg = String.Format("Positional parameter not found for provided argument '{0}'", curParam.Value);
-                    throw new ParameterBindingException(msg, "PositionalParameterNotFound");
+                    if (i < positionals.Count)
+                    {
+                        var affectedParam = positionals[i];
+                        if (!_boundParameters.Contains(affectedParam.MemberInfo))
+                        {
+                            BindParameter(affectedParam, curParam.Value, true);
+                            bound = true;
+                        }
+                        i++;
+                    }
+                    else
+                    {
+                        var msg = String.Format("Positional parameter not found for provided argument '{0}'", curParam.Value);
+                        throw new ParameterBindingException(msg, "PositionalParameterNotFound");
+                    }
                 }
             }
         }

--- a/Source/System.Management/Pash/Implementation/Commands/EncodingMapping.cs
+++ b/Source/System.Management/Pash/Implementation/Commands/EncodingMapping.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace System.Management.Pash.Implementation
+{
+    static internal class EncodingMapping
+    {
+        public static Encoding GetEncoding(string encoding)
+        {
+            if (string.IsNullOrEmpty(encoding))
+            {
+                return Encoding.UTF8;
+            }
+
+            switch (encoding.ToUpperInvariant())
+            {
+                case "UNICODE":
+                    return Encoding.Unicode;
+                case "UTF7":
+                    return Encoding.UTF7;
+                case "UTF8":
+                    return Encoding.UTF8;
+                case "UTF32":
+                    return Encoding.UTF32;
+                case "ASCII":
+                    return Encoding.ASCII;
+                case "BIGENDIANUNICODE":
+                    return Encoding.BigEndianUnicode;
+                case "DEFAULT":
+                    return Encoding.Default;
+                case "OEM":
+                    return Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+                default:
+                    throw new NotImplementedException(encoding);
+            }
+        }
+    }
+}

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -429,6 +429,7 @@
     </Compile>
     <Compile Include="Microsoft.PowerShell\PSCorePSSnapIn.cs" />
     <Compile Include="Pash\BitwiseOperation.cs" />
+    <Compile Include="Pash\Implementation\Commands\EncodingMapping.cs" />
     <Compile Include="Pash\Implementation\Commands\FileContentReader.cs" />
     <Compile Include="Pash\Implementation\Commands\FileContentWriter.cs" />
     <Compile Include="Pash\Implementation\Commands\SessionStateContentReader.cs" />

--- a/Source/TestPSSnapIn/TestCommands.cs
+++ b/Source/TestPSSnapIn/TestCommands.cs
@@ -634,4 +634,33 @@ namespace TestPSSnapIn
             }
         }
     }
+
+    [Cmdlet(VerbsDiagnostic.Test, "ParametersByPositionWhenOneBoundByName")]
+    public class TestParametersByPositionWhenOneBoundByName : PSCmdlet
+    {
+        [Parameter(
+            Mandatory = true,
+            Position = 0)]
+        public string First { get; set; }
+
+        [Parameter(
+            Position = 1,
+            Mandatory = true)]
+        public string Second { get; set; }
+
+        [Parameter(
+            Position = 2,
+            Mandatory = true)]
+        public string Third { get; set; }
+
+        [Parameter(
+            Position = 3,
+            Mandatory = true)]
+        public string Fourth { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            WriteObject(string.Format("'{0}', '{1}', '{2}', '{3}'", First, Second, Third, Fourth));
+        }
+    }
 }


### PR DESCRIPTION
Implemented Select-String apart from the -Context parameter.

Also fixed a parameter binding problem where named and positional parameters were being used. Example:

    Select-String C:\Scripts\Test.txt -Pattern "CTP"

Pattern is a positional parameter with position 0 whilst Path has position 1. PowerShell will bind the filename to the Path parameter.

Also added support for multiple pipeline items in Set-Content and Add-Content.

