### PR TITLE
LanguagePrimitives: Don't enumerate XmlNodes

### DIFF
--- a/Source/Microsoft.PowerShell.Commands.Utility/OutCommandBase.cs
+++ b/Source/Microsoft.PowerShell.Commands.Utility/OutCommandBase.cs
@@ -36,6 +36,11 @@ namespace Microsoft.PowerShell.Commands
                 }
                 data = _formatManager.Process(InputObject);
             }
+            // make sure we have data to process
+            if (data.Count == 0)
+            {
+                return;
+            }
             // although we might have multiple FormatData objects, they are all derived from a single data object
             // so all should be formatted in the same shape
             var processor = FormatProcessor.Get(OutputWriter, data[0].Shape);

--- a/Source/ReferenceTests/API/LanguagePrimitivesTests.cs
+++ b/Source/ReferenceTests/API/LanguagePrimitivesTests.cs
@@ -4,6 +4,9 @@ using System.Management.Automation;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
+using System.Collections.Generic;
+using System.Collections;
+using System.Xml;
 
 namespace ReferenceTests.API
 {
@@ -260,6 +263,34 @@ namespace ReferenceTests.API
         {
             var result = LanguagePrimitives.ConvertTo(null, typeof(PSObject));
             Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void StringsAreNotEnumerated()
+        {
+            Assert.That(LanguagePrimitives.GetEnumerator("foo"), Is.Null);
+        }
+
+        [Test]
+        public void DictionariesAreNotEnumerated()
+        {
+            var testDict = new Dictionary<string, object> { { "foo", 123 } };
+            Assert.That(LanguagePrimitives.GetEnumerator(testDict), Is.Null);
+        }
+
+        [Test]
+        public void HashtablesAreNotEnumerated()
+        {
+            var testTable = new Hashtable { { "foo", 123 } };
+            Assert.That(LanguagePrimitives.GetEnumerator(testTable), Is.Null);
+        }
+
+        [Test]
+        public void XmlNodesAreNotEnumerated()
+        {
+            var xml = new XmlDocument();
+            xml.LoadXml("<a><b>foo</b><b>bar</b></a>");
+            Assert.That(LanguagePrimitives.GetEnumerator(xml), Is.Null);
         }
     }
 }


### PR DESCRIPTION
I made `LanguagePrimitives` more flexible concerning which types not to enumerate.