### PR TITLE
Move to .NET Framework v4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false   # use the new container-based Travis infrastructure
 mono:
   - latest
   - 3.2.8
-  - 2.10.8
 
 notifications:
   email:

--- a/Libraries/Libraries.Tests/Libraries.Tests.csproj
+++ b/Libraries/Libraries.Tests/Libraries.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Libraries.Tests</RootNamespace>
     <AssemblyName>Libraries.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Common.props
+++ b/Source/Common.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+</Project>

--- a/Source/Common.props
+++ b/Source/Common.props
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
 </Project>

--- a/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Management/Microsoft.Commands.Management.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/Source/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
+++ b/Source/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/NUnitAssertHandlerAddin/NUnitAssertHandlerAddin.csproj
+++ b/Source/NUnitAssertHandlerAddin/NUnitAssertHandlerAddin.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/PashConsole.Tests/PashConsole.Tests.csproj
+++ b/Source/PashConsole.Tests/PashConsole.Tests.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/PashConsole/PashConsole.csproj
+++ b/Source/PashConsole/PashConsole.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/ReferenceTests/Commands/GetCommandTests.cs
+++ b/Source/ReferenceTests/Commands/GetCommandTests.cs
@@ -45,7 +45,7 @@ namespace ReferenceTests.Commands
         [TestCase("Convert-Path", new[] { typeof(string) })]
         [TestCase("ConvertTo-Csv", new[] { typeof(string) })]
         [TestCase("Get-ChildItem", new[] { typeof(FileInfo), typeof(DirectoryInfo) })]
-        [TestCase("Get-Command", new[] { typeof(AliasInfo), typeof(ApplicationInfo), typeof(FunctionInfo), typeof(CmdletInfo), typeof(ExternalScriptInfo), typeof(FilterInfo), typeof(WorkflowInfo), typeof(String) })]
+        [TestCase("Get-Command", new[] { typeof(AliasInfo), typeof(ApplicationInfo), typeof(FunctionInfo), typeof(CmdletInfo), typeof(ExternalScriptInfo), typeof(FilterInfo), typeof(WorkflowInfo), typeof(String), typeof(PSObject) })]
         [TestCase("Get-Content", new[] { typeof(byte), typeof(string) })]
         [TestCase("Get-Date", new[] { typeof(string), typeof(DateTime) })]
         [TestCase("Get-History", new[] { typeof(HistoryInfo) })]

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -10,7 +10,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReferenceTests</RootNamespace>
     <AssemblyName>ReferenceTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/ReferenceTests/ReferenceTests.csproj
+++ b/Source/ReferenceTests/ReferenceTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Source/System.Management.Tests/System.Management.Tests.csproj
+++ b/Source/System.Management.Tests/System.Management.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/System.Management/Microsoft.PowerShell/Commands/GetCommandCommand.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/GetCommandCommand.cs
@@ -7,7 +7,7 @@ using Pash.Implementation;
 namespace Microsoft.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Get, "Command", DefaultParameterSetName = "CmdletSet")]
-    [OutputType(typeof(AliasInfo), typeof(ApplicationInfo), typeof(FunctionInfo), typeof(CmdletInfo), typeof(ExternalScriptInfo), typeof(FilterInfo), typeof(WorkflowInfo), typeof(String))]
+    [OutputType(typeof(AliasInfo), typeof(ApplicationInfo), typeof(FunctionInfo), typeof(CmdletInfo), typeof(ExternalScriptInfo), typeof(FilterInfo), typeof(WorkflowInfo), typeof(String), typeof(PSObject))]
     public sealed class GetCommandCommand : PSCmdlet
     {
         [AllowEmptyCollection]

--- a/Source/System.Management/System.Management.csproj
+++ b/Source/System.Management/System.Management.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/TestHost/TestHost.csproj
+++ b/Source/TestHost/TestHost.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Source/TestPSSnapIn/TestPSSnapIn.csproj
+++ b/Source/TestPSSnapIn/TestPSSnapIn.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Spikes/Spikes/Spikes.csproj
+++ b/Spikes/Spikes/Spikes.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Spikes</RootNamespace>
     <AssemblyName>Spikes</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/WindowsPowershellReferenceTests/TestModule/TestModule.csproj
+++ b/WindowsPowershellReferenceTests/TestModule/TestModule.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestModule</RootNamespace>
     <AssemblyName>TestModule</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/WindowsPowershellReferenceTests/WindowsPowershellReferenceTests.csproj
+++ b/WindowsPowershellReferenceTests/WindowsPowershellReferenceTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReferenceTests</RootNamespace>
     <AssemblyName>WindowsPowershellReferenceTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
AppVeyor's build machines are now on Windows 2012 R2, which has a PowerShell built w/ 4.5.