### PR TITLE
Foreach loop & parameter list fix

### DIFF
--- a/Source/ReferenceTests/Language/FunctionTests.cs
+++ b/Source/ReferenceTests/Language/FunctionTests.cs
@@ -80,6 +80,13 @@ namespace ReferenceTests.Language
             ExecuteAndCompareTypedResult(funStart + "$a; $b; $args; }; f -b 1 '-a' -d -e", "-a", 1, "-d", "-e");
         }
 
+        [TestCase("function f($a, $b=3, $c=4) { ")]
+        [TestCase("function f { param($a, $b=3, $c=4); ")]
+        public void FunctionCanHaveMultipleDefautValues(string funStart)
+        {
+            ExecuteAndCompareTypedResult(funStart + "$a + $b + $c }; f 1 -c 1", 5);
+        }
+
         [TestCase("function f($a, $b) { ")]
         [TestCase("function f { param($a, $b); ")]
         public void FunctionsUndefinedNamedArgsAreInArgsVar(string funStart)
@@ -99,7 +106,16 @@ namespace ReferenceTests.Language
         public void FunctionsNamedUnsetParameterThrows(string funStart)
         {
             Assert.Throws<ParameterBindingException>(delegate {
-               ReferenceHost.Execute(funStart + "}; f -a");
+                ReferenceHost.Execute(funStart + "}; f -a");
+            });
+        }
+
+        [TestCase("function f($a=1,2) { ")]
+        [TestCase("function f { param($a=1,2); ")]
+        public void FunctionWithLiteralArrayAsDefaultParameterThrows(string funStart)
+        {
+            Assert.Throws<ParseException>(delegate {
+                ReferenceHost.Execute(funStart + "};");
             });
         }
 

--- a/Source/ReferenceTests/Language/FunctionTests.cs
+++ b/Source/ReferenceTests/Language/FunctionTests.cs
@@ -29,8 +29,8 @@ namespace ReferenceTests.Language
             Assert.AreEqual(NewlineJoin(Environment.CurrentDirectory), result);
         }
 
-        [TestCase("function f { param($test=3+4 -eq 7")]
-        [TestCase("function f ($test=2*3.5 -eq 7h) {")]
+        [TestCase("function f { param($test=3+4 -eq 7); ")]
+        [TestCase("function f ($test=2*3 -eq 6) {")]
         public void FunctionParamsDefaultValueCanBeLogicalExpressionWithoutParens(string funStart)
         {
             var cmd = funStart + " $test }; f";

--- a/Source/ReferenceTests/Language/FunctionTests.cs
+++ b/Source/ReferenceTests/Language/FunctionTests.cs
@@ -29,6 +29,14 @@ namespace ReferenceTests.Language
             Assert.AreEqual(NewlineJoin(Environment.CurrentDirectory), result);
         }
 
+        [TestCase("function f { param($test=3+4 -eq 7")]
+        [TestCase("function f ($test=2*3.5 -eq 7h) {")]
+        public void FunctionParamsDefaultValueCanBeLogicalExpressionWithoutParens(string funStart)
+        {
+            var cmd = funStart + " $test }; f";
+            ExecuteAndCompareTypedResult(cmd, true);
+        }
+
         [TestCase("function f($a, $b) { ")]
         [TestCase("function f { param($a, $b); ")]
         public void FunctionWithParameters(string funStart)

--- a/Source/ReferenceTests/Language/Loops.cs
+++ b/Source/ReferenceTests/Language/Loops.cs
@@ -90,6 +90,20 @@ namespace ReferenceTests.Language
         }
 
         [Test]
