### PR TITLE
Grammar: expandable_here_string_literal and verbatim_here_string_literal

### DIFF
--- a/Source/ReferenceTests/Language/HereStringTests.cs
+++ b/Source/ReferenceTests/Language/HereStringTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using NUnit.Framework;
+using System.Management.Automation;
+
+namespace ReferenceTests.Language
+{
+    [TestFixture]
+    public class HereStringTests : ReferenceTestBase
+    {
+        [Test] // @"...'@ throws
+        public void MixExpandableVerbatimSytnax()
+        {
+            Assert.Catch<ParseException>(delegate
+            {
+                ReferenceHost.Execute("@\"\r\nfoo bar\r\n'@");
+            });
+        }
+
+        [TestCase("@\"\r\nfoo bar\r\n\"@", "foo bar")]
+        [TestCase("@\"\r\nfoo\r\nbar\r\n\"@", "foo\r\nbar")]
+        [TestCase("@\"\r\n$foo\r\n\"@", "1")]
+        public void ExpandableHereString(string psStr, string expected)
+        {
+            var res = ReferenceHost.Execute("$foo = 1; " + psStr);
+            Assert.AreEqual(NewlineJoin(expected), res);
+        }
+
+        [TestCase("@'\r\nfoo bar\r\n'@", "foo bar")]
+        [TestCase("@'\r\nfoo\r\nbar\r\n'@", "foo\r\nbar")]
+        [TestCase("@\'\r\n$foo\r\n\'@", "$foo")]
+        public void VerbatimHereString(string psStr, string expected)
+        {
+            var res = ReferenceHost.Execute("$foo = 1; " + psStr);
+            Assert.AreEqual(NewlineJoin(expected), res);
+        }
+    }
+}

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Commands\WhereObjectTests.cs" />
     <Compile Include="Integration\RosettaCode.cs" />
     <Compile Include="Language\FileRedirectionTests.cs" />
+    <Compile Include="Language\HereStringTests.cs" />
     <Compile Include="Language\ObjectMemberTests.cs" />
     <Compile Include="Language\Operators\FormatOperatorTests_7_5.cs" />
     <Compile Include="Language\Operators\BitwiseTests.cs" />

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -1872,9 +1872,19 @@ namespace Pash.ParserIntrinsics
                 return BuildExpandableStringLiteralAst(parseTreeNode.ChildNodes.Single());
             }
 
+            if (parseTreeNode.ChildNodes[0].Term == this._grammar.expandable_here_string_literal)
+            {
+                return BuildExpandableHereStringLiteralAst(parseTreeNode.ChildNodes.Single());
+            }
+
             if (parseTreeNode.ChildNodes[0].Term == this._grammar.verbatim_string_literal)
             {
                 return BuildVerbatimStringLiteralAst(parseTreeNode.ChildNodes.Single());
+            }
+
+            if (parseTreeNode.ChildNodes[0].Term == this._grammar.verbatim_here_string_literal)
+            {
+                return BuildVerbatimHereStringLiteralAst(parseTreeNode.ChildNodes.Single());
             }
 
             throw new NotImplementedException(parseTreeNode.ChildNodes[0].Term.Name);
@@ -1895,6 +1905,20 @@ namespace Pash.ParserIntrinsics
             return new StringConstantExpressionAst(new ScriptExtent(parseTreeNode), value, StringConstantType.DoubleQuoted);
         }
 
+        ExpressionAst BuildExpandableHereStringLiteralAst(ParseTreeNode parseTreeNode)
+        {
+            var matches = Regex.Match(parseTreeNode.FindTokenAndGetText(), this._grammar.expandable_here_string_literal.Pattern, RegexOptions.IgnoreCase);
+            string value = matches.Groups[this._grammar.expandable_here_string_characters.Name].Value
+                ;
+
+            var ast = new ExpandableStringExpressionAst(new ScriptExtent(parseTreeNode), value, StringConstantType.DoubleQuoted);
+            if (ast.NestedExpressions.Any())
+            {
+                return ast;
+            }
+            return new StringConstantExpressionAst(new ScriptExtent(parseTreeNode), value, StringConstantType.DoubleQuoted);
+        }
+
         StringConstantExpressionAst BuildVerbatimStringLiteralAst(ParseTreeNode parseTreeNode)
         {
             VerifyTerm(parseTreeNode, this._grammar.verbatim_string_literal);
@@ -1903,6 +1927,15 @@ namespace Pash.ParserIntrinsics
             string value = matches.Groups[this._grammar.verbatim_string_characters.Name].Value;
 
             return new StringConstantExpressionAst(new ScriptExtent(parseTreeNode), value, StringConstantType.SingleQuoted);
+        }
+
+        ExpressionAst BuildVerbatimHereStringLiteralAst(ParseTreeNode parseTreeNode)
+        {
+            var matches = Regex.Match(parseTreeNode.FindTokenAndGetText(), this._grammar.verbatim_here_string_literal.Pattern, RegexOptions.IgnoreCase);
+            string value = matches.Groups[this._grammar.verbatim_here_string_characters.Name].Value
+                ;
+
+            return new StringConstantExpressionAst(new ScriptExtent(parseTreeNode), value, StringConstantType.DoubleQuoted);
         }
 
         ConstantExpressionAst BuildRealLiteralAst(ParseTreeNode parseTreeNode)

