### PR TITLE
Pass arrays as separate arguments to external application

### DIFF
--- a/Source/System.Management/Pash/Implementation/ApplicationProcessor.cs
+++ b/Source/System.Management/Pash/Implementation/ApplicationProcessor.cs
@@ -1,5 +1,6 @@
 // Copyright (C) Pash Contributors. License: GPL/BSD. See https://github.com/Pash-Project/Pash/
 using System;
+using System.Collections;
 using System.Diagnostics;
 using System.Management.Automation;
 using System.Runtime.InteropServices;
@@ -165,16 +166,31 @@ namespace Pash.Implementation
 
                 if (parameter.Value != null)
                 {
-                    var argument = parameter.Value.ToString();
-                    if (argument.Contains(" ") && !argument.StartsWith("\""))
+                    IEnumerable values;
+
+                    if( parameter.Value is PSObject &&
+                        ((PSObject)parameter.Value).BaseObject is IEnumerable )
                     {
-                        arguments.AppendFormat("\"{0}\"", argument);
+                        values = (IEnumerable)((PSObject)parameter.Value).BaseObject;
                     }
                     else
                     {
-                        arguments.Append(argument);
+                        values = new object[] { parameter.Value };
                     }
-                    arguments.Append(' ');
+
+                    foreach (var value in values)
+                    {
+                        var argument = value.ToString();
+                        if (argument.Contains(" ") && !argument.StartsWith("\""))
+                        {
+                            arguments.AppendFormat("\"{0}\"", argument);
+                        }
+                        else
+                        {
+                            arguments.Append(argument);
+                        }
+                        arguments.Append(' ');
+                    }
                 }
             }
 

--- a/Source/TestHost/FileSystemTests/FileSystemTestBase.cs
+++ b/Source/TestHost/FileSystemTests/FileSystemTestBase.cs
@@ -96,6 +96,18 @@ namespace TestHost.FileSystemTests
         /// <returns>Test environment root path.</returns>
         protected string SetupExecutableWithResult(string fileName, string result)
         {
+            var isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+            var content = isWindows ?
+                "@echo off\necho {0}\n" :
+                "#!/bin/sh\necho {0}\n";
+            content = string.Format(content, result);
+
+            return SetupExecutable(fileName, content);
+        }
+
+        protected string SetupExecutable(string fileName, string content)
+        {
             var directory = System.IO.Path.GetDirectoryName(fileName);
             var subPath = string.IsNullOrEmpty(directory)
                 ? Enumerable.Empty<string>()
@@ -108,10 +120,7 @@ namespace TestHost.FileSystemTests
 
             var isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
-            var text = string.Format(
-                isWindows ? "@echo off\necho {0}\n" : "#!/bin/sh\necho {0}\n",
-                result);
-            File.WriteAllText(filePath, text);
+            File.WriteAllText(filePath, content);
             _filesCreated.Add(filePath);
 
             if (!isWindows)


### PR DESCRIPTION
Changes current behavior
```powershell
PASH C:\> $array="one","two"
PASH C:\> echoargs.exe $array
Arg 0 is <one two>

Command line:
"C:\echoargs.exe" "one two"

PASH C:\>
```
to
```powershell
PASH C:\> $array="one","two"
PASH C:\> echoargs.exe $array
Arg 0 is <one>
Arg 1 is <two>

Command line:
"C:\echoargs.exe" one two

PASH C:\>
```
PowerShell for comparsion
```powershell
PS C:\> $array="one","two"
PS C:\> echoargs.exe $array
Arg 0 is <one>
Arg 1 is <two>

Command line:
"C:\EchoArgs.exe"  one two

PS C:\>
```