### PR TITLE
Enabling an easy version of the Clear-Host function

### DIFF
--- a/Source/System.Management/Automation/Runspaces/InitialSessionState.cs
+++ b/Source/System.Management/Automation/Runspaces/InitialSessionState.cs
@@ -256,11 +256,25 @@ namespace System.Management.Automation.Runspaces
             /* not yet working
             initialSessionState.Commands.Add(new SessionStateFunctionEntry("prompt", "$(if (test-path variable:/PSDebugContext) { '[DBG]: ' } else { '' }) + 'PS ' + $(Get-Location) + $(if ($nestedpromptlevel -ge 1) { '>>' }) + '> '"));
             initialSessionState.Commands.Add(new SessionStateFunctionEntry("ImportSystemModules", "\r\n $SnapIns = @(Get-PSSnapin -Registered -ErrorAction SilentlyContinue)"));
-            initialSessionState.Commands.Add(new SessionStateFunctionEntry("Clear-Host", "$space = New-Object System.Management.Automation.Host.BufferCell\n$space.Character = ' '\n$space.ForegroundColor = $host.ui.rawui.ForegroundColor\n$space.BackgroundColor = $host.ui.rawui.BackgroundColor\n$rect = New-Object System.Management.Automation.Host.Rectangle\n$rect.Top = $rect.Bottom = $rect.Right = $rect.Left = -1\n$origin = New-Object System.Management.Automation.Host.Coordinates\n$Host.UI.RawUI.CursorPosition = $origin\n$Host.UI.RawUI.SetBufferContents($rect, $space)\n"));
             initialSessionState.Commands.Add(new SessionStateFunctionEntry("more", "param([string[]]$paths)\n\n$OutputEncoding = [System.Console]::OutputEncoding\n\nif($paths)\n{\n    foreach ($file in $paths)\n    {\n        Get-Content $file | more.com\n    }\n}\nelse\n{\n    $input | more.com\n}\n"));
             initialSessionState.Commands.Add(new SessionStateFunctionEntry("Get-Verb", "\r\nparam(\r\n    [Parameter(ValueFromPipeline=$true)]\r\n    [string[]]\r\n    $verb = '*'\r\n)\r\nbegin {\r\n    $allVerbs = [PSObject].Assembly.GetTypes() |\r\n        Where-Object {$_.Name -match '^Verbs.'} |\r\n        Get-Member -type Properties -static |\r\n        Select-Object @{\r\n            Name='Verb'\r\n            Expression = {$_.Name}\r\n        }, @{\r\n            Name='Group'\r\n            Expression = {\r\n                $str = \"$($_.TypeName)\"\r\n                $str.Substring($str.LastIndexOf('Verbs') + 5)\r\n            }                \r\n        }        \r\n}\r\nprocess {\r\n    foreach ($v in $verb) {\r\n        $allVerbs | Where-Object { $_.Verb -like $v }\r\n    }       \r\n}\r\n"));
             */
             initialSessionState.Commands.Add(new SessionStateFunctionEntry("Prompt", "'PASH ' + (Get-Location) + '> '"));
+            /* TODO: as soon as we have #HostSupport for other hosts than our console, we need to enable the following
+            /       function and implement the proper functions/structs
+            initialSessionState.Commands.Add(new SessionStateFunctionEntry("Clear-Host",
+                "$space = New-Object System.Management.Automation.Host.BufferCell\n" +
+                "$space.Character = ' '\n" +
+                "$space.ForegroundColor = $host.ui.rawui.ForegroundColor\n" +
+                "$space.BackgroundColor = $host.ui.rawui.BackgroundColor\n" +
+                "$rect = New-Object System.Management.Automation.Host.Rectangle\n" +
+                "$rect.Top = $rect.Bottom = $rect.Right = $rect.Left = -1\n" +
+                "$origin = New-Object System.Management.Automation.Host.Coordinates\n" +
+                "$Host.UI.RawUI.CursorPosition = $origin\n" +
+                "$Host.UI.RawUI.SetBufferContents($rect, $space)\n")
+            );
+            */
+            initialSessionState.Commands.Add(new SessionStateFunctionEntry("Clear-Host", "[Console]::Clear()"));
             // TODO:
             // "TabExpansion"
             // "help"


### PR DESCRIPTION
This has to be implemented differently once we support different hosts.
But for the sake of simplicity, I chose to implement it this way for now.

There is obviously no unit test as it's a UI-only thing with platform specific implementation, that we cannot test with out existing testing framework.
Fixes #382.