--- a/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.Terminals.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.Terminals.cs
@@ -544,21 +544,59 @@ namespace Pash.ParserIntrinsics
         ////        expandable_here_string_literal:
         ////            @   double_quote_character   whitespace_opt   new_line_character
         ////                    expandable_here_string_characters_opt   new_line_character   double_quote_character   @
+        public readonly RegexBasedTerminal expandable_here_string_literal = null; // Initialized by reflection.
+        const string expandable_here_string_literal_pattern = "(?<expandable_here_string_literal>" + "@" + double_quote_character_pattern + whitespace_pattern + "*?" + new_line_character_pattern + expandable_here_string_characters_pattern + "?" + new_line_character_pattern + double_quote_character_pattern + "@" + ")";
+
         ////        expandable_here_string_characters:
         ////            expandable_here_string_part
         ////            expandable_here_string_characters   expandable_here_string_part
+        public readonly RegexBasedTerminal expandable_here_string_characters = null; // Initialized by reflection.
+        const string expandable_here_string_characters_pattern = "(?<expandable_here_string_characters>" + expandable_here_string_part_pattern + "+" + ")";
+
         ////        expandable_here_string_part:
+        public readonly RegexBasedTerminal expandable_here_string_part = null; // Initialized by reflection.
+        const string expandable_here_string_part_pattern = "(?<expandable_here_string_part>" +
+            _expandable_here_string_part_plain_pattern + "|" +
+            _expandable_here_string_part_braced_variable_pattern + "|" +
+            _expandable_here_string_part_expansion_one_pattern + "|" +
+            _expandable_here_string_part_expansion_two_pattern + "|" +
+            _expandable_here_string_part_expansion_three_pattern + "|" +
+            _expandable_here_string_part_expansion_four_pattern + "|" +
+            _expandable_here_string_part_expansion_five_pattern +
+            ")";
+
         ////            Any Unicode character except
         ////                    $
         ////                    new_line_character
+        public readonly RegexBasedTerminal _expandable_here_string_part_plain = null; // Initialized by reflection
+        const string _expandable_here_string_part_plain_pattern = "(?<_expandable_here_string_part_plain>" + @"[^\$" + new_line_character_ + "]" + ")";
+
         ////            braced_variable
+        public readonly RegexBasedTerminal _expandable_here_string_part_braced_variable = null; // Initialized by reflection
+        const string _expandable_here_string_part_braced_variable_pattern = "(?<_expandable_here_string_part_braced_variable>" + braced_variable_pattern + ")";
+
         ////            $   Any Unicode character except
         ////                    (
         ////                    new_line_character
+        public readonly RegexBasedTerminal _expandable_here_string_part_expansion_one = null; // Initialized by reflection
+        const string _expandable_here_string_part_expansion_one_pattern = "(?<_expandable_here_string_part_expansion_one>" + @"\$[^\(" + new_line_character_pattern + "]" + ")";
+
         ////            $   new_line_character   Any Unicode character except double_quote_char
+        public readonly RegexBasedTerminal _expandable_here_string_part_expansion_two = null; // Initialized by reflection
+        const string _expandable_here_string_part_expansion_two_pattern = "(?<_expandable_here_string_part_expansion_two>" + @"\$" + new_line_character_pattern + @"[^" + double_quote_character_ + "]" + ")";
+
         ////            $   new_line_character   double_quote_char   Any Unicode character except @
+        public readonly RegexBasedTerminal _expandable_here_string_part_expansion_three = null; // Initialized by reflection
+        const string _expandable_here_string_part_expansion_three_pattern = "(?<_expandable_here_string_part_expansion_three>" + @"\$" + new_line_character_pattern + double_quote_character_pattern + @"[^@]" + ")";
+
         ////            new_line_character   Any Unicode character except double_quote_char
+        public readonly RegexBasedTerminal _expandable_here_string_part_expansion_four = null; // Initialized by reflection
+        const string _expandable_here_string_part_expansion_four_pattern = "(?<_expandable_here_string_part_expansion_four>" + new_line_character_pattern + @"[^" + double_quote_character_ + "]" + ")";
+
         ////            new_line_character   double_quote_char   Any Unicode character except @
