### PR TITLE
Don't check system drive info for *nix default drive

### DIFF
--- a/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
+++ b/Source/System.Management/Microsoft.PowerShell/Commands/FileSystemProvider.cs
@@ -347,6 +347,13 @@ namespace Microsoft.PowerShell.Commands
 
         protected override PSDriveInfo NewDrive(PSDriveInfo drive)
         {
+            // The special drive for *nix systems is always valid
+            if (drive.Name == FallbackDriveName &&
+                drive.Root == System.IO.Path.GetPathRoot(Environment.CurrentDirectory))
+            {
+                return drive;
+            }
+
             try
             {
                 var driveInfo = new System.IO.DriveInfo(System.IO.Path.GetPathRoot(drive.Root));


### PR DESCRIPTION
A new submit of #426 which will hopefully trigger the checks.

This fixes #425 as discussed and tested on the mailing list.

For non-Windows systems we provide a special "File" drive for the root folder.
It does not make sense to check System.IO.DriveInfo information for this drive,
as it is always valid on *nix systems.

When running Pash in docker, this can actually cause Pash to be unusable since "/" might not be listed as a mounted filesystem, so mono can't provide information about it.