### PR TITLE
Command elements postprocessing

### DIFF
--- a/Source/System.Management.Tests/Ast/Ast.Tests.cs
+++ b/Source/System.Management.Tests/Ast/Ast.Tests.cs
@@ -2233,10 +2233,9 @@ ls
             }
 
             /// <summary>
-            /// <code>ping 8.8.8.8</code> parses as <code>ping ((8.8).8).8</code> or
-            /// <code>ping 8.8 .8 .8</code> according to the spec and initial implementation;
-            /// neither are good and neither matches PowerShell behavior. In reality it is
-            /// reasonable to represent it as <code>ping "8.8.8.8"</code>. 
+            /// <code>ping 8.8.8.8</code> parses as <code>ping ((8.8).8).8</code> or <code>ping 8.8 .8 .8</code>
+            /// according to the spec and initial implementation; neither are good and neither matches PowerShell
+            /// behavior. In reality it is reasonable to represent it as <code>ping "8.8.8.8"</code>.
             /// </summary>
             [Test]
             public void MergeCommandElementsTest()
@@ -2244,6 +2243,17 @@ ls
                 var commandAst = Parse("ping 8.8.8.8");
                 Assert.AreEqual(2, commandAst.CommandElements.Count);
                 Assert.AreEqual("8.8.8.8", commandAst.CommandElements[1].Value);
+            }
+
+            /// <summary>
+            /// The same as the previous, but with real member access operator instead of numeric literals.
+            /// </summary>
+            [Test]
+            public void MemberExpressionProcessing()
+            {
+                var commandAst = Parse("ping 8.8.ToString.ToString");
+                Assert.AreEqual(2, commandAst.CommandElements.Count);
+                Assert.AreEqual("8.8.ToString.ToString", commandAst.CommandElements[1].Value);
             }
         }
     }

--- a/Source/System.Management.Tests/Ast/Ast.Tests.cs
+++ b/Source/System.Management.Tests/Ast/Ast.Tests.cs
@@ -2231,6 +2231,20 @@ ls
                 Assert.AreEqual(RedirectionStream.Error, redirectAst.FromStream);
                 Assert.AreEqual("out.txt", redirectFileNameAst.Value);
             }
+
+            /// <summary>
+            /// <code>ping 8.8.8.8</code> parses as <code>ping ((8.8).8).8</code> or
+            /// <code>ping 8.8 .8 .8</code> according to the spec and initial implementation;
+            /// neither are good and neither matches PowerShell behavior. In reality it is
+            /// reasonable to represent it as <code>ping "8.8.8.8"</code>. 
+            /// </summary>
+            [Test]
+            public void MergeCommandElementsTest()
+            {
+                var commandAst = Parse("ping 8.8.8.8");
+                Assert.AreEqual(2, commandAst.CommandElements.Count);
+                Assert.AreEqual("8.8.8.8", commandAst.CommandElements[1].Value);
+            }
         }
     }
 }

--- a/Source/System.Management.Tests/Ast/ExpectedScriptExtent.cs
+++ b/Source/System.Management.Tests/Ast/ExpectedScriptExtent.cs
@@ -14,6 +14,7 @@ namespace ParserTests
         public int StartLineNumber { get; set; }
         public int StartOffset { get; set; }
         public string Text { get; set; }
+        public string FullText { get { return Text; } }
 
         public void AssertAreEqual(IScriptExtent extent)
         {

--- a/Source/System.Management/Automation/Language/ConstantExpressionAst.cs
+++ b/Source/System.Management/Automation/Language/ConstantExpressionAst.cs
@@ -21,5 +21,17 @@ namespace System.Management.Automation.Language
         {
             return this.Value.ToString();
         }
+
+        /// <summary>
+        /// Member access expansion will be delayed when the constant literal is a part of command
+        /// parameters. This property should return <c>true</c> for numeric constants so commands
+        /// like <code>ping 8.8.8.8</code> will be processed correctly (it will be casted to
+        /// string instead of treating it as a two member accessors a-la <code>(((8.8).8).8)</code>
+        /// or subsequent numeric literals such as <code>8.8 .8 .8</code>.
+        /// </summary>
+        public virtual bool DelayMemberAccessExpansion
+        {
+            get { return true; }
+        }
     }
 }