+        public void ForEachWithOneElementWorks()
+        {
+            var cmd = "foreach ($num in 1) { $num }";
+            ExecuteAndCompareTypedResult(cmd, 1);
+        }
+
+        [Test]
+        public void ForEachWithNullDoesntExecute()
+        {
+            var cmd = "foreach ($i in $null) { 1 }";
+            ExecuteAndCompareTypedResult(cmd, new object[0]);
+        }
+
+        [Test]
         public void ForEachCharacterInStringIsString()
         {
             var cmd = "foreach ($char in 'abc') { $char }";

--- a/Source/System.Management.Tests/Ast/Ast.Tests.cs
+++ b/Source/System.Management.Tests/Ast/Ast.Tests.cs
@@ -1518,7 +1518,9 @@ ls
         [Test]
         public void ParamBlockWithOneParameterTest()
         {
-            ParamBlockAst result = ParseInput("param($path)")
+            // NOTE: the implementation cannot parse a param block with directly an EOD behind it. We need a ';' or
+            // a newline, which is also used in any practical situation (EOD after param block doesn't make sense)
+            ParamBlockAst result = ParseInput("param($path)\n")
                 .ParamBlock;
 
             ParameterAst parameter = result.Parameters.FirstOrDefault();
@@ -1529,7 +1531,9 @@ ls
         [Test]
         public void ParamBlockWithTwoParametersTest()
         {
-            ParamBlockAst result = ParseInput("param($first, $second)")
+            // NOTE: the implementation cannot parse a param block with directly an EOD behind it. We need a ';' or
+            // a newline, which is also used in any practical situation (EOD after param block doesn't make sense)
+            ParamBlockAst result = ParseInput("param($first, $second)\n")
                 .ParamBlock;
 
             ParameterAst firstParameter = result.Parameters.FirstOrDefault();
@@ -1542,7 +1546,9 @@ ls
         [Test]
         public void ParamBlockWithOneParameterWithDefaultIntegerValueTest()
         {
-            ParamBlockAst result = ParseInput("param($first = 2)")
+            // NOTE: the implementation cannot parse a param block with directly an EOD behind it. We need a ';' or
+            // a newline, which is also used in any practical situation (EOD after param block doesn't make sense)
+            ParamBlockAst result = ParseInput("param($first = 2)\n")
                 .ParamBlock;
 
             ParameterAst parameter = result.Parameters.FirstOrDefault();

--- a/Source/System.Management/Automation/ParseException.cs
+++ b/Source/System.Management/Automation/ParseException.cs
@@ -12,6 +12,7 @@ namespace System.Management.Automation
     [Serializable]
     public class ParseException : RuntimeException
     {
+        private const int _maxLineLength = 70;
         public string RawMessage { get; private set; }
         public string FormattedMessage { get; private set; }
 
@@ -27,16 +28,16 @@ namespace System.Management.Automation
         {
         }
 
-        public ParseException(string rawMessage) : this(rawMessage, -1, -1)
+        public ParseException(string rawMessage) : this(rawMessage, -1, -1, "")
         {
         }
 
-        public ParseException(string rawMessage, int line, int col)
+        public ParseException(string rawMessage, int line, int col, string srcText)
         {
             Id = "Parse";
             Category = ErrorCategory.ParserError;
             RawMessage = rawMessage;
-            FormattedMessage = FormatMessage(rawMessage, line, col);
+            FormattedMessage = FormatMessage(rawMessage, line, col, srcText);
         }
 
         public ParseException(string message, Exception innerException)
@@ -51,7 +52,7 @@ namespace System.Management.Automation
         {
         }
 
-        private string FormatMessage(string rawMessage, int line, int col)
+        private string FormatMessage(string rawMessage, int line, int col, string srcText)
         {
             var msg = new StringBuilder("Parse error");
             if (line >= 0 || col >= 0)
@@ -59,16 +60,46 @@ namespace System.Management.Automation
                 msg.AppendFormat(" at ({0}:{1})", line, col);
             }
             msg.Append(": ");
-            if (rawMessage.Length > 100)
+            if (rawMessage.Length > _maxLineLength)
             {
-                msg.Append(rawMessage.Substring(0, 97));
+                msg.Append(rawMessage.Substring(0, _maxLineLength - 3));
                 msg.Append("...");
             }
             else
             {
                 msg.Append(rawMessage);
             }
+            AddErrorLocationDescription(line, col, srcText, msg);
             return msg.ToString();
+        }
+
+        private void AddErrorLocationDescription(int line, int col, string srcText, StringBuilder msgBuilder)
+        {
+            const int leftFromError = 50;
+            if (line < 0 || col < 0)
+            {
+                return;
+            }
+            var srcLines = srcText.Split(new [] { "\r\n", "\n" }, StringSplitOptions.None);
+            if (line > srcLines.Length)
+            {
+                return;
+            }
+            var affectedLine = srcLines[line];
+            msgBuilder.AppendLine();
+            var cutLen = col - leftFromError;
+            if (cutLen > 0)
+            {
+                affectedLine = "..." + affectedLine.Substring(cutLen + 3);
+                col -= leftFromError;
+            }
+            if (affectedLine.Length > _maxLineLength)
+            {
+                affectedLine = affectedLine.Substring(0, _maxLineLength - 3) + "...";
+            }
+            msgBuilder.Append("> ");
+            msgBuilder.AppendLine(affectedLine);
+            msgBuilder.Append("^".PadLeft(col + 3)); // +1 because index offset, + 2 because '> ' in line above
         }
     }
 }

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -951,6 +951,13 @@ namespace System.Management.Pash.Implementation
         public override AstVisitAction VisitForEachStatement(ForEachStatementAst forEachStatementAst)
         {
             object enumerable = EvaluateAst(forEachStatementAst.Condition);
+
+            // if the enumerable object is null, the loop is not executed at all
+            if (enumerable == null)
+            {
+                return AstVisitAction.SkipChildren;
+            }
+
             IEnumerator enumerator = LanguagePrimitives.GetEnumerator(enumerable);
 
             if (enumerator == null)
@@ -961,7 +968,7 @@ namespace System.Management.Pash.Implementation
             while (enumerator.MoveNext())
             {
                 this.ExecutionContext.SessionState.PSVariable.Set(forEachStatementAst.Variable.VariablePath.UserPath,
-                                                          enumerator.Current);
+                                                                  enumerator.Current);
                 // TODO: pass the loop label
                 if (!EvaluateLoopBodyAst(forEachStatementAst.Body, null))
                 {

--- a/Source/System.Management/Pash/Implementation/Parser.cs
+++ b/Source/System.Management/Pash/Implementation/Parser.cs
@@ -85,7 +85,8 @@ namespace Pash.Implementation
             if (parseTree.HasErrors()) // ParseTreeStatus is Error
             {
                 var logMessage = parseTree.ParserMessages.First();
-                throw new ParseException(logMessage.Message, logMessage.Location.Line, logMessage.Location.Column);
+                throw new ParseException(logMessage.Message, logMessage.Location.Line, logMessage.Location.Column,
+                                         parseTree.SourceText);
             }
             return parseTree;
         }

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -70,7 +70,8 @@ namespace Pash.ParserIntrinsics
         {
             VerifyTerm(parseTreeNode, this._grammar.param_block);
 
-            IEnumerable<ParameterAst> parameters = BuildParameterListAst(parseTreeNode.ChildNodes[2]);
+            // second child, because the rule is "param + _marked_parameter_list"
+            IEnumerable<ParameterAst> parameters = BuildParameterListAst(parseTreeNode.ChildNodes[1]);
 
             return new ParamBlockAst(
                 new ScriptExtent(parseTreeNode),
@@ -83,6 +84,8 @@ namespace Pash.ParserIntrinsics
             // ISSUE: https://github.com/Pash-Project/Pash/issues/203
             // Since parameter_list was changed to parameter_list_opt we need
             // to anticipate a closing parenthesis here too.
+            VerifyTerm(parseTreeNode, this._grammar._marked_parameter_list);
+            parseTreeNode = parseTreeNode.ChildNodes[2]; // skips "(" and beginParamList tokens
             VerifyTerm(parseTreeNode, this._grammar.parameter_list, this._grammar.ToTerm(")"));
 
             var parameters = new List<ParameterAst>();
@@ -276,7 +279,7 @@ namespace Pash.ParserIntrinsics
 
             if (parseTreeNode.ChildNodes.Count == 6)
             {
-                parameters = BuildParameterListAst(parseTreeNode.ChildNodes[2].ChildNodes[1]);
+                parameters = BuildParameterListAst(parseTreeNode.ChildNodes[2].ChildNodes[0]);
                 scriptBlock = BuildScriptBlockAst(parseTreeNode.ChildNodes[4]);
             }
             else

--- a/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/PowerShellGrammar.cs
@@ -55,8 +55,10 @@ namespace Pash.ParserIntrinsics
         public readonly NonTerminal script_block = null; // Initialized by reflection.
         public readonly NonTerminal param_block = null; // Initialized by reflection.
         public readonly NonTerminal param_block_opt = null; // Initialized by reflection.
+
         public readonly NonTerminal parameter_list = null; // Initialized by reflection.
         public readonly NonTerminal parameter_list_opt = null; // Initialized by reflection.
+        public readonly NonTerminal _marked_parameter_list = null; // Initialized by reflection.
         public readonly NonTerminal script_parameter = null; // Initialized by reflection.
         public readonly NonTerminal script_parameter_default = null; // Initialized by reflection.
         public readonly NonTerminal script_parameter_default_opt = null; // Initialized by reflection.
@@ -252,6 +254,13 @@ namespace Pash.ParserIntrinsics
         public readonly NonTerminal attribute_arguments = null; // Initialized by reflection.
         public readonly NonTerminal attribute_argument = null; // Initialized by reflection.
         #endregion
+
+        #endregion
+
+        #region Workaround related
+
+        public readonly ImpliedSymbolTerminal _begin_paramlist_marker = new ImpliedSymbolTerminal("beginParamList");
+        public readonly ImpliedSymbolTerminal _end_paramlist_marker = new ImpliedSymbolTerminal("endParamList");
 
         #endregion
 
@@ -458,15 +467,24 @@ namespace Pash.ParserIntrinsics
             ////        param_block:
             ////            new_lines_opt   attribute_list_opt   new_lines_opt   param   new_lines_opt
             ////                    (   parameter_list_opt   new_lines_opt   )
+            // NOTE: use _marked_parameter_list here, a parameter_list_opt with implicit marker symbols
             param_block.Rule =
                 /*  TODO: https://github.com/Pash-Project/Pash/issues/11 attribute_list_opt +  */ @param
-                        + "(" + parameter_list_opt + ")";
+                + _marked_parameter_list;
+
+            // ISSUE: https://github.com/Pash-Project/Pash/issues/367
+            // multiple parameters with default values were not possible, because they were mistaken for a 
+            // literal array. They aren't allowed anymore without brakets inside a parameter list. To parse this
+            // in a context sensitive manner, implicit marker symbols and a custom action in array_literal_expression
+            // are used
+            _marked_parameter_list.Rule = "(" + _begin_paramlist_marker + parameter_list_opt + ")" + _end_paramlist_marker;
 
             ////        parameter_list:
             ////            script_parameter
             ////            parameter_list   new_lines_opt   ,   script_parameter
-            parameter_list.Rule =
-                MakePlusRule(parameter_list, ToTerm(","), script_parameter);
+            parameter_list.Rule = 
+                MakePlusRule(parameter_list, ToTerm(","), script_parameter)
+                ;
 
             ////        script_parameter:
             ////            new_lines_opt   attribute_list_opt   new_lines_opt   variable   script_parameter_default_opt
@@ -790,11 +808,11 @@ namespace Pash.ParserIntrinsics
             ////        function_parameter_declaration:
             ////            new_lines_opt   (   parameter_list   new_lines_opt   )
             // ISSUE: https://github.com/Pash-Project/Pash/issues/203
-            // parameter_list was changed to parameter_list_opt here, which
-            // is not in accordance with the published grammar, but otherwise
+            // parameter_list was changed to _marked_parameter_list here, which includes parameter_list_opt
+            // it is not in accordance with the published grammar, but otherwise
             // an empty parameter list wouldn't be allowed.
             function_parameter_declaration.Rule =
-                 "(" + parameter_list_opt + ")";
+                 _marked_parameter_list;
 
             ////        flow_control_statement:
             ////            break   label_expression_opt
@@ -1091,10 +1109,12 @@ namespace Pash.ParserIntrinsics
             ////        array_literal_expression:
             ////            unary_expression
             ////            unary_expression   ,    new_lines_opt   array_literal_expression
-            array_literal_expression.Rule =
+            // ISSUE 367 https://github.com/Pash-Project/Pash/issues/367
+            // A custom action is used to not allow literal arrays in a parameter list default value
+            array_literal_expression.Rule = 
                 unary_expression
                 |
-                (unary_expression + PreferShiftHere() + "," + array_literal_expression)
+                (unary_expression + CustomActionHere(ResolveLiteralArrayConflict) + "," + array_literal_expression)
                 ;
 
             ////        unary_expression:
@@ -1548,6 +1568,56 @@ namespace Pash.ParserIntrinsics
             #endregion
             #endregion
         }
+
+        #region Context-sensitive resolving of shift/reduce conflict with parameter lists and literal arrays
+
+        // Only parse a literal array if we're not inside a pameter list. We check the context sensitivity by
+        // using implict beginParamList and endParamList symbols
+        void ResolveLiteralArrayConflict(ParsingContext context, CustomParserAction customAction)
+        {
+            // First check for a comma term. Any other is not a list, so it must be a reduction to unary_expression
+            if (context.CurrentParserInput.Term.Name != ",")
+            {
+                customAction.ReduceActions.First().Execute(context);
+                return;
+            }
+            // if there is no possibility to reduce, just do a shift
+            var firstCorrectShiftAction = customAction.ShiftActions.First(a => a.Term.Name == ",");
+            if (customAction.ReduceActions.Count < 1)
+            {
+                firstCorrectShiftAction.Execute(context);
+                return;
+            }
+            // so we can shift or reduce. Let's look if we're in a paramBlock
+            // we do this be iterating over the read tokens backwards and checking for a marker token which marks
+            // the beginning and end of a parameter list
+            var tokens = context.CurrentParseTree.Tokens;
+            var isParamList = false;
+            for (int i = tokens.Count - 1; i >= 0; i--)
+            {
+                var tk = tokens[i];
+                if (tk.Terminal == _begin_paramlist_marker)
+                {
+                    isParamList = true; // yes, inside a param block
+                    break;
+                }
+                else if (tk.Terminal == _end_paramlist_marker)
+                {
+                    break; // we're outside a param block
+                }
+            }
+
+            // if we're inside a parameter list, reduce (so not array literal is parsed)
+            if (isParamList)
+            {
+                customAction.ReduceActions.First().Execute(context);
+                return;
+            }
+            // otherwise just shift to parse the array literal
+            firstCorrectShiftAction.Execute(context);
+        }
+
+        #endregion
 
         bool AreTerminalsContiguous(ParseTreeNode parseTreeNode1, ParseTreeNode parseTreeNode2)
         {

--- a/Source/TestHost/FullHostTests.cs
+++ b/Source/TestHost/FullHostTests.cs
@@ -141,7 +141,7 @@ namespace TestHost
             HostUI.SetInput("$" + Environment.NewLine); // simple parse error
             FullHost.Run();
             var outlines = HostUI.GetOutput().Split(new string[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
-            Assert.AreEqual(6, outlines.Length); // Banner + prompt + 3 error lines + prompt
+            Assert.AreEqual(8, outlines.Length); // Banner + prompt + 5 error lines + prompt
             Assert.That(outlines[2], Is.StringStarting("Parse error"));
         }
     }


### PR DESCRIPTION
- Foreach with $null doesn't evaluate the body anymore
- Parameter list with multiple default values work now
Before, a parameter list like this `param($a=1,$b)` as parsed like an array literal as in `param($a=(1,$b))`, which is obviously wrong. Array literals aren't allowed in parameter lists without braces to avoid ambiguities. Therefore I made parsing of the array literals context sensitive by introducing implicit symbols and a custom action.

These commits fix #368 and #367 