+        public readonly RegexBasedTerminal _expandable_here_string_part_expansion_five = null; // Initialized by reflection
+        const string _expandable_here_string_part_expansion_five_pattern = "(?<_expandable_here_string_part_expansion_five>" + new_line_character_pattern + @"[^@]" + ")";
+
 
         ////        expandable_string_with_subexpr_start:
         ////            double_quote_character   expandable_string_chars_opt [sic]   $(
@@ -607,13 +645,34 @@ namespace Pash.ParserIntrinsics
         ////        verbatim_here_string_literal:
         ////            @   single_quote_character   whitespace_opt   new_line_character
         ////                    verbatim_here_string_characters_opt   new_line_character   single_quote_character   @
+        public readonly RegexBasedTerminal verbatim_here_string_literal = null; // Initialized by reflection.
+        const string verbatim_here_string_literal_pattern = "(?<verbatim_here_string_literal>" + "@" + single_quote_character_pattern + whitespace_pattern + "*?" + new_line_character_pattern + verbatim_here_string_characters_pattern + "?" + new_line_character_pattern + single_quote_character_pattern + "@" + ")";
+
         ////        verbatim_here_string_characters:
         ////            verbatim_here_string_part
         ////            verbatim_here_string_characters   verbatim_here_string_part
+        public readonly RegexBasedTerminal verbatim_here_string_characters = null; // Initialized by reflection.
+        const string verbatim_here_string_characters_pattern = "(?<verbatim_here_string_characters>" + verbatim_here_string_part_pattern + "+" + ")";
         ////        verbatim_here_string_part:
+        public readonly RegexBasedTerminal verbatim_here_string_part = null; // Initialized by reflection.
+        const string verbatim_here_string_part_pattern = "(?<verbatim_here_string_part>" +
+            _verbatim_here_string_part_plain_pattern + "|" +
+            _verbatim_here_string_part_expansion_one_pattern + "|" +
+            _verbatim_here_string_part_expansion_two_pattern +
+            ")";
+
         ////            Any Unicode character except new_line_character
+        public readonly RegexBasedTerminal _verbatim_here_string_part_plain = null; // Initialized by reflection
+        const string _verbatim_here_string_part_plain_pattern = "(?<_verbatim_here_string_part_plain>" + @"[^" + new_line_character_ + "]" + ")";
+
         ////            new_line_character   Any Unicode character except single_quote_character
+        public readonly RegexBasedTerminal _verbatim_here_string_part_expansion_one = null; // Initialized by reflection
+        const string _verbatim_here_string_part_expansion_one_pattern = "(?<_verbatim_here_string_part_expansion_one>" + new_line_character_pattern + @"[^" + single_quote_character_ + "]" + ")";
+
         ////            new_line_character   single_quote_character   Any Unicode character except @
+        public readonly RegexBasedTerminal _verbatim_here_string_part_expansion_two = null; // Initialized by reflection
+        const string _verbatim_here_string_part_expansion_two_pattern = "(?<_verbatim_here_string_part_expansion_two>" + new_line_character_pattern + single_quote_character_pattern + @"[^@]" + ")";
+
         #endregion
         #endregion
 

--- a/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.Terminals.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.Terminals.cs
@@ -73,7 +73,7 @@ namespace Pash.ParserIntrinsics
         ////            Line feed character (U+000A)
         ////            Carriage return character (U+000D) followed by line feed character (U+000A)
         public readonly RegexBasedTerminal new_line_character = null; // Initialized by reflection.
-        const string new_line_character_pattern = "(?<new_line_character>" + @"\u000D|\u000A|\u000D\u000A" + ")";
+        const string new_line_character_pattern = "(?<new_line_character>" + @"\u000D\u000A|\u000D|\u000A" + ")";
         const string new_line_character_ = @"\u000D\u000A";
 
         #endregion

--- a/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
@@ -386,7 +386,11 @@ namespace Pash.ParserIntrinsics
             string_literal.Rule =
                 expandable_string_literal
                 |
+                expandable_here_string_literal
+                |
                 verbatim_string_literal
+                |
+                verbatim_here_string_literal
                 ;
             #endregion
 


### PR DESCRIPTION
Irony grammar. One of the most confusing things I have seen in a long time. I hope I got it right.
One of my scripts required the following syntax (not even sure what its name is).
```powershell
@"
#expandable_here_string_literal
"@
```
I followed the grammar in Windows PowerShell Language Specifcation Version 3.0.
Seems to be working. But I am bit overwhelmed by the grammar stuff to be sure.

And while I was at it, I also did other version.
```powershell
@'
#verbatim_here_string_literal
'@
```