--- a/Source/System.Management/Automation/Language/IScriptExtent.cs
+++ b/Source/System.Management/Automation/Language/IScriptExtent.cs
@@ -14,6 +14,15 @@ namespace System.Management.Automation.Language
         int StartLineNumber { get; }
         int StartOffset { get; }
         IScriptPosition StartScriptPosition { get; }
+
+        /// <summary>
+        /// Text of the root element.
+        /// </summary>
         string Text { get; }
+
+        /// <summary>
+        /// Text of the whole subtree.
+        /// </summary>
+        string FullText { get; }
     }
 }

--- a/Source/System.Management/Automation/Language/StringConstantExpressionAst.cs
+++ b/Source/System.Management/Automation/Language/StringConstantExpressionAst.cs
@@ -51,5 +51,10 @@ namespace System.Management.Automation.Language
                     throw new InvalidOperationException();
             }
         }
+
+        public override bool DelayMemberAccessExpansion
+        {
+            get { return false; }
+        }
     }
 }

--- a/Source/System.Management/Automation/Language/StringConstantExpressionAst.cs
+++ b/Source/System.Management/Automation/Language/StringConstantExpressionAst.cs
@@ -54,7 +54,7 @@ namespace System.Management.Automation.Language
 
         public override bool DelayMemberAccessExpansion
         {
-            get { return false; }
+            get { return StringConstantType == StringConstantType.BareWord; }
         }
     }
 }

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -2226,7 +2226,7 @@ namespace Pash.ParserIntrinsics
                                                        lastParameter.ParameterName));
             }
 
-            return elementAsts;
+            return PostprocessCommandElements(elementAsts);
         }
 
         ExpressionAst BuildCommandArgumentAstFromCommandElement(ParseTreeNode parseTreeNode, string parameterName)
@@ -2269,6 +2269,63 @@ namespace Pash.ParserIntrinsics
 
             return new CommandParameterAst(new ScriptExtent(parseTreeNode), parameterName, null,
                                            new ScriptExtent(parseTreeNode), requiresArgument);
