### PR TITLE
Comparison Operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ obj/
 *.suo
 *.userprefs
 
+# Vim Specific Files
+*.swp
+
 #Resource Caches
 _ReSharper.*
 *.sln.cache

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@ Alexander Sturm            | [@Ventero](https://github.com/Ventero)             
 Stefan Burnicki            | [@sburnicki](https://github.com/sburnicki)             | <stefan.burnicki@gmail.com>   |
 Sergei Vorobev             | [@vors](https://github.com/vors)                       | <xvorsx@gmail.com>            | 
 Matt Ward                  | [@mrward](https://github.com/mrward)                   |                               | 
+Alexander Bussmann         | [@atbussma](https://github.com/atbussma)               | <alex@parsestack.com>         |

--- a/Source/ReferenceTests/Language/Operators/RelationshipOperators_7_9.cs
+++ b/Source/ReferenceTests/Language/Operators/RelationshipOperators_7_9.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+using NUnit.Framework;
+
+namespace ReferenceTests.Language.Operators
+{
+    ///
+    /// RelationshipOperators:
+    ///     - GreaterThan
+    ///     - GreaterThanEquals
+    ///     - LessThan
+    ///     - LessThanEquals
+    ///     - Equals
+    ///     - NotEquals
+    ///
+    /// Organize Tests based on LHS Operand Types
+    /// Test Cases are reused for each Relationship Operation
+    /// Lowercase < Uppercase
+    ///
+    /// Organized for Primitive Types:
+    ///     - String
+    ///     - DateTime
+    ///     - Double
+    ///     - Float
+    ///     - Long
+    ///     - Int
+    ///     - Char
+    ///     - Byte
+    ///     - Bool
+    ///
+    [TestFixture]
+    public class RelationshipOperators_7_9 : ReferenceTestBase
+    {
+        [Test]
+        [TestCase("$null -gt $true                                  ", "False")]
+        [TestCase("$null -igt 0                                     ", "False")]
+        [TestCase("$null -cgt \"abc\"                               ", "False")]
+        [TestCase("$null -ge $false                                 ", "False")]
+        [TestCase("$null -ige 1.0                                   ", "False")]
+        [TestCase("$null -cge [float] -1.0                          ", "True")]
+        [TestCase("$null -cgt [double] -1.0                         ", "True")]
+        [TestCase("$null -ilt [long] -1                             ", "False")]
+        [TestCase("$null -clt -1                                    ", "False")]
+        [TestCase("$d = Get-Date; $null -lt $d;                     ", "True")]
+        [TestCase("$c = [char] 0x1010; $null -ilt $c;               ", "True")]
+        [TestCase("$b = [byte] 0x10; $null -clt $b;                 ", "True")]
+        [TestCase("$null -le $true;                                 ", "True")]
+        [TestCase("$null -ile 0;                                    ", "True")]
+        [TestCase("$null -cle \"abc\";                              ", "True")]
+        public void RelationshipOperatorsWithNull(string input, string expected)
+        {
+            string result = ReferenceHost.Execute(input);
+            Assert.AreEqual(expected + Environment.NewLine, result);
+        }
+
+
+        [Test]
+            /// -gt, -igt, -cgt
+        [TestCase("\"a\" -gt $null                                      ", "True")]
+        [TestCase("\"u\" -gt $true                                      ", "True")]
+        [TestCase("\"a\" -igt \"B\"                                     ", "False")]
+        [TestCase("\"a\" -cgt \"A\"                                     ", "False")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; \"01/02/2015\" -gt $d; ", "True")]
+        [TestCase("\"1.23450\" -gt 1.2345                               ", "True")]
+        [TestCase("\"1.23450\" -gt [float] 1.2345                       ", "True")]
+        [TestCase("\"2\" -gt [long] 1                                   ", "True")]
+        [TestCase("\"0\" -gt 1                                          ", "False")]
+        [TestCase("$c = [char] 0x1000; \"1025\" -gt $c;                 ", "False")]
+        [TestCase("$b = [byte] 0x10; \"17\" -gt $b;                     ", "True")]
+            /// -ge, -ige, -cge
+        [TestCase("\"a\" -ge $null                                      ", "True")]
+        [TestCase("\"t\" -ge $true                                      ", "False")]
+        [TestCase("\"a\" -ige \"A\"                                     ", "True")]
+        [TestCase("\"a\" -cge \"A\"                                     ", "False")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; \"01/01/2015\" -ge $d; ", "False")]
+        [TestCase("\"1.2345\" -ge 1.2345                                ", "True")]
+        [TestCase("\"1.2345\" -ge [float] 1.2345                        ", "True")]
+        [TestCase("\"1\" -ge [long] 1                                   ", "True")]
+        [TestCase("\"1\" -ge 1                                          ", "True")]
+        [TestCase("$c = [char] 0x1000; \"1024\" -ge $c;                 ", "False")]
+        [TestCase("$b = [byte] 0x10; \"16\" -ge $b;                     ", "True")]
+            /// -lt, -ilt, -clt
+        [TestCase("\"a\" -lt $null                                      ", "False")]
+        [TestCase("\"t\" -lt $true                                      ", "True")]
+        [TestCase("\"a\" -ilt \"A\"                                     ", "False")]
+        [TestCase("\"a\" -clt \"A\"                                     ", "True")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; \"01/01/2015\" -lt $d; ", "True")]
+        [TestCase("\"1.2345\" -lt 1.2345                                ", "False")]
+        [TestCase("\"1.2345\" -lt [float] 1.2345                        ", "False")]
+        [TestCase("\"1\" -lt [long] 1                                   ", "False")]
+        [TestCase("\"1\" -lt 1                                          ", "False")]
+        [TestCase("$c = [char] 0x1000; \"1024\" -lt $c;                 ", "True")]
+        [TestCase("$b = [byte] 0x10; \"16\" -lt $b;                     ", "False")]
+            /// -le, -ile, -cle
+        [TestCase("\"a\" -le $null                                      ", "False")]
+        [TestCase("\"t\" -le $true                                      ", "True")]
+        [TestCase("\"a\" -ile \"A\"                                     ", "True")]
+        [TestCase("\"a\" -cle \"A\"                                     ", "True")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; \"01/01/2015\" -le $d; ", "True")]
+        [TestCase("\"1.2345\" -le 1.2345                                ", "True")]
+        [TestCase("\"1.2345\" -le [float] 1.2345                        ", "True")]
+        [TestCase("\"1\" -le [long] 1                                   ", "True")]
+        [TestCase("\"1\" -le 1                                          ", "True")]
+        [TestCase("$c = [char] 0x1000; \"1024\" -le $c;                 ", "True")]
+        [TestCase("$b = [byte] 0x10; \"16\" -le $b;                     ", "True")]
+        public void RelationshipOperatorsWithString(string input, string expected)
+        {
+            string result = ReferenceHost.Execute(input);
+            Assert.AreEqual(expected + Environment.NewLine, result);
+        }
+
+
+        [Test]
+            /// -gt, -igt, -cgt
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -gt $null               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -gt $true               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -igt \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -cgt \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -gt \"01/01/2014\"      ", "True")]
+        [TestCase("(Get-Date \"01/01/2015\") -gt (Get-Date \"01/01/2015\")  ", "False")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -gt 1.2345              ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -gt [float] 1.2345      ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -gt [long] 1            ", "True")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -gt 1                   ", "True")]
+        [TestCase("(Get-Date \"01/01/2015\") -gt [char] 0x1000              ", "True")]
+        [TestCase("(Get-Date \"01/01/2015\") -gt [byte] 0x10                ", "True")]
+            /// -ge, -ige, -cge
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ge $null               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ge $true               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ige \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -cge \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ge \"01/01/2014\"      ", "True")]
+        [TestCase("(Get-Date \"01/01/2015\") -ge (Get-Date \"01/01/2015\")  ", "True")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ge 1.2345              ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ge [float] 1.2345      ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ge [long] 1            ", "True")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ge 1                   ", "True")]
+        [TestCase("(Get-Date \"01/01/2015\") -ge [char] 0x1000              ", "True")]
+        [TestCase("(Get-Date \"01/01/2015\") -ge [byte] 0x10                ", "True")]
+            /// -lt, -ilt, -clt
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -lt $null               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -lt $true               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ilt \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -clt \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -lt \"01/01/2014\"      ", "False")]
+        [TestCase("(Get-Date \"01/01/2015\") -lt (Get-Date \"01/01/2015\")  ", "False")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -lt 1.2345              ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -lt [float] 1.2345      ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -lt [long] 1            ", "False")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -lt 1                   ", "False")]
+        [TestCase("(Get-Date \"01/01/2015\") -lt [char] 0x1000              ", "False")]
+        [TestCase("(Get-Date \"01/01/2015\") -lt [byte] 0x10                ", "False")]
+            /// -le, -ile, -cle
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -le $null               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -le $true               ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -ile \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -cle \"Jan. 1st. 2014\" ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -le \"01/01/2014\"      ", "False")]
+        [TestCase("(Get-Date \"01/01/2015\") -le (Get-Date \"01/01/2015\")  ", "True")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -le 1.2345              ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -le [float] 1.2345      ", "Exception")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -le [long] 1            ", "False")]
+        [TestCase("$d = Get-Date \"01/01/2015\"; $d -le 1                   ", "False")]
+        [TestCase("(Get-Date \"01/01/2015\") -le [char] 0x1000              ", "False")]
+        [TestCase("(Get-Date \"01/01/2015\") -le [byte] 0x10                ", "False")]
+        public void RelationshipOperatorsWithDateTime(string input, string expected)
+        {
+            try
+            {
+                string result = ReferenceHost.Execute(input);
+                Assert.AreEqual(expected + Environment.NewLine, result);
+            }
+            catch (Exception)
+            {
+                ///
+                /// Pash throws PSInvalidOperationException
+                /// Powershell throws PSInvalidCastException, or RuntimeException
+                ///
+                Assert.AreEqual(expected, "Exception");
+            }
+        }
+
+
+        ///
+        /// RelationshipOperatorsWithNumericTypes:
+        ///     - $null, string, datetime are selected based on the LHS operand
+        ///     - conversion operations that are invalid result in Exceptions
+        ///     - precedence:  double > float > long > int > char > byte > bool
+        ///     - types can be mixed and matched
+        ///     - based on type precedence, conversion takes place to normalize operands
+        ///     - based on the normalization a type specific comparer is choosen to handle the operation
+        ///
+        [Test]
+            /// -gt, -igt, -cgt
+        [TestCase("1.2345 -gt $null                                         ", "True")]
+        [TestCase("1.2345 -gt \"1.2345\"                                    ", "False")]
+        [TestCase("1.2345 -gt \"ABC\"                                       ", "Exception")]
+        [TestCase("1.2345 -gt (Get-Date \"01/01/2015\")                     ", "Exception")]
+        [TestCase("1.2345 -gt $true                                         ", "True")]
+        [TestCase("1.2345 -gt 1.23449                                       ", "True")]
+        [TestCase("1.2345 -gt [float] 1.2345                                ", "False")]
+        [TestCase("[float] 1.2345 -gt 1.2345                                ", "True")]
+        [TestCase("[float] 1.2345 -gt [float] 1.23449                       ", "True")]
+        [TestCase("[float] 1.2345 -gt [long] 1                              ", "True")]
+        [TestCase("[long] 11 -gt [float] 1.2345                             ", "True")]
+        [TestCase("[long] 11 -gt [long] 10                                  ", "True")]
+        [TestCase("[long] 11 -gt 11                                         ", "False")]
+        [TestCase("11 -gt [long] 10                                         ", "True")]
+        [TestCase("11 -gt 10                                                ", "True")]
+        [TestCase("11 -gt [char] 10                                         ", "True")]
+        [TestCase("[char] 0x1000 -gt 4095                                   ", "True")]
+        [TestCase("[char] 0x1000 -gt [char] 0x0FFF                          ", "True")]
+        [TestCase("[char] 0x0010 -gt [byte] 0x10                            ", "False")]
+        [TestCase("[byte] 0x10 -gt [char] 0x0010                            ", "False")]
+        [TestCase("[byte] 0x10 -gt [byte] 0x0F                              ", "True")]
+        [TestCase("[byte] 0x10 -gt $false                                   ", "True")]
+            /// -ge, -ige, -cge
+        [TestCase("1.2345 -ge $null                                         ", "True")]
+        [TestCase("1.2345 -ge \"1.2345\"                                    ", "True")]
+        [TestCase("1.2345 -ge \"ABC\"                                       ", "Exception")]
+        [TestCase("1.2345 -ge (Get-Date \"01/01/2015\")                     ", "Exception")]
+        [TestCase("1.2345 -ge $true                                         ", "True")]
+        [TestCase("1.2345 -ge 1.23449                                       ", "True")]
+        [TestCase("1.2345 -ge [float] 1.2345                                ", "False")]
+        [TestCase("[float] 1.2345 -ge 1.2345                                ", "True")]
+        [TestCase("[float] 1.2345 -ge [float] 1.23449                       ", "True")]
+        [TestCase("[float] 1.2345 -ge [long] 1                              ", "True")]
+        [TestCase("[long] 11 -ge [float] 1.2345                             ", "True")]
+        [TestCase("[long] 11 -ge [long] 11                                  ", "True")]
+        [TestCase("[long] 11 -ge 11                                         ", "True")]
+        [TestCase("11 -ge [long] 11                                         ", "True")]
+        [TestCase("11 -ge 11                                                ", "True")]
+        [TestCase("11 -ge [char] 10                                         ", "True")]
+        [TestCase("[char] 0x1000 -ge 4096                                   ", "True")]
+        [TestCase("[char] 0x1000 -ge [char] 0x1000                          ", "True")]
+        [TestCase("[char] 0x0010 -ge [byte] 0x10                            ", "True")]
+        [TestCase("[byte] 0x10 -ge [char] 0x0010                            ", "True")]
+        [TestCase("[byte] 0x10 -ge [byte] 0x0F                              ", "True")]
+        [TestCase("[byte] 0x10 -ge $false                                   ", "True")]
+            /// -lt, -ilt, -clt
+        [TestCase("1.2345 -lt $null                                         ", "False")]
+        [TestCase("1.2345 -lt \"1.2345\"                                    ", "False")]
+        [TestCase("1.2345 -lt \"ABC\"                                       ", "Exception")]
+        [TestCase("1.2345 -lt (Get-Date \"01/01/2015\")                     ", "Exception")]
+        [TestCase("1.2345 -lt $true                                         ", "False")]
+        [TestCase("1.2345 -lt 1.23449                                       ", "False")]
+        [TestCase("1.2345 -lt [float] 1.2345                                ", "True")]
+        [TestCase("[float] 1.2345 -lt 1.2345                                ", "False")]
+        [TestCase("[float] 1.2345 -lt [float] 1.23449                       ", "False")]
+        [TestCase("[float] 1.2345 -lt [long] 1                              ", "False")]
+        [TestCase("[long] 11 -lt [float] 1.2345                             ", "False")]
+        [TestCase("[long] 11 -lt [long] 12                                  ", "True")]
+        [TestCase("[long] 11 -lt 11                                         ", "False")]
+        [TestCase("11 -lt [long] 12                                         ", "True")]
+        [TestCase("11 -lt 12                                                ", "True")]
+        [TestCase("11 -lt [char] 12                                         ", "True")]
+        [TestCase("[char] 0x1000 -lt 4097                                   ", "True")]
+        [TestCase("[char] 0x1000 -lt [char] 0x1000                          ", "False")]
+        [TestCase("[char] 0x0010 -lt [byte] 0x10                            ", "False")]
+        [TestCase("[byte] 0x10 -lt [char] 0x0011                            ", "True")]
+        [TestCase("[byte] 0x10 -lt [byte] 0x11                              ", "True")]
+        [TestCase("[byte] 0x10 -lt $false                                   ", "False")]
+            /// -le, -ile, -cle
+        [TestCase("1.2345 -le $null                                         ", "False")]
+        [TestCase("1.2345 -le \"1.2345\"                                    ", "True")]
+        [TestCase("1.2345 -le \"ABC\"                                       ", "Exception")]
+        [TestCase("1.2345 -le (Get-Date \"01/01/2015\")                     ", "Exception")]
+        [TestCase("1.2345 -le $true                                         ", "False")]
+        [TestCase("1.2345 -le 1.23449                                       ", "False")]
+        [TestCase("1.2345 -le [float] 1.2345                                ", "True")]
+        [TestCase("[float] 1.2345 -le 1.2345                                ", "False")]
+        [TestCase("[float] 1.2345 -le [float] 1.23456                       ", "True")]
+        [TestCase("[float] 1.2345 -le [long] 1                              ", "False")]
+        [TestCase("[long] 11 -le [float] 1.2345                             ", "False")]
+        [TestCase("[long] 11 -le [long] 11                                  ", "True")]
+        [TestCase("[long] 11 -le 11                                         ", "True")]
+        [TestCase("11 -le [long] 11                                         ", "True")]
+        [TestCase("11 -le 11                                                ", "True")]
+        [TestCase("11 -le [char] 11                                         ", "True")]
+        [TestCase("[char] 0x1000 -le 4096                                   ", "True")]
+        [TestCase("[char] 0x1000 -le [char] 0x1000                          ", "True")]
+        [TestCase("[char] 0x0010 -le [byte] 0x10                            ", "True")]
+        [TestCase("[byte] 0x10 -le [char] 0x0011                            ", "True")]
+        [TestCase("[byte] 0x10 -le [byte] 0x10                              ", "True")]
+        [TestCase("[byte] 0x10 -le $false                                   ", "False")]
+        public void RelationshipOperatorsWithNumericTypes(string input, string expected)
+        {
+            try
+            {
+                string result = ReferenceHost.Execute(input);
+                Assert.AreEqual(expected + Environment.NewLine, result);
+            }
+            catch (Exception)
+            {
+                ///
+                /// Pash throws PSInvalidOperationException
+                /// Powershell throws PSInvalidCastException, or RuntimeException
+                ///
+                Assert.AreEqual(expected, "Exception");
+            }
+        }
+    }
+}

