### PR TITLE
Fix fail when importing a module with cmdlets twice

### DIFF
--- a/Source/ReferenceTests/Commands/ImportModuleTests.cs
+++ b/Source/ReferenceTests/Commands/ImportModuleTests.cs
@@ -30,6 +30,17 @@ namespace ReferenceTests.Commands
         }
 
         [Test]
+        public void ImportingAssemblyModuleTwiceDoesntThrow()
+        {
+            var cmd = NewlineJoin(
+                "$m1 = Import-Module '" + BinaryTestModule + "' -PassThru",
+                "$m2 = Import-Module '" + BinaryTestModule + "' -PassThru",
+                "[object]::ReferenceEquals($m1, $m2)"
+            );
+            ExecuteAndCompareTypedResult(cmd, true);
+        }
+
+        [Test]
         public void CanImportManifestModule()
         {
             var module = CreateFile(CreateManifest(null, "Me", "FooComp", "1.0"), "psd1");

--- a/Source/System.Management/Pash/Implementation/CmdletIntrinsics.cs
+++ b/Source/System.Management/Pash/Implementation/CmdletIntrinsics.cs
@@ -14,6 +14,12 @@ namespace Pash.Implementation
 
         public void Set(CmdletInfo cmdlet)
         {
+            // manually remove the cmdlet if already imported, because the normale "overwrite" flag doesn't work,
+            // as the CmdletInfo doesn't support ItemOptions
+            if (Scope.HasLocal(cmdlet))
+            {
+                Scope.RemoveLocal(cmdlet.ItemName);
+            }
             Scope.SetLocal(cmdlet, false);
         }
 


### PR DESCRIPTION
Because the `CmdletInfo` objects weren't overwritten in the SessionState, re-importing a module with cmdlets failed with an exception.