+        }
+
+        IEnumerable<CommandElementAst> PostprocessCommandElements(IEnumerable<CommandElementAst> elements)
+        {
+            var queue = new Queue<CommandElementAst>(elements);
+            while (queue.Count > 0)
+            {
+                var element = queue.Dequeue();
+                var constant = element as ConstantExpressionAst;
+                if (constant != null && constant.DelayMemberAccessExpansion && queue.Count > 0)
+                {
+                    // Is the member access should be delayed, then merge all subsequent arguments
+                    // that were started with . or :: and weren't separated with any space. It's a
+                    // deviation from the spec, but PowerShell does the same.
+                    var next = queue.Peek();
+                    while (next != null && CanMergeMemberAccessExpressions(element, next))
+                    {
+                        next = queue.Dequeue();
+
+                        element = MergeMemberAccessExpressions(element, next);
+
+                        next = queue.Count > 0 ? queue.Peek() : null;
+                    }
+                }
+                
+                yield return element;
+            }
+        }
+
+        bool CanMergeMemberAccessExpressions(CommandElementAst left, CommandElementAst right)
+        {
+            var rightExtent = right.Extent;
+            return left.Extent.EndOffset == rightExtent.StartOffset
+                && (rightExtent.Text.StartsWith(".") || rightExtent.Text.StartsWith("::"));
+        }
+
+        CommandElementAst MergeMemberAccessExpressions(CommandElementAst left, CommandElementAst right)
+        {
+            var leftExtent = left.Extent;
+            var rightExtent = right.Extent;
+            if (leftExtent.EndOffset != rightExtent.StartOffset)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            string value = leftExtent.Text + rightExtent.Text;
+            var extent = new ScriptExtent(
+                new SourceSpan(
+                    new SourceLocation(leftExtent.StartOffset, leftExtent.StartLineNumber,
+                        leftExtent.StartColumnNumber), right.Extent.EndOffset - leftExtent.StartOffset),
+                0,
+                0,
+                value);
+            return new StringConstantExpressionAst(
+                extent,
+                value,
+                StringConstantType.BareWord);
         }
 
         IEnumerable<RedirectionAst> BuildCommandElementRedirectionAsts(ParseTreeNode parseTreeNode)

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -2277,55 +2277,23 @@ namespace Pash.ParserIntrinsics
             while (queue.Count > 0)
             {
                 var element = queue.Dequeue();
-                var constant = element as ConstantExpressionAst;
-                if (constant != null && constant.DelayMemberAccessExpansion && queue.Count > 0)
+                var constant = GetRootConstantExpression(element);
+                if (constant != null && constant.DelayMemberAccessExpansion)
                 {
-                    // Is the member access should be delayed, then merge all subsequent arguments
-                    // that were started with . or :: and weren't separated with any space. It's a
-                    // deviation from the spec, but PowerShell does the same.
-                    var next = queue.Peek();
-                    while (next != null && CanMergeMemberAccessExpressions(element, next))
+                    // First of all, flatten expressions such as 8.8.ToString.ToString as PowerShell does.
+                    element = ExpressionAsStringConstant(element);
+                    while (queue.Count > 0 && CanMergeMemberAccessExpressions(element, queue.Peek()))
                     {
-                        next = queue.Dequeue();
-
+                        // If the member access should be delayed, then merge all subsequent arguments that were
+                        // started with . or :: and weren't separated with any space. It's a deviation from the spec,
+                        // but PowerShell does the same.
+                        var next = queue.Dequeue();
                         element = MergeMemberAccessExpressions(element, next);
-
-                        next = queue.Count > 0 ? queue.Peek() : null;
                     }
                 }
                 
                 yield return element;
             }
-        }
-
-        bool CanMergeMemberAccessExpressions(CommandElementAst left, CommandElementAst right)
-        {
-            var rightExtent = right.Extent;
-            return left.Extent.EndOffset == rightExtent.StartOffset
-                && (rightExtent.Text.StartsWith(".") || rightExtent.Text.StartsWith("::"));
-        }
-
-        CommandElementAst MergeMemberAccessExpressions(CommandElementAst left, CommandElementAst right)
-        {
-            var leftExtent = left.Extent;
-            var rightExtent = right.Extent;
-            if (leftExtent.EndOffset != rightExtent.StartOffset)
-            {
-                throw new ArgumentOutOfRangeException();
-            }
-
-            string value = leftExtent.Text + rightExtent.Text;
-            var extent = new ScriptExtent(
-                new SourceSpan(
-                    new SourceLocation(leftExtent.StartOffset, leftExtent.StartLineNumber,
-                        leftExtent.StartColumnNumber), right.Extent.EndOffset - leftExtent.StartOffset),
-                0,
-                0,
-                value);
-            return new StringConstantExpressionAst(
-                extent,
-                value,
-                StringConstantType.BareWord);
         }
 
         IEnumerable<RedirectionAst> BuildCommandElementRedirectionAsts(ParseTreeNode parseTreeNode)
@@ -2345,6 +2313,52 @@ namespace Pash.ParserIntrinsics
             }
 
             return redirectionAsts;