--- a/Source/ReferenceTests/Language/Operators/RelationshipOperators_7_9.cs
+++ b/Source/ReferenceTests/Language/Operators/RelationshipOperators_7_9.cs
@@ -85,6 +85,7 @@ namespace ReferenceTests.Language.Operators
         [TestCase("\"t\" -lt $true                                      ", "True")]
         [TestCase("\"a\" -ilt \"A\"                                     ", "False")]
         [TestCase("\"a\" -clt \"A\"                                     ", "True")]
+        [TestCase("\"[\" -clt \"{\"                                     ", "True")]
         [TestCase("$d = Get-Date \"01/01/2015\"; \"01/01/2015\" -lt $d; ", "True")]
         [TestCase("\"1.2345\" -lt 1.2345                                ", "False")]
         [TestCase("\"1.2345\" -lt [float] 1.2345                        ", "False")]

--- a/Source/ReferenceTests/Language/Operators/RelationshipOperators_7_9.cs
+++ b/Source/ReferenceTests/Language/Operators/RelationshipOperators_7_9.cs
@@ -6,13 +6,11 @@ using NUnit.Framework;
 namespace ReferenceTests.Language.Operators
 {
     ///
-    /// RelationshipOperators:
+    /// Handles the following relationship operators:
     ///     - GreaterThan
     ///     - GreaterThanEquals
     ///     - LessThan
     ///     - LessThanEquals
-    ///     - Equals
-    ///     - NotEquals
     ///
     /// Organize Tests based on LHS Operand Types
     /// Test Cases are reused for each Relationship Operation
@@ -184,7 +182,7 @@ namespace ReferenceTests.Language.Operators
 
 
         ///
-        /// RelationshipOperatorsWithNumericTypes:
+        ///     - handles LHS numeric types case
         ///     - $null, string, datetime are selected based on the LHS operand
         ///     - conversion operations that are invalid result in Exceptions
         ///     - precedence:  double > float > long > int > char > byte > bool

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Language\FunctionTests.cs" />
     <Compile Include="Language\InvocationTests.cs" />
     <Compile Include="Language\Operators\LogicalOperators_7_10.cs" />
+    <Compile Include="Language\Operators\RelationshipOperators_7_9.cs" />
     <Compile Include="Language\Operators\RangeOperatorTests_7_4.cs" />
     <Compile Include="Language\ScopeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/System.Management/Pash/Implementation/ComparisonOperations.cs
+++ b/Source/System.Management/Pash/Implementation/ComparisonOperations.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Text;
+using System.Management.Automation;
+
+namespace System.Management.Pash.Implementation
+{
+    ///
+    /// ComparisonOperations:
+    ///     - class implementing comparison operations in the language
+    ///     - uses IComparer<T> interface and default implementations to perform comparisons
+    ///     - handles type mapping for objects to specific comparers based on LHS type
+    ///     - currently only handles primitive types (but should be extensible)
+    ///     - numeric types are handled by LHS or RHS type match in:  double, float, long, int, char, byte, bool order
+    ///     - TODO:  handle ==, != cases here as well
+    ///     - TODO:  handle arrays, hashtables
+    ///     - TODO:  improve test cases to ensure correctness with Microsoft Powershell
+    ///
+    internal static class ComparisonOperations
+    {
+        ///
+        /// NOTE:  dynamic doesn't seem to work in Mono (on Mac OS X)
+        ///        use generic functions and type based dispatching instead.
+        /// EXAMPLE:
+        ///     Func<IComparer<dynamic>, dynamic, dynamic, object> opComparer =
+        ///         (IComparer<dynamic> c, dynamic l, dynamic r) => checked(c.Compare(l, r) > 0);
+        ///     return ComparisonOperation(lhs, rhs, ignoreCase, "-gt", opComparer);
+        ///
+        private static object GreaterThanOp<T>(IComparer<T> c, T l, T r) { return (c.Compare(l, r) > 0); }
+        private static object GreaterThanEqualsOp<T>(IComparer<T> c, T l, T r) { return (c.Compare(l, r) >= 0); }
+        private static object LessThanOp<T>(IComparer<T> c, T l, T r) { return (c.Compare(l, r) < 0); }
+        private static object LessThanEqualsOp<T>(IComparer<T> c, T l, T r) { return (c.Compare(l, r) <= 0); }
+        private static Func<IComparer<T>, T, T, object> GetComparerOp<T>(string op)
+        {
+            if (op.Equals("-gt")) { return GreaterThanOp<T>; }
+            if (op.Equals("-ge")) { return GreaterThanEqualsOp<T>; }
+            if (op.Equals("-lt")) { return LessThanOp<T>; }
+            if (op.Equals("-le")) { return LessThanEqualsOp<T>; }
+            throw new NotImplementedException(String.Format("Invalid Operation: {0}", op));
+        }
+
+
+        ///
+        /// GreaterThan:
+        ///     - method for handling -gt, -igt, -cgt operations
+        ///     - called with unpacked lhs/rhs operands and whether to respect case
+        ///
+        public static object GreaterThan(object lhs, object rhs, bool ignoreCase)
+        {
+            return ComparisonOperation(lhs, rhs, ignoreCase, "-gt");
+        }
+
+
+        ///
+        /// GreaterThanEquals:
+        ///     - method for handling -ge, -ige, -cge operations
+        ///     - called with unpacked lhs/rhs operands and whether to respect case
+        ///
+        public static object GreaterThanEquals(object lhs, object rhs, bool ignoreCase)
+        {
+            return ComparisonOperation(lhs, rhs, ignoreCase, "-ge");
+        }
+
+
+        ///
+        /// LessThan:
+        ///     - method for handling -lt, -ilt, -clt operations
+        ///     - called with unpacked lhs/rhs operands and whether to respect case
+        ///
+        public static object LessThan(object lhs, object rhs, bool ignoreCase)
+        {
+            return ComparisonOperation(lhs, rhs, ignoreCase, "-lt");
+        }
+
+
+        ///
+        /// LessThanEquals:
+        ///     - method for handling -le, -ile, -cle operations
+        ///     - called with unpacked lhs/rhs operands and whether to respect case
+        ///
+        public static object LessThanEquals(object lhs, object rhs, bool ignoreCase)
+        {
+            return ComparisonOperation(lhs, rhs, ignoreCase, "-le");
+        }
+
+
+        ///
+        /// ComparisonOperation:
+        ///     - implements type mapping and ordering (primitive overload resolution)
+        ///
+        ///     7.9 Relational and type-testing Operators
+        ///     Description:
+        ///
+        ///         Rules in Order:
+        ///             - LHS is String then (String op String)
+        ///             - LHS is DateTiem then (DateTime op DateTime)
+        ///             - LHS or RHS is Double then (Double op Double)
+        ///             - LHS or RHS is Float then (Float op Float)
+        ///             - LHS or RHS is Long then (Long op Long)
+        ///             - LHS or RHS is Int then (Int op Int)
+        ///             - LHS or RHS is Char then (Char op Char)
+        ///             - LHS or RHS is Byte then (Byte op Byte)
+        ///             - LHS or RHS is Bool then (Bool op Bool)
+        ///         Overload resolution is determined per 7.2.4.
+        ///         This operator is left associative.
+        ///
+        ///      Examples: See ReferenceTests.RelationshipOperatorTests_7_9
+        ///
+        ///         Operations:  gt, gte, lt, lte, eq, neq
+        ///
+        ///         string op string, string op *
+        ///         datetime op datetime, datetime op *
+        ///         double op double, double op *
+        ///         float op float, float op *
+        ///         long op long, long op *
+        ///         int op int, int op *
+        ///         char op char, char op *
+        ///         byte op byte, byte op *
+        ///         bool op bool, bool op *
+        ///
+        private static object ComparisonOperation(
+                object leftValue,
+                object rightValue,
+                bool ignoreCase,
+                string op)
+        {
+            var lhs = PSObject.Unwrap(leftValue);
+            var rhs = PSObject.Unwrap(rightValue);
+
+            ///
+            /// allow some null cases to be handled by RHS operand type
+            ///
+            if (((lhs == null) &&
+                 ((rhs == null) ||
+                  (rhs is string) ||
+                  (rhs is DateTime) ||
+                  (rhs is bool))) ||
+                (lhs is string))
+            {
+                Func<IComparer<string>, string, string, object> checkedOp = GetComparerOp<string>(op);
+                return Compare<string>(getStringComparer(ignoreCase), lhs, rhs, op, checkedOp);
+            }
+
+            if (((lhs == null) && (rhs is DateTime)) ||
+                (lhs is DateTime))
+            {
+                return Compare<DateTime>(lhs, rhs, op);
+            }
+
+            ///
+            /// these cases will automatically handle the null case if the RHS operand is of the correct type
+            ///
+            if (lhs is double || rhs is double) { return Compare<double>(lhs, rhs, op); }
+            if (lhs is float || rhs is float) { return Compare<float>(lhs, rhs, op); }
+            if (lhs is long || rhs is long) { return Compare<long>(lhs, rhs, op); }
+            if (lhs is int || rhs is int) { return Compare<int>(lhs, rhs, op); }
+            if (lhs is char || rhs is char) { return Compare<char>(lhs, rhs, op); }
+            if (lhs is byte || rhs is byte) { return Compare<byte>(lhs, rhs, op); }
+            if (lhs is bool || rhs is bool) { return Compare<bool>(lhs, rhs, op); }
+
+            // array comparison
+            // hashtable comparison
+            throw new NotImplementedException(String.Format("{0} {1} {2}", lhs, op, rhs));
+        }
+
+
+        ///
+        /// getStringComparer:
+        ///     returns an IComparer<T> for StringComparer based on the case sensititivity flag
+        ///     used in the -i*, -c* relationship comparison operators
+        ///
+        private static IComparer<string> getStringComparer(bool ignoreCase)
+        {
+            return ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        }
+
+
+        ///
+        /// Compare<T>:
+        ///     - generic case Comparison
+        ///
+        private static object Compare<T>(object lhs, object rhs, string op)
+        {
+            Func<IComparer<T>, T, T, object> checkedOp = GetComparerOp<T>(op);
+            return Compare<T>(Comparer<T>.Default, lhs, rhs, op, checkedOp);
+        }
+
+
+        ///
+        /// Compare<T>:
+        ///     - generic comparison function
+        ///     - callers provide the type specific comparer
+        ///     - depends on LanguagePrimitives.ConvertTo for type conversion
+        ///     - type conversion can fail in some cases (such as to DateTime)
+        ///     - performs the actual comparison operation as +ve, 0, -ve check in checkOp
+        ///
+        private static object Compare<T>(
+                IComparer<T> comparer,
+                object lhs,
+                object rhs,
+                string op,
+                Func<IComparer<T>, T, T, object> checkedOp)
+        {
+            try
+            {
+                var left = LanguagePrimitives.ConvertTo<T>(lhs);
+                var right = LanguagePrimitives.ConvertTo<T>(rhs);
+                return checkedOp(comparer, left, right);
+            }
+            catch (Exception ex)
+            {
+                ThrowInvalidComparisonOperationException(lhs, rhs, op, ex);
+            }
+            return null;
+        }
+
+
+        ///
+        /// constructs invalid comparison errors similar to Posh
+        ///
+        private static void ThrowInvalidComparisonOperationException(
+                object left,
+                object right,
+                string op,
+                Exception ex)
+        {
+            var msg = String.Format("Could not compare \"{0}\" to \"{1}\". {2}", left, right, ex.Message);
+            throw new PSInvalidOperationException(msg);
+        }
+    }
+}
+

--- a/Source/System.Management/Pash/Implementation/ComparisonOperations.cs
+++ b/Source/System.Management/Pash/Implementation/ComparisonOperations.cs
@@ -138,8 +138,14 @@ namespace System.Management.Pash.Implementation
                   (rhs is bool))) ||
                 (lhs is string))
             {
+                var lhsInverted = lhs;
+                var rhsInverted = rhs;
+
+                if (lhs is string) lhsInverted = StringExtensions.InvertCase(lhs as string);
+                if (rhs is string) rhsInverted = StringExtensions.InvertCase(rhs as string);
+
                 Func<IComparer<string>, string, string, object> checkedOp = GetComparerOp<string>(op);
-                return Compare<string>(getStringComparer(ignoreCase), lhs, rhs, op, checkedOp);
+                return Compare<string>(getStringComparer(ignoreCase), lhsInverted, rhsInverted, op, checkedOp);
             }
 
             if (((lhs == null) && (rhs is DateTime)) ||

--- a/Source/System.Management/Pash/Implementation/ComparisonOperations.cs
+++ b/Source/System.Management/Pash/Implementation/ComparisonOperations.cs
@@ -7,7 +7,6 @@ using System.Management.Automation;
 namespace System.Management.Pash.Implementation
 {
     ///
-    /// ComparisonOperations:
     ///     - class implementing comparison operations in the language
     ///     - uses IComparer<T> interface and default implementations to perform comparisons
     ///     - handles type mapping for objects to specific comparers based on LHS type
@@ -42,7 +41,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// GreaterThan:
         ///     - method for handling -gt, -igt, -cgt operations
         ///     - called with unpacked lhs/rhs operands and whether to respect case
         ///
@@ -53,7 +51,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// GreaterThanEquals:
         ///     - method for handling -ge, -ige, -cge operations
         ///     - called with unpacked lhs/rhs operands and whether to respect case
         ///
@@ -64,7 +61,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// LessThan:
         ///     - method for handling -lt, -ilt, -clt operations
         ///     - called with unpacked lhs/rhs operands and whether to respect case
         ///
@@ -75,7 +71,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// LessThanEquals:
         ///     - method for handling -le, -ile, -cle operations
         ///     - called with unpacked lhs/rhs operands and whether to respect case
         ///
@@ -86,7 +81,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// ComparisonOperation:
         ///     - implements type mapping and ordering (primitive overload resolution)
         ///
         ///     7.9 Relational and type-testing Operators
@@ -172,7 +166,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// getStringComparer:
         ///     returns an IComparer<T> for StringComparer based on the case sensititivity flag
         ///     used in the -i*, -c* relationship comparison operators
         ///
@@ -183,7 +176,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// Compare<T>:
         ///     - generic case Comparison
         ///
         private static object Compare<T>(object lhs, object rhs, string op)
@@ -194,7 +186,6 @@ namespace System.Management.Pash.Implementation
 
 
         ///
-        /// Compare<T>:
         ///     - generic comparison function
         ///     - callers provide the type specific comparer
         ///     - depends on LanguagePrimitives.ConvertTo for type conversion

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -67,9 +67,6 @@ namespace System.Management.Pash.Implementation
             if (leftOperand is PSObject) leftOperand = ((PSObject)leftOperand).BaseObject;
             if (rightOperand is PSObject) rightOperand = ((PSObject)rightOperand).BaseObject;
 
-            int? leftOperandInt = leftOperand is int ? ((int?)leftOperand) : null;
-            int? rightOperandInt = rightOperand is int ? ((int?)rightOperand) : null;
-
             switch (binaryExpressionAst.Operator)
             {
                 case TokenKind.DotDot:
@@ -107,12 +104,18 @@ namespace System.Management.Pash.Implementation
                     return !Object.Equals(leftOperand, rightOperand);
 
                 case TokenKind.Igt:
-                    if (leftOperandInt.HasValue) return leftOperandInt > rightOperandInt;
-                    throw new NotImplementedException(binaryExpressionAst.ToString());
+                case TokenKind.Cgt:
+                    return ComparisonOperations.GreaterThan(
+                            leftOperand,
+                            rightOperand,
+                            (TokenKind.Cgt != binaryExpressionAst.Operator));
 
                 case TokenKind.Ige:
-                    if (leftOperandInt.HasValue) return leftOperandInt >= rightOperandInt;
-                    throw new NotImplementedException(binaryExpressionAst.ToString());
+                case TokenKind.Cge:
+                    return ComparisonOperations.GreaterThanEquals(
+                            leftOperand,
+                            rightOperand,
+                            (TokenKind.Cge != binaryExpressionAst.Operator));
 
                 case TokenKind.Or:
                     return LanguagePrimitives.ConvertTo<bool>(leftOperand) || LanguagePrimitives.ConvertTo<bool>(rightOperand);
@@ -124,12 +127,18 @@ namespace System.Management.Pash.Implementation
                     return LanguagePrimitives.ConvertTo<bool>(leftOperand) && LanguagePrimitives.ConvertTo<bool>(rightOperand);
 
                 case TokenKind.Ilt:
-                    if (leftOperandInt.HasValue) return leftOperandInt < rightOperandInt;
-                    throw new NotImplementedException(binaryExpressionAst.ToString());
+                case TokenKind.Clt:
+                    return ComparisonOperations.LessThan(
+                            leftOperand,
+                            rightOperand,
+                            (TokenKind.Clt != binaryExpressionAst.Operator));
 
                 case TokenKind.Ile:
-                    if (leftOperandInt.HasValue) return leftOperandInt <= rightOperandInt;
-                    throw new NotImplementedException(binaryExpressionAst.ToString());
+                case TokenKind.Cle:
+                    return ComparisonOperations.LessThanEquals(
+                            leftOperand,
+                            rightOperand,
+                            (TokenKind.Clt != binaryExpressionAst.Operator));
 
                 case TokenKind.Band:
                     return BitwiseOperation.And(leftOperand, rightOperand);
@@ -183,10 +192,6 @@ namespace System.Management.Pash.Implementation
                 case TokenKind.Iin:
                 case TokenKind.Inotin:
                 case TokenKind.Isplit:
-                case TokenKind.Cge:
-                case TokenKind.Cgt:
-                case TokenKind.Clt:
-                case TokenKind.Cle:
                 case TokenKind.Clike:
                 case TokenKind.Cnotlike:
                 case TokenKind.Creplace:

--- a/Source/System.Management/Pash/Implementation/StringExtensions.cs
+++ b/Source/System.Management/Pash/Implementation/StringExtensions.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+
+namespace System.Management.Pash.Implementation
+{
+    public static partial class StringExtensions
+    {
+        public static String InvertCase(this String t)
+        {
+            Func<char, String> selector =
+                c => (char.IsUpper(c) ? char.ToLower(c) : char.ToUpper(c)).ToString();
+
+            return t.Select(selector).Aggregate(String.Concat);
+        }
+    }
+}

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -531,6 +531,7 @@
     <Compile Include="Pash\Implementation\IncludeExcludeFilter.cs" />
     <Compile Include="Pash\Implementation\SecureStringReader.cs" />
     <Compile Include="Pash\Implementation\CredentialMessages.cs" />
+    <Compile Include="Pash\Implementation\StringExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -501,6 +501,7 @@
     <Compile Include="Pash\Implementation\TabExpansionProvider.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Pash\Implementation\ArithmeticOperations.cs" />
+    <Compile Include="Pash\Implementation\ComparisonOperations.cs" />
     <Compile Include="Automation\FlowControlException.cs" />
     <Compile Include="Automation\ExitException.cs" />
     <Compile Include="Automation\LoopFlowException.cs" />


### PR DESCRIPTION
This pull request aims to add support for -gt, -lt, -ge, -le and (i/c) variants for most primitive types.  This tracks well against the built-in Powershell functionality via the added ReferenceTests.  It is implemented via the various IComparer<T>::Default or case relevant StringComparer functions.  There are two added reference tests that are failing on the Pash side still.  I wasn't sure how best to handle them at this time.

"a" -clt "A" == False in Pash, is True in Powershell
"a" -cge "A" == True in Pash, is False in Powershell
"a" -cgt "A" == True in Pash, is False in Powershell

These are all related and it looks like Powershell is forcing lowercase to be less than uppercase.  Most days of the week "A" == 65 and "a" == 97 and "a" > "A" when comparing these as ASCII ordinals.  I'm happy to continue to preserve the output of StringComparer instead of forcing the same Powershell behaviour.  The floor is open for discussion on this.  At a minimum if we keep this behaviour I should mark these specific tests as failing/ignoring (how do we do this)?

resolves: #373