### PR TITLE
Support for "finally" clauses

### DIFF
--- a/Source/ReferenceTests/Language/TryCatchFinallyTests.cs
+++ b/Source/ReferenceTests/Language/TryCatchFinallyTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ReferenceTests.Language
+{
+    [TestFixture]
+    public class TryCatchFinallyTests : ReferenceTestBase
+    {
+        [Test]
+        public void TryFinallyWithoutCatch()
+        {
+            ExecuteAndCompareTypedResult(
+                "try { 2 + 2 } finally { 0 }",
+                4,
+                0
+            );                
+        }
+    }
+}
+

--- a/Source/ReferenceTests/Language/TryCatchFinallyTests.cs
+++ b/Source/ReferenceTests/Language/TryCatchFinallyTests.cs
@@ -15,6 +15,26 @@ namespace ReferenceTests.Language
                 0
             );                
         }
+
+        [Test]
+        public void TryCatchFinally()
+        {
+            ExecuteAndCompareTypedResult(
+                "try { 2 + 2 } catch { -1 } finally { 0 }",
+                4,
+                0
+            );
+        }
+
+        [Test]
+        public void TryCatchFinallyWithException()
+        {
+            ExecuteAndCompareTypedResult(
+                "try { 2 / 0 } catch { -1 } finally { 3 }",
+                -1,
+                3
+            );
+        }
     }
 }
 

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="TestUtil.cs" />
     <Compile Include="Commands\ConvertToSecureStringTests.cs" />
     <Compile Include="Language\ExpressionTests.cs" />
+    <Compile Include="Language\TryCatchFinallyTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Management\System.Management.csproj">

--- a/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
+++ b/Source/System.Management/Pash/Implementation/ExecutionVisitor.cs
@@ -1322,7 +1322,15 @@ namespace System.Management.Pash.Implementation
             {
                 SetUnderscoreVariable(ex);
 
+                // not yet considered: no catches, special catches!
                 tryStatementAst.CatchClauses.Last().Body.Visit(this);
+            }
+            finally
+            {
+                if (tryStatementAst.Finally != null)
+                {
+                    tryStatementAst.Finally.Visit(this);
+                }
             }
 
             return AstVisitAction.SkipChildren;


### PR DESCRIPTION
`finally` clauses are now correctly parsed and executed.
Fixes #411.