+        }
+
+        private static IScriptExtent MergeExtents(IScriptExtent left, IScriptExtent right)
+        {
+            if (left.EndOffset != right.StartOffset)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            string value = left.Text + right.Text;
+            return new ScriptExtent(
+                new SourceSpan(
+                    new SourceLocation(left.StartOffset, left.StartLineNumber,
+                        left.StartColumnNumber), right.EndOffset - left.StartOffset),
+                0,
+                0,
+                value);
+        }
+
+        private static ConstantExpressionAst GetRootConstantExpression(CommandElementAst element)
+        {
+            while (element is MemberExpressionAst)
+            {
+                var memberExpression = (MemberExpressionAst)element;
+                element = memberExpression.Expression;
+            }
+
+            return element as ConstantExpressionAst;
+        }
+
+        private static ConstantExpressionAst ExpressionAsStringConstant(Ast element)
+        {
+            return new StringConstantExpressionAst(element.Extent, element.Extent.Text, StringConstantType.BareWord);
+        }
+
+        private static bool CanMergeMemberAccessExpressions(Ast left, Ast right)
+        {
+            var rightExtent = right.Extent;
+            return left.Extent.EndOffset == rightExtent.StartOffset
+                && (rightExtent.Text.StartsWith(".") || rightExtent.Text.StartsWith("::"));
+        }
+
+        private static StringConstantExpressionAst MergeMemberAccessExpressions(Ast left, CommandElementAst right)
+        {
+            var extent = MergeExtents(left.Extent, right.Extent);
+            return new StringConstantExpressionAst(extent, extent.Text, StringConstantType.BareWord);
         }
 
         private IEnumerable<RedirectionAst> BuildRedirectionsAst(ParseTreeNode parseTreeNode)

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -2322,7 +2322,7 @@ namespace Pash.ParserIntrinsics
                 throw new ArgumentOutOfRangeException();
             }
 
-            string value = left.Text + right.Text;
+            string value = left.FullText + right.FullText;
             return new ScriptExtent(
                 new SourceSpan(
                     new SourceLocation(left.StartOffset, left.StartLineNumber,

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -2281,7 +2281,7 @@ namespace Pash.ParserIntrinsics
                 if (constant != null && constant.DelayMemberAccessExpansion)
                 {
                     // First of all, flatten expressions such as 8.8.ToString.ToString as PowerShell does.
-                    element = ExpressionAsStringConstant(element);
+                    element = ToConstantExpression(element);
                     while (queue.Count > 0 && CanMergeMemberAccessExpressions(element, queue.Peek()))
                     {
                         // If the member access should be delayed, then merge all subsequent arguments that were
@@ -2343,9 +2343,12 @@ namespace Pash.ParserIntrinsics
             return element as ConstantExpressionAst;
         }
 
-        private static ConstantExpressionAst ExpressionAsStringConstant(Ast element)
+        private static ConstantExpressionAst ToConstantExpression(Ast element)
         {
-            return new StringConstantExpressionAst(element.Extent, element.Extent.Text, StringConstantType.BareWord);
+            return element as ConstantExpressionAst ?? new StringConstantExpressionAst(
+                element.Extent,
+                element.Extent.FullText,
+                StringConstantType.BareWord);
         }
 
         private static bool CanMergeMemberAccessExpressions(Ast left, Ast right)

--- a/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Management.Automation.Language;
 using Irony.Parsing;
@@ -89,8 +87,18 @@ namespace Pash.ParserIntrinsics
                     return _text;
                 }
 
-                return GetParseTreeNodeText(_parseTreeNode);
+                if (_parseTreeNode == null)
+                {
+                    return string.Empty;
+                }
+
+                return _parseTreeNode.FindTokenAndGetText() ?? string.Empty;
             }
+        }
+
+        string IScriptExtent.FullText
+        {
+            get { return GetParseTreeNodeText(_parseTreeNode); }
         }
 
         private SourceLocation Location

--- a/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
@@ -12,9 +12,11 @@ namespace Pash.ParserIntrinsics
     {
         readonly ParseTreeNode _parseTreeNode;
         readonly SourceSpan _span;
+        private readonly string _text;
 
-        public ScriptExtent(SourceSpan origSpan, int startOffset, int endOffset)
+        public ScriptExtent(SourceSpan origSpan, int startOffset, int endOffset, string textValue = null)
         {
+            _text = textValue;
             if (startOffset == 0 && endOffset == 0)
             {
                 _span = origSpan;
@@ -82,6 +84,11 @@ namespace Pash.ParserIntrinsics
         {
             get
             {
+                if (_text != null)
+                {
+                    return _text;
+                }
+
                 if (_parseTreeNode == null)
                 {
                     return string.Empty;

--- a/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
@@ -98,7 +98,7 @@ namespace Pash.ParserIntrinsics
 
         string IScriptExtent.FullText
         {
-            get { return GetParseTreeNodeText(_parseTreeNode); }
+            get { return _text ?? GetParseTreeNodeText(_parseTreeNode); }
         }
 
         private SourceLocation Location

--- a/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/ScriptExtent.cs
@@ -89,11 +89,7 @@ namespace Pash.ParserIntrinsics
                     return _text;
                 }
 
-                if (_parseTreeNode == null)
-                {
-                    return string.Empty;
-                }
-                return this._parseTreeNode.FindTokenAndGetText() ?? string.Empty;
+                return GetParseTreeNodeText(_parseTreeNode);
             }
         }
 
@@ -105,6 +101,35 @@ namespace Pash.ParserIntrinsics
         private SourceSpan Span
         {
             get { return _span; }
+        }
+
+        private static string GetParseTreeNodeText(ParseTreeNode parseTreeNode)
+        {
+            if (parseTreeNode == null)
+            {
+                return string.Empty;
+            }
+
+            // We cannot use FindTokenAndGetText always because it will give us only the text of the root node in
+            // case of complex expressions. So we have to do that:
+            if (parseTreeNode.ChildNodes.Count > 0)
+            {
+                var result = new StringBuilder();
+                foreach (var node in parseTreeNode.ChildNodes)
+                {
+                    int offset = node.Span.Location.Position - parseTreeNode.Span.Location.Position;
+                    if (result.Length < offset)
+                    {
+                        result.Append(' ', offset - result.Length);
+                    }
+
+                    result.Append(GetParseTreeNodeText(node));
+                }
+
+                return result.ToString();
+            }
+
+            return parseTreeNode.FindTokenAndGetText() ?? string.Empty;
         }
     }
 }

--- a/Source/TestHost/FileSystemTests/ShellExecutionTest.cs
+++ b/Source/TestHost/FileSystemTests/ShellExecutionTest.cs
@@ -20,7 +20,7 @@ namespace TestHost.FileSystemTests
         [Platform("Unix")]
         [TestCase("file.sh", "123", "./file.sh", Ignore = true, IgnoreReason = "Ignored because of bug in command parser.")]
         [TestCase("directory/file.sh", "123", "directory/file.sh")]
-        [TestCase("directory/file.sh", "123", "directory/file.sh 127.0.0.1", Ignore = true, IgnoreReason = "Ignored because of bug in argument parser.")]
+        [TestCase("directory/file.sh", "123", "directory/file.sh 127.0.0.1")]
         public void UnixFileShouldBeExecutedByRelativePath(string executableName, string executableResult, string command)
         {
             FileShouldBeExecutedByRelativePath(executableName, executableResult, command);
@@ -46,7 +46,7 @@ namespace TestHost.FileSystemTests
         [Platform("Win")]
         [TestCase("file.bat", "123", @".\file.bat", Ignore = true, IgnoreReason = "Ignored because of bug in command parser.")]
         [TestCase(@"directory\file.bat", "123", @"directory\file.bat")]
-        [TestCase(@"directory\file.bat", "123", @"directory\file.bat 127.0.0.1", Ignore = true, IgnoreReason = "Ignored because of bug in argument parser.")]
+        [TestCase(@"directory\file.bat", "123", @"directory\file.bat 127.0.0.1")]
         public void WinFileShouldBeExecutedByRelativePath(string executableName, string executableResult, string command)
         {
             FileShouldBeExecutedByRelativePath(executableName, executableResult, command);


### PR DESCRIPTION
It will allow us to properly parse expressions such as `ping 8.8.8.8` or `ping 8.8.ToString` as PowerShell do (slightly hacky, ignoring member access expressions under some conditions, but that's the best I can make).

This pull request will close